### PR TITLE
Add rtl languages support and Arabic translation

### DIFF
--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -33,7 +33,7 @@ jobs:
         upload_translations: false
 
         download_translations: true
-        download_translations_args: '-l ca -l da -l de -l es-ES -l eu -l fr -l gl -l it -l ja -l ka -l ko -l nl -l pt-PT -l pt-BR -l pl -l ru -l uk -l uz -l zh-CN -l zh-TW'
+        download_translations_args: '-l ar -l ca -l da -l de -l es-ES -l eu -l fr -l gl -l it -l ja -l ka -l ko -l nl -l pt-PT -l pt-BR -l pl -l ru -l uk -l uz -l zh-CN -l zh-TW'
         localization_branch_name: update_translations_crowdin
         push_translations: true
         commit_message: 'Update translations'

--- a/locales/ar/messages.json
+++ b/locales/ar/messages.json
@@ -1,0 +1,9986 @@
+{
+    "yes": {
+        "message": "نعم",
+        "description": "General Yes message to be used across the application"
+    },
+    "no": {
+        "message": "لا",
+        "description": "General No message to be used across the application"
+    },
+    "on": {
+        "message": "تشغيل"
+    },
+    "off": {
+        "message": "إيقاف"
+    },
+    "auto": {
+        "message": "تلقائي"
+    },
+    "error": {
+        "message": "خطأ: {{errorMessage}}"
+    },
+    "errorTitle": {
+        "message": "خطأ"
+    },
+    "warningTitle": {
+        "message": "تحذير"
+    },
+    "noticeTitle": {
+        "message": "ملاحظة"
+    },
+    "search": {
+        "message": "بحث"
+    },
+    "dontShowAgain": {
+        "message": "عدم الإظهار مرة أخرى"
+    },
+    "pwaOnNeedRefreshTitle": {
+        "message": "التطبيق يحتاج إلى تحديث",
+        "description": "Title of the window that appears when the app needs to be refreshed to get the latest changes"
+    },
+    "pwaOnNeedRefreshText": {
+        "message": "يجب عليك تحديث الصفحة للحصول على آخر التغييرات. تحديثها الآن سيعمل على إعادة تحميل الصفحة وستخسر كل التغييرات التي أجريتها ولم تحفظها وسيتم إيقاف عملية جارٍة. <br><br> هل ترغب بتحديثها الآن؟ يمكنك أيضا إلغاء هذه الرسالة وتحديث الصفحة بشكل يدوي لاحقا.",
+        "description": "Text of the window that appears when the app needs to be refreshed to get the latest changes"
+    },
+    "pwaOnOfflineReadyTitle": {
+        "message": "التطبيق مُعدّ للاستخدام دون اتصال بالإنترنت",
+        "description": "Title of the window that appears when the app is ready to be installed and used offline"
+    },
+    "pwaOnOfflineReadyText": {
+        "message": "يمكنك تثبيته كتطبيق مستقل على جهازك إذا أردت",
+        "description": "Text of the window that appears when the app is ready to be installed and used offline"
+    },
+    "operationNotSupported": {
+        "message": "هذه العملية غير مدعومة من قبل الأجهزة الخاصة بك."
+    },
+    "storageDeviceNotReady": {
+        "message": "جهاز التخزين غير جاهز. في حالة استخدام بطاقة الذاكرة الصغيرة microSD, تحقق أن ذراع التحكم تتعرف عليها بشكل صحيح."
+    },
+    "connect": {
+        "message": "اتصل"
+    },
+    "connecting": {
+        "message": "جارٍ الوصل"
+    },
+    "disconnect": {
+        "message": "قطع الوصل"
+    },
+    "disconnectVirtual": {
+        "message": "قطع الاتصال (الافتراضي)",
+        "description": "Disconnect button label shown when connected in virtual mode."
+    },
+    "disconnectManual": {
+        "message": "قطع الاتصال (يدوي)",
+        "description": "Disconnect button label shown when connected via manual port override."
+    },
+    "disconnectBluetooth": {
+        "message": "قطع الاتصال (Bluetooth)",
+        "description": "Disconnect button label shown when connected via Bluetooth."
+    },
+    "portsSelectNoSelection": {
+        "message": "حدد جهازك",
+        "description": "Text for the option to select a device in the port selection dropdown"
+    },
+    "portsSelectManual": {
+        "message": "اختيار يدوي"
+    },
+    "portsSelectNone": {
+        "message": "لا يوجد اتصال متاح"
+    },
+    "portsSelectVirtual": {
+        "message": "الوضع الافتراضي (تجريبي)",
+        "description": "Configure a Virtual Flight Controller without the need of a physical FC."
+    },
+    "portsSelectPermission": {
+        "message": "--- لا يمكنني العثور على جهاز USB ---",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access the device."
+    },
+    "portsSelectPermissionBluetooth": {
+        "message": "--- لا يمكنني العثور على جهاز Bluetooth الخاص بي --",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access a Bluetooth device."
+    },
+    "portsSelectPermissionDFU": {
+        "message": "--- لا يمكنني العثور على جهازي DFU ---",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access a DFU device."
+    },
+    "bluetoothConnected": {
+        "message": "متصل بجهاز Bluetooth: $1"
+    },
+    "bluetoothConnectionType": {
+        "message": "نوع اتصال Bluetooth: $1"
+    },
+    "bluetoothConnectionError": {
+        "message": "خطأ في Bluetooth: $1"
+    },
+    "virtualMode": {
+        "message": "الوضع الافتراضي"
+    },
+    "virtualMSPVersion": {
+        "message": "إصدار البرنامج الظاهري"
+    },
+    "portOverrideText": {
+        "message": "منفذ:"
+    },
+    "connectVirtualDescription": {
+        "message": "محاكاة متحكم طيران دون الحاجة إلى جهاز حقيقي",
+        "description": "Helper text in the connect dialog when choosing the virtual FC mode."
+    },
+    "connectVirtual": {
+        "message": "اتصال (افتراضي)",
+        "description": "Connect button label shown when virtual mode port is selected."
+    },
+    "connectManualDescription": {
+        "message": "أدخل مسار المنفذ التسلسلي أو عنوان URL للاتصال",
+        "description": "Helper text in the connect dialog when choosing the manual port mode."
+    },
+    "connectBookmarks": {
+        "message": "الاتصالات المحفوظة",
+        "description": "Title of the saved manual connection (bookmark) list in the connect dialog."
+    },
+    "connectBookmarkName": {
+        "message": "الاسم:",
+        "description": "Label of the input naming a saved manual connection in the connect dialog."
+    },
+    "connectBookmarkNamePlaceholder": {
+        "message": "اسم هذا الاتصال",
+        "description": "Placeholder of the input naming a saved manual connection in the connect dialog."
+    },
+    "connectBookmarkSave": {
+        "message": "حفظ",
+        "description": "Button that saves the entered address as a bookmark in the connect dialog."
+    },
+    "connectBookmarkUpdate": {
+        "message": "تحديث",
+        "description": "Button that renames the bookmark already pointing at the entered address."
+    },
+    "connectBookmarkRemove": {
+        "message": "إزالة الاتصال المحفوظ",
+        "description": "Button that deletes a saved manual connection in the connect dialog."
+    },
+    "autoConnect": {
+        "message": "وصل تلقائي"
+    },
+    "close": {
+        "message": "أغلق"
+    },
+    "openSidebarMenu": {
+        "message": "فتح القائمة الجانبية",
+        "description": "Accessible label for the floating hamburger button shown on narrow viewports."
+    },
+    "OK": {
+        "message": "موافق"
+    },
+    "cancel": {
+        "message": "إلغاء"
+    },
+    "submit": {
+        "message": "إرسال"
+    },
+    "delete": {
+        "message": "حذف"
+    },
+    "edit": {
+        "message": "تحرير"
+    },
+    "add": {
+        "message": "إضافة"
+    },
+    "update": {
+        "message": "تحديث"
+    },
+    "save": {
+        "message": "حفظ"
+    },
+    "autoConnectEnabled": {
+        "message": "الاتصال التلقائي: مفعّل - يحاول التطبيق الاتصال تلقائيًا عند اكتشاف منفذ جديد"
+    },
+    "autoConnectDisabled": {
+        "message": "الاتصال التلقائي: معطل - المستخدم يحتاج اختيار المنفذ التسلسلي الصحيح، والنقر فوق الزر \"اتصال\" بنفسه"
+    },
+    "expertMode": {
+        "message": "تمكين وضع الخبراء"
+    },
+    "expertModeDescription": {
+        "message": "تفعيل خيارات وضع الخبير"
+    },
+    "warningSettings": {
+        "message": "عرض التحذيرات"
+    },
+    "rememberLastTab": {
+        "message": "إعادة فتح آخر علامة تبويب في الاتصال"
+    },
+    "meteredConnection": {
+        "message": "تعطيل الوصول إلى الإنترنت (للاتصالات المحدودة أو البطيئة)",
+        "description": "Text for the option to disable internet access for metered connection or to disable data over slow connections"
+    },
+    "analyticsOptOut": {
+        "message": "عدم جمع الإحصائيات مجهولة المصدر"
+    },
+    "connectionTimeout": {
+        "message": "تعيين مهلة الاتصال للسماح بتهيئة أطول على إضافة الجهاز أو إعادة التفعيل",
+        "description": "Change timeout on auto-connect and reboot so the bus has more time to initialize after being detected by the system"
+    },
+    "languageAndAppearanceSettings": {
+        "message": "اللغة والمظهر",
+        "description": "Title for the language and appearance settings section"
+    },
+    "developmentSettings": {
+        "message": "إعدادات التطوير",
+        "description": "Title for the development settings section"
+    },
+    "showAllSerialDevices": {
+        "message": "إظهار جميع الأجهزة التسلسلية (للمصانع أو التطوير)",
+        "description": "Do not filter serial devices using VID\/PID values (for manufacturers or development)"
+    },
+    "cliOnlyMode": {
+        "message": "تفعيل وضع واجهة الأوامر النصية",
+        "description": "Text for the option to enable or disable CLI only mode"
+    },
+    "automaticDevOptions": {
+        "message": "تفعيل إعدادات التطوير تلقائيًا لإصدارات المعاينة",
+        "description": "Text for the option to automatically enable development settings for preview builds"
+    },
+    "showManualMode": {
+        "message": "تفعيل وضع الاتصال اليدوي",
+        "description": "Text for the option to enable or disable manual connection mode"
+    },
+    "showVirtualMode": {
+        "message": "تفعيل وضع الاتصال الافتراضي",
+        "description": "Text for the option to enable or disable the virtual FC"
+    },
+    "useLegacyRenderingModel": {
+        "message": "تفعيل العرض القديم للنموذج ثلاثي الأبعاد (للأجهزة ضعيفة الأداء)",
+        "description": "Text for the option to enable or disable legacy rendering of the 3D model"
+    },
+    "cordovaForceComputerUI": {
+        "message": "استخدم واجهة الكمبيوتر بدلا من واجهة الجوال"
+    },
+    "language_changed": {
+        "message": "تم حفظ تغيير اللغة"
+    },
+    "language_choice_message": {
+        "message": "تغيير اللغة:",
+        "description": "Try and be brief"
+    },
+    "userLanguageSelect": {
+        "message": "حدد اللغة الافتراضية"
+    },
+    "language_default": {
+        "message": "الوضع الافتراضي للنظام"
+    },
+    "sensorDataFlashNotFound": {
+        "message": "لم يتم العثور على شريحة بيانات <br>",
+        "description": "Text of the dataflash image in the header of the page."
+    },
+    "sensorDataFlashFreeSpace": {
+        "message": "البيانات: مساحة حرة",
+        "description": "Text of the dataflash image in the header of the page."
+    },
+    "sensorStatusGyro": {
+        "message": "الجيروسكوب"
+    },
+    "configurationGyroRequired": {
+        "message": "يجب تمكين جيروسكوب واحد على الأقل"
+    },
+    "sensorStatusGyroShort": {
+        "message": "الجيرو",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusAccel": {
+        "message": "مقياس التسارع"
+    },
+    "sensorStatusAccelShort": {
+        "message": "تسارع",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusMag": {
+        "message": "مقياس الحقل المغناطيسي"
+    },
+    "sensorStatusMagShort": {
+        "message": "الحقل المغناطيسي",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusBaro": {
+        "message": "مقياس الضغط"
+    },
+    "sensorStatusBaroShort": {
+        "message": "الضغط",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusGPS": {
+        "message": "نظام تحديد المواقع"
+    },
+    "sensorStatusGPSShort": {
+        "message": "نظام تحديد المواقع",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusSonar": {
+        "message": "سونار \/ الباحث عن النطاق"
+    },
+    "sensorStatusSonarShort": {
+        "message": "سونار",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "checkForConfiguratorUnstableVersions": {
+        "message": "عرض إشعارات التحديث للإصدارات غير المستقرة من التطبيق"
+    },
+    "configuratorUpdateNotice": {
+        "message": "أنت تستخدم إصدارًا قديمًا من تطبيق <b>Betaflight App<\/b>.<br>$t(configuratorUpdateHelp.message)"
+    },
+    "configuratorUpdateHelp": {
+        "message": "عند توفر الإنترنت، سيطلب التطبيق تلقائياً إجراء التحديثات المتوفرة."
+    },
+    "rebootFlightController": {
+        "message": "إعادة تفعيل وحدة تحكم الطيران، إعادة الاتصال عندما تكون جاهزة"
+    },
+    "rebootFlightControllerReady": {
+        "message": "وحدة تحكم الطيران جاهزة"
+    },
+    "rebootFlightControllerFailed": {
+        "message": "لم تتم إعادة الاتصال بمتحكم الطيران"
+    },
+    "deviceRebooting": {
+        "message": "الجهاز - <span class=\"message-negative\">جارٍ إعادة التفعيل<\/span>"
+    },
+    "deviceRebooting_flashBootloader": {
+        "message": "الجهاز - <span class=\"message-negative\">جارٍ إعادة التفعيل لبرمجة محمل الإقلاع<\/span>"
+    },
+    "deviceRebooting_romBootloader": {
+        "message": "الجهاز - <span class=\"message-negative\">جارٍ إعادة التفعيل إلى محمل الإقلاع<\/span>"
+    },
+    "deviceReady": {
+        "message": "الجهاز - <span class=\"message-positive\">مستعد<\/span>"
+    },
+    "tabFirmwareFlasher": {
+        "message": "أداة تثبيت البرنامج"
+    },
+    "tabLanding": {
+        "message": "مرحبًا"
+    },
+    "tabPrivacyPolicy": {
+        "message": "سياسة الخصوصية"
+    },
+    "tabHelp": {
+        "message": "الوثائق و الدعم"
+    },
+    "tabOptions": {
+        "message": "خيارات"
+    },
+    "sidebarOpenOptions": {
+        "message": "الخيارات",
+        "description": "Tooltip for the options icon button in the sidebar footer."
+    },
+    "sidebarToggleDarkMode": {
+        "message": "التبديل بين الوضع الداكن والفاتح",
+        "description": "Tooltip for the dark mode toggle icon button in the sidebar footer."
+    },
+    "sidebarToggleExpertMode": {
+        "message": "تفعيل\/تعطيل وضع الخبير",
+        "description": "Tooltip for the expert mode toggle icon button in the sidebar footer."
+    },
+    "tabSetup": {
+        "message": "إعداد"
+    },
+    "tabSetupOSD": {
+        "message": "إعداد العرض على الشاشة"
+    },
+    "tabSensorConfig": {
+        "message": "المستشعرات"
+    },
+    "sensorConfigHardware": {
+        "message": "مكونات المستشعرات"
+    },
+    "sensorConfigGyroLabel": {
+        "message": "الجيروسكوب"
+    },
+    "sensorConfigSaved": {
+        "message": "تم حفظ إعدادات المستشعرات"
+    },
+    "sensorConfigSaveFailed": {
+        "message": "فشل حفظ إعدادات المستشعرات"
+    },
+    "sensorConfigMagnetometer": {
+        "message": "المقياس المغناطيسي"
+    },
+    "sensorConfigAccelerometer": {
+        "message": "مقياس التسارع"
+    },
+    "sensorConfigAccCalibrateHelp": {
+        "message": "ضع الطائرة على سطح مستوٍ قبل المعايرة"
+    },
+    "sensorConfigAccNeedsCalibration": {
+        "message": "لم تتم معايرة مقياس التسارع. يرجى معايرته قبل الطيران"
+    },
+    "sensorConfigMagNeedsCalibration": {
+        "message": "قيم إزاحة معايرة المقياس المغناطيسي تساوي صفرًا. يرجى إجراء المعايرة للحصول على قراءات دقيقة"
+    },
+    "sensorConfigCalibrate": {
+        "message": "معايرة"
+    },
+    "sensorConfig3dPreview": {
+        "message": "معاينة وضعية الطائرة ثلاثية الأبعاد"
+    },
+    "sensorConfigLiveData": {
+        "message": "بيانات المستشعرات المباشرة"
+    },
+    "sensorConfigShowLiveData": {
+        "message": "عرض بيانات المستشعرات المباشرة"
+    },
+    "sensorConfigLiveStop": {
+        "message": "إيقاف البيانات المباشرة"
+    },
+    "tabConfiguration": {
+        "message": "إعدادات"
+    },
+    "tabPorts": {
+        "message": "منافذ"
+    },
+    "tabPidTuning": {
+        "message": "ضبط PID"
+    },
+    "tabAutotune": {
+        "message": "الضبط التلقائي"
+    },
+    "tabBlackboxViewer": {
+        "message": "عرض Blackbox",
+        "description": "Navigation sidebar label for the Blackbox log viewer tab"
+    },
+    "autotuneImportTitle": {
+        "message": "تحليل Chirp في Blackbox"
+    },
+    "autotuneImportButton": {
+        "message": "استيراد سجل Blackbox"
+    },
+    "autotuneImportDescription": {
+        "message": "استورد سجل Blackbox الذي تم تسجيله باستخدام debug_mode = CHIRP لتحليل بيانات Chirp"
+    },
+    "autotuneSelectingFile": {
+        "message": "جارٍ اختيار الملف..."
+    },
+    "autotuneAnalyzing": {
+        "message": "جارٍ تحليل بيانات Chirp..."
+    },
+    "autotuneBandwidth": {
+        "message": "عرض النطاق الترددي"
+    },
+    "autotunePhaseMargin": {
+        "message": "هامش الطور"
+    },
+    "autotuneResonantPeak": {
+        "message": "ذروة الرنين"
+    },
+    "autotuneCoherence": {
+        "message": "التماسك"
+    },
+    "autotuneParameter": {
+        "message": "المعلمة"
+    },
+    "autotuneCurrent": {
+        "message": "الحالي"
+    },
+    "autotuneProposed": {
+        "message": "المقترح"
+    },
+    "autotuneChange": {
+        "message": "التغيير"
+    },
+    "autotuneApplying": {
+        "message": "جارٍ التطبيق..."
+    },
+    "autotuneApplied": {
+        "message": "تم تطبيق قيم الزيادة وحفظها."
+    },
+    "autotuneApplyFailed": {
+        "message": "فشل تطبيق قيم الزيادة"
+    },
+    "autotuneConnectRequired": {
+        "message": "اتصل بمتحكم الطيران لتطبيق قيم الزيادة."
+    },
+    "autotuneNoLogs": {
+        "message": "لم يتم العثور على سجلات Blackbox صالحة في هذا الملف."
+    },
+    "autotuneNoChirpData": {
+        "message": "لم يتم العثور على بيانات chirp. تأكد من التسجيل باستخدام debug_mode = CHIRP وتفعيل وضع chirp"
+    },
+    "autotuneSampleCount": {
+        "message": "{{count}} عينة"
+    },
+    "autotuneSampleRate": {
+        "message": "معدل أخذ العينات: {{rate}} Hz"
+    },
+    "autotuneImportAnother": {
+        "message": "استيراد ملف آخر"
+    },
+    "autotuneImportRetry": {
+        "message": "حاول مرة أخرى"
+    },
+    "autotuneFile": {
+        "message": "ملف"
+    },
+    "autotuneAxesDetected": {
+        "message": "تم اكتشاف المحاور"
+    },
+    "autotuneApplyGains": {
+        "message": "تطبيق قيم الزيادة"
+    },
+    "autotuneGainTitle": {
+        "message": "توصية قيم الزيادة"
+    },
+    "autotuneAxisSelector": {
+        "message": "اختر المحور"
+    },
+    "autotuneAxisRoll": {
+        "message": "الميل الجانبي (Roll)"
+    },
+    "autotuneAxisPitch": {
+        "message": "الميل الأمامي والخلفي (Pitch)"
+    },
+    "autotuneAxisYaw": {
+        "message": "الدوران (Yaw)"
+    },
+    "autotuneBodePlotTitle": {
+        "message": "استجابة التردد"
+    },
+    "autotuneSectionCurrentPids": {
+        "message": "قيم PID الحالية (من السجل)"
+    },
+    "autotuneSectionAnalysis": {
+        "message": "التحليل"
+    },
+    "autotuneSectionProposedSliders": {
+        "message": "الأشرطة المقترحة"
+    },
+    "autotuneSliderMasterMultiplier": {
+        "message": "المضاعف الرئيسي"
+    },
+    "autotuneSliderPIGain": {
+        "message": "كسب P \/ I"
+    },
+    "autotuneSliderIGain": {
+        "message": "كسب I"
+    },
+    "autotuneSliderDGain": {
+        "message": "كسب D"
+    },
+    "autotuneSliderFeedforward": {
+        "message": "Feedforward"
+    },
+    "autotuneSliderDTermFilter": {
+        "message": "فلتر D-Term"
+    },
+    "autotuneApplyFromAxis": {
+        "message": "تطبيق قيم الكسب من المحور"
+    },
+    "autotuneSensitivityPeak": {
+        "message": "ذروة الحساسية"
+    },
+    "autotuneOvershoot": {
+        "message": "التجاوز"
+    },
+    "autotuneRiseTime": {
+        "message": "زمن الصعود"
+    },
+    "autotuneSettlingTime": {
+        "message": "زمن الاستقرار"
+    },
+    "autotuneSpectrogramTitle": {
+        "message": "المخطط الطيفي (Gyro)"
+    },
+    "tabReceiver": {
+        "message": "المستقبل"
+    },
+    "tabModeSelection": {
+        "message": "اختيار النمط"
+    },
+    "tabServos": {
+        "message": "السيرفو"
+    },
+    "tabFailsafe": {
+        "message": "الأمان عند الفشل"
+    },
+    "tabOsd": {
+        "message": "عرض المعلومات على الشاشة"
+    },
+    "tabVtx": {
+        "message": "جهاز إرسال الفيديو"
+    },
+    "tabPower": {
+        "message": "الطاقة والبطارية"
+    },
+    "tabGPS": {
+        "message": "نظام تحديد المواقع"
+    },
+    "tabFlightPlan": {
+        "message": "خُطَّة الطيران"
+    },
+    "tabMotorTesting": {
+        "message": "المحركات"
+    },
+    "tabLedStrip": {
+        "message": "شريط إضاءة LED"
+    },
+    "tabCLI": {
+        "message": "واجهة الأوامر النصية"
+    },
+    "tabLogging": {
+        "message": "تسجيل البيانات"
+    },
+    "tabOnboardLogging": {
+        "message": "الصندوق الأسود"
+    },
+    "tabAdjustments": {
+        "message": "تعديلات"
+    },
+    "tabAuxiliary": {
+        "message": "أنماط"
+    },
+    "logActionHide": {
+        "message": "إخفاء السجل"
+    },
+    "logActionShow": {
+        "message": "إظهار السجل"
+    },
+    "tabLog": {
+        "message": "السجل"
+    },
+    "i2cErrorDetected": {
+        "message": "تم اكتشاف خطأ I2C (+{{delta}}، الإجمالي {{total}})",
+        "description": "Logged when the flight controller reports new I2C bus errors. {{delta}} is how many errors since the last poll; {{total}} is the running total."
+    },
+    "logActionClear": {
+        "message": "مسح"
+    },
+    "logAutoScroll": {
+        "message": "تمرير تلقائي"
+    },
+    "fileSystemPickerFiles": {
+        "message": "ملفات {{typeof}}",
+        "description": "Text for the file picker dialog, showing the type of files selected. The parameter can be HEX, TXT, etc."
+    },
+    "fileSystemPickerFirmwareFiles": {
+        "message": "ملفات البرنامَج"
+    },
+    "serialErrorFrameError": {
+        "message": "خطأ في الاتصال التسلسلي: إطار سيء"
+    },
+    "serialErrorParityError": {
+        "message": "خطأ في الاتصال التسلسلي: تكافؤ سيء"
+    },
+    "serialPortOpened": {
+        "message": "المنفذ التسلسلي <span class=\"message-positive\">تم فتحه<\/span> بالمعرف: $1"
+    },
+    "serialPortOpenFail": {
+        "message": "<span class=\"message-negative\">فشل<\/span> في فتح المنفذ التسلسلي"
+    },
+    "connectionFailedTitle": {
+        "message": "فشل الاتصال"
+    },
+    "connectionFailed": {
+        "message": "<span class=\"message-negative\">فشل<\/span> الاتصال بالمنفذ المحدد. تحقق من إمكانية الوصول إلى الجهاز ومن صحة إعدادات الاتصال، ثم حاول مرة أخرى."
+    },
+    "connectionFailedLocalNetworkIOS": {
+        "message": "على iOS، اسمح لـBetaflight بالوصول إلى <strong>الشبكة المحلية<\/strong> من الإعدادات &rarr; الخصوصية والأمان &rarr; الشبكة المحلية، ثم حاول مرة أخرى."
+    },
+    "connectionLostTitle": {
+        "message": "فُقد الاتصال"
+    },
+    "connectionLostUnresponsive": {
+        "message": "<span class=\"message-negative\">توقف متحكم الطيران عن الاستجابة<\/span> وتم إغلاق الاتصال. أعد توصيل اللوحة وحاول مرة أخرى؛ وإذا استمرت المشكلة، افصل طاقة متحكم الطيران ثم أعد تشغيله."
+    },
+    "serialPortClosedOk": {
+        "message": "المنفذ التسلسلي <span class=\"message-positive\">تم الإغلاق بنجاح<\/span>"
+    },
+    "serialPortClosedFail": {
+        "message": "<span class=\"message-negative\">فشل<\/span> في إغلاق المنفذ التسلسلي"
+    },
+    "serialUnrecoverable": {
+        "message": "<span class=\"message-negative\">فشل<\/span> غير قابل للاسترجاع في الربط التسلسلي، جارٍ الفصل..."
+    },
+    "serialPortLoading": {
+        "message": "جارٍ التحميل ..."
+    },
+    "usbDeviceOpened": {
+        "message": "جهاز USB <span class=\"message-positive\">تم فتحه بنجاح<\/span> مع المعرف: $1"
+    },
+    "usbDeviceOpenFail": {
+        "message": "<span class=\"message-negative\">فشل<\/span> في فتح جهاز USB!"
+    },
+    "usbDeviceClosed": {
+        "message": "جهاز USB <span class=\"message-positive\">تم إغلاقه بنجاح<\/span>"
+    },
+    "usbDeviceCloseFail": {
+        "message": "<span class=\"message-negative\">فشل<\/span> في إغلاق جهاز USB"
+    },
+    "usbDeviceUdevNotice": {
+        "message": "هل تم تثبيت <strong>قواعد udev<\/strong> بشكل صحيح؟ راجع الوثائق للحصول على التعليمات"
+    },
+    "stm32UsbDfuNotFound": {
+        "message": "لم يتم العثور على USB DFU"
+    },
+    "stm32DfuPermissionRequired": {
+        "message": "أُعيد تشغيل الجهاز في وضع DFU.<br><br>يتطلب متصفحك إذن USB للوصول إلى جهاز DFU. انقر الزر أدناه لاختياره من قائمة الأجهزة."
+    },
+    "stm32RebootingToBootloader": {
+        "message": "بدء إعادة التفعيل إلى محمل الإقلاع ..."
+    },
+    "stm32RebootingToBootloaderFailed": {
+        "message": "إعادة تفعيل الجهاز إلى محمل الإقلاع: فشل"
+    },
+    "stm32TimedOut": {
+        "message": "STM32 - انتهت المهلة، البرمجة: فشل"
+    },
+    "stm32WrongResponse": {
+        "message": "فشل الاتصال مع STM32، استجابة خاطئة، المتوقع: $1 (0 x$2) تم الاستلام: $3 (0 x$4)"
+    },
+    "stm32ContactingBootloader": {
+        "message": "جارٍ الاتصال بمحمل الإقلاع..."
+    },
+    "stm32ContactingBootloaderFailed": {
+        "message": "الاتصال بمحمل الإقلاع فشل"
+    },
+    "stm32ResponseBootloaderFailed": {
+        "message": "لا توجد استجابة من محمل الإقلاع، البرمجة: فشل"
+    },
+    "stm32GlobalEraseExtended": {
+        "message": "تنفيذ محو شامل للشريحة (عن طريق المحو الموسع) ..."
+    },
+    "stm32LocalEraseExtended": {
+        "message": "تنفيذ المحو المحلي (عن طريق المحو الموسع) ..."
+    },
+    "stm32GlobalErase": {
+        "message": "تنفيذ المحو الشامل للشريحة ..."
+    },
+    "stm32LocalErase": {
+        "message": "تنفيذ المحو المحلي..."
+    },
+    "stm32InvalidHex": {
+        "message": "Hex غير صالح"
+    },
+    "stm32Erase": {
+        "message": "جارٍ المحو..."
+    },
+    "stm32Flashing": {
+        "message": "جارٍ البرمجة..."
+    },
+    "stm32Verifying": {
+        "message": "جارٍ التحقق من الصحة ..."
+    },
+    "stm32ProgrammingSuccessful": {
+        "message": "البرمجة: تمت بنجاح"
+    },
+    "stm32ProgrammingFailed": {
+        "message": "البرمجة: فشل"
+    },
+    "stm32AddressLoadFailed": {
+        "message": "فشل تحميل عنوان خيار قطاع البايت. من المرجح جداً أن السبب حماية القراءة."
+    },
+    "stm32AddressLoadSuccess": {
+        "message": "نجح تحميل عنوان خيار قطاع البايت."
+    },
+    "stm32AddressLoadUnknown": {
+        "message": "فشل تحميل عنوان خيار قطاع البايت مع خطأ غير معروف. إلغاء."
+    },
+    "stm32NotReadProtected": {
+        "message": "حماية القراءة غير مفعلة"
+    },
+    "stm32ReadProtected": {
+        "message": "اللوحة الإلكترونية تبدو محمية من القراءة. أزل الحماية. لا تقم بفصل أو إزالة القابس!"
+    },
+    "stm32UnprotectSuccessful": {
+        "message": "نجاح إلغاء الحماية."
+    },
+    "stm32UnprotectUnplug": {
+        "message": "الإجراء مطلوب: فصل وإعادة توصيل وحدة تحكم الطيران في وضع DFU لمحاولة البرمجة مرة أخرى!"
+    },
+    "stm32UnprotectFailed": {
+        "message": "فشل في إلغاء حماية اللوحة"
+    },
+    "stm32UnprotectInitFailed": {
+        "message": "فشل في بدء إجراء إلغاء الحماية"
+    },
+    "noConfigurationReceived": {
+        "message": "لم يتم استلام أي إعداد خلال <span class=\"message-negative\"> عشرة ثواني<\/span>،\nالاتصال <span class=\"message-negative\"> فشل<\/span>"
+    },
+    "firmwareVersionNotSupported": {
+        "message": "إصدار البرنامج الثابت هذا <span class=\"message-negative\">غير مدعوم<\/span>. يرجى الترقية إلى إصدار برنامج ثابت يدعم إصدار API <strong>$1<\/strong> أو أعلى. استخدم واجهة الأوامر CLI لعمل نسخة احتياطية قبل التحديث. إجراءات النسخ الاحتياطي\/الاستعادة باستخدام CLI موضحة في الوثائق.<br \/>بدلاً من ذلك، يمكنك تنزيل واستخدام إصدار قديم من التطبيق إذا لم تكن مستعدًا للترقية."
+    },
+    "firmwareTypeNotSupported": {
+        "message": "البرنامج الثابت ليس من إصدارات Betaflight وغير مدعوم إلا من خلال لوحة الأوامر."
+    },
+    "firmwareUpgradeRequired": {
+        "message": "قد لا يدعم الإصدار الحالي من التطبيق إصدار البرنامج الثابت الموجود على هذا الجهاز. يمكنك استخدام إصدارات أقدم، مثل <a href=\"https:\/\/github.com\/betaflight\/betaflight-configurator\/releases\/10.8.0\" target=\"_blank\" rel=\"noopener noreferrer\">10.8.0<\/a> للبرامج الثابتة وصولًا إلى الإصدار 4.1، أو <a href=\"https:\/\/github.com\/betaflight\/betaflight-configurator\/releases\/10.5.1\" target=\"_blank\" rel=\"noopener noreferrer\">10.5.1<\/a> لإصدارات البرامج الثابتة الأقدم من ذلك.<br><br>سيحاول التطبيق الوصول إلى CLI على الجهاز؛ وإذا نجح، يمكنك معرفة إصدار البرنامج الثابت الحالي بإرسال الأمر <code>version<\/code> في CLI.<br><br>بدلًا من ذلك، يمكنك الترقية إلى إصدار أحدث من البرنامج الثابت. استخدم CLI لإنشاء نسخة احتياطية قبل التحديث؛ وتجد خطوات الإجراء في <a href=\"https:\/\/betaflight.com\/docs\/wiki\/getting-started\/setup-guide#backup-your-configuration\" target=\"_blank\" rel=\"noopener noreferrer\">الوثائق<\/a>. لكن ضع في اعتبارك أن النسخ الاحتياطية من إصدارات البرامج الثابتة القديمة قد لا تُستعاد بصورة صحيحة على إصدار أحدث. يُفترض أن تنتقل إعدادات الأوضاع وOSD ومعدلات الدوران والمنافذ بأمان، لكن توخَّ الحذر عند استعادة إعدادات PID وFailsafe."
+    },
+    "resetToCustomDefaultsDialog": {
+        "message": "هناك إعدادات مخصصة متاحة لهذه اللوحة. عادةً، اللوحة لن تعمل بصورة صحيحة ما لم يتم تثبيت الإعدادات المخصصة. هل ترغب بتثبيت الإعدادات المخصصة لهذه اللوحة؟"
+    },
+    "resetToCustomDefaultsAccept": {
+        "message": "تطبيق الإعدادات الافتراضية المخصصة"
+    },
+    "reportProblemsDialogHeader": {
+        "message": "تم اكتشاف المشاكل التالية في برنامج التثبيت لديك:"
+    },
+    "reportProblemsDialogFooter": {
+        "message": "<span class=\"message-negative\"><strong>يجب عليك إصلاح هذه المشكلات قبل محاولة طيران طائرتك<\/strong><\/span>."
+    },
+    "reportProblemsDialogAPI_VERSION_MAX_SUPPORTED": {
+        "message": "النسخة الحالية من التطبيق (<strong>$1<\/strong>) لا تدعم إصدار الـ<strong>firmware $2<\/strong>.<br>$t(configuratorUpdateHelp.message)\n"
+    },
+    "reportProblemsDialogMOTOR_PROTOCOL_DISABLED": {
+        "message": "<strong>لا يوجد بروتوكول إخراج للمحركات محدد<\/strong>.<br>يرجى اختيار بروتوكول إخراج محركات مناسب لوحدات ESCs الخاصة بك في ‎'$t(configurationEscFeatures.message)'‎ ضمن تبويب ‎'$t(tabMotorTesting.message)'‎.<br>$t(escProtocolDisabledMessage.message)"
+    },
+    "reportProblemsDialogACC_NEEDS_CALIBRATION": {
+        "message": "<strong>مقياس التسارع مفعل، لكنه غير معاير<\/strong>.<br>إذا كنت تريد استخدام مقياس التسارع، اتبع التعليمات الخاصة بـ '$t(initialSetupButtonCalibrateAccel.message)' في علامة التبويب '$t(tabSetup.message)'. إذا كان أي وظيفة تتطلب مقياس التسارع مفعلة (أوضاع المستوى التلقائي، إنقاذ GPS، ...)، سيتم تعطيل وضع الاستعداد للطيران حتى يتم معايرة مقياس التسارع.<br>إذا لم تكن تخطط لاستخدام مقياس التسارع، يوصى بتعطيله في \"$t(configurationSystem.message)\" في علامة التبويب \"$t(tabConfiguration.message)\"."
+    },
+    "infoVersionOs": {
+        "message": "نظام التشغيل: <strong>{{operatingSystem}}<\/strong>",
+        "description": "Message that appears in the GUI log panel indicating operating system"
+    },
+    "infoVersionConfigurator": {
+        "message": "إصدار التطبيق: <strong>{{configuratorVersion}}<\/strong>",
+        "description": "Message that appears in the GUI log panel indicating application version"
+    },
+    "buildServerSuccess": {
+        "message": "تم بنجاح: $1"
+    },
+    "buildServerFailure": {
+        "message": "<b>فشل بناء الخادم: $1 <code>$2<\/code><\/b>"
+    },
+    "buildServerUsingCached": {
+        "message": "استخدام معلومات البناء المخزنة مؤقتًا مقابل $1."
+    },
+    "buildServerSupportRequestSubmission": {
+        "message": "<br>*** تم إرسال بيانات الدعم *** <br>المعرّف: $1<br><br><br># انسخ المعرّف وقدّمه إلى فريق Betaflight."
+    },
+    "buildKey": {
+        "message": "مفتاح البناء: <strong>$1<\/strong>"
+    },
+    "supportWarningDialogTitle": {
+        "message": "تأكيد تقديم البيانات"
+    },
+    "supportWarningDialogText": {
+        "message": "يرجى تأكيد إرسال البيانات إلى فريق Betaflight.<br><br>\nستقوم هذه العملية بتشغيل بعض الأوامر وإرسال المخرجات إلى خادم البناء.<br><br>\nسيتم بعد ذلك تزويدك بمعرّف فريد لعملية إرسال البيانات الخاصة بك.<br><br>\nيرجى التأكد من تزويد فريق Betaflight بهذا المعرّف الفريد عند استخدام Discord أو عند فتح مشكلة على Github."
+    },
+    "supportWarningDialogInputPlaceHolder": {
+        "message": "وصف المشكلة"
+    },
+    "releaseCheckLoaded": {
+        "message": "تم تحميل معلومات الإصدار $1 من GitHub."
+    },
+    "releaseCheckFailed": {
+        "message": "فشل استعلام GitHub لإصدارات $1، استخدام المعلومات المخزنة مؤقتًا.<br>السبب: <code>$2<\/code>"
+    },
+    "releaseCheckCached": {
+        "message": "استخدام معلومات الإصدار المخزنة مؤقتاً للإصدارات $1."
+    },
+    "releaseCheckNoInfo": {
+        "message": "لا يوجد معلومات متوفرة للإصدار $1."
+    },
+    "tabSwitchConnectionRequired": {
+        "message": "أنت بحاجة إلى <strong>الاتصال<\/strong> قبل أن يمكنك عرض أي من علامات التبويب."
+    },
+    "tabSwitchWaitForOperation": {
+        "message": "<span class=\"message-negative\">لا يمكن القيام بهذا الآن<\/span>، الرجاء الانتظار حتى انتهاء العملية الحالية..."
+    },
+    "tabSwitchUpgradeRequired": {
+        "message": "أنت تحتاج إلى <strong>ترقية<\/strong> البرنامج الثابت الخاص بك إلى الإصدار الأحدث من Betaflight قبل أن يمكنك استخدام علامة التبويب $1."
+    },
+    "firmwareVersion": {
+        "message": "إصدار البرامج الثابتة: <strong>$1<\/strong>"
+    },
+    "apiVersionReceived": {
+        "message": "إصدار MultiWii API: <strong>$1<\/strong>"
+    },
+    "uniqueDeviceIdReceived": {
+        "message": "المعرف الفريد للجهاز: <strong>0 ×$1<\/strong>"
+    },
+    "craftNameReceived": {
+        "message": "اسم الطائرة: $1"
+    },
+    "armingDisabled": {
+        "message": "<strong>تم تعطيل وضع الاستعداد للطيران<\/strong>"
+    },
+    "armingEnabled": {
+        "message": "<strong>تم تفعيل وضع الاستعداد للطيران<\/strong>"
+    },
+    "runawayTakeoffPreventionDisabled": {
+        "message": "<strong>منع الإقلاع غير المتحكم به تم تعطيله مؤقتًا<\/strong>"
+    },
+    "runawayTakeoffPreventionEnabled": {
+        "message": "<strong>منع الإقلاع غير المتحكم به مفعل<\/strong>"
+    },
+    "boardInfoReceived": {
+        "message": "اللوحة الإلكترونية: <strong>$1<\/strong>، الإصدار: <strong>$2<\/strong>"
+    },
+    "buildInfoReceived": {
+        "message": "تم بناء البرامج الثابتة بتاريخ: <strong>$1<\/strong>"
+    },
+    "fcInfoReceived": {
+        "message": "معلومات وحدة تحكم الطيران، المعرف: <strong>$1<\/strong>، الإصدار: <strong>$2<\/strong>"
+    },
+    "versionLabelTarget": {
+        "message": "الهدف"
+    },
+    "versionLabelFirmware": {
+        "message": "إصدار البرنامح الثابت"
+    },
+    "versionLabelConfigurator": {
+        "message": "إصدار التطبيق"
+    },
+    "notifications_app_just_updated_to_version": {
+        "message": "التطبيق تم تحديثه إلى الإصدار: $1"
+    },
+    "notifications_click_here_to_start_app": {
+        "message": "انقر هنا لبدء تشغيل التطبيق"
+    },
+    "statusbar_port_utilization": {
+        "message": "استخدام المنفذ:",
+        "description": "Port utilization text shown in the status bar"
+    },
+    "statusbar_usage_download": {
+        "message": "تنزيل:",
+        "description": "References 'Download' in the status bar, port utilization. Keep one character long if possible"
+    },
+    "statusbar_usage_upload": {
+        "message": "رفع:",
+        "description": "References 'Upload' in the status bar, port utilization. Keep one character long if possible"
+    },
+    "statusbar_packet_error": {
+        "message": "خطأ في الحزمة:",
+        "description": "Packet error text shown in the status bar"
+    },
+    "statusbar_i2c_error": {
+        "message": "خطأ I2C:",
+        "description": "CPU load text shown in the status bar"
+    },
+    "statusbar_cycle_time": {
+        "message": "وقت الدورة:",
+        "description": "Cycle time text shown in the status bar"
+    },
+    "statusbar_cpu_load": {
+        "message": "حمولة المعالج:",
+        "description": "CPU load text shown in the status bar"
+    },
+    "statusbar_connection_time": {
+        "message": "مدة الاتصال:",
+        "description": "Connection time text shown in the status bar"
+    },
+    "dfu_connect_message": {
+        "message": "الرجاء استخدام أداة تثبيت البرنامج للوصول إلى أجهزة DFU"
+    },
+    "dfu_erased_kilobytes": {
+        "message": "تم مسح $1 كيلوبايت من وحدة التخزين المؤقتة <span class=\"message-positive\"> بنجاح <\/span>"
+    },
+    "dfu_device_flash_info": {
+        "message": "الجهاز الذي تم اكتشافه مع إجمالي حجم ذاكرة الفلاش $1 كيلوبايت"
+    },
+    "dfu_hex_address_errors": {
+        "message": "رمز البرنامج الثابت يتضمن عناوين لم يتم العثور عليها على الجهاز المستهدف"
+    },
+    "dfu_error_image_size": {
+        "message": "<span class=\"message-negative\">خطأ<\/span>: الصورة المقدمة أكبر من ذاكرة الفلاش المتوفرة على الشريحة! الصورة: $1 كيلوبايت, الحد =$2 كيلوبايت"
+    },
+    "eeprom_saved_ok": {
+        "message": "ذاكرة EEPROM <span class=\"message-positive\">تم حفظها<\/span>"
+    },
+    "defaultWelcomeIntro": {
+        "message": "مرحبًا بك في <strong>تطبيق Betaflight<\/strong>، وهي أداة مصممة لتبسيط عملية التحديث، والضبط، والمعايرة لوحدة التحكم في الطيران الخاصة بك."
+    },
+    "defaultHardwareHead": {
+        "message": "الجهاز"
+    },
+    "defaultHardwareText": {
+        "message": "يدعم التطبيق جميع الأجهزة القادرة على تشغيل Betaflight. راجع تبويب Firmware Flasher للاطلاع على القائمة الكاملة للأجهزة.<br \/><br \/>أدوات وتعريفات مفيدة للأجهزة:<ul><li>للأجهزة القديمة التي تستخدم شريحة CP210x USB to Serial، يمكن تنزيل أحدث <b>تعريفات CP210x<\/b> من <a href=\"https:\/\/www.silabs.com\/software-and-tools\/usb-to-uart-bridge-vcp-drivers\" target=\"_blank\" rel=\"noopener noreferrer\">هنا<\/a><\/li><li>يمكن تنزيل أحدث إصدار من <b>Zadig<\/b> لتثبيت تعريفات USB على Windows من <a href=\"https:\/\/zadig.akeo.ie\/\" target=\"_blank\" rel=\"noopener noreferrer\">هنا<\/a><\/li><li>يمكن تنزيل <b>ImpulseRC Driver Fixer<\/b> من <a href=\"https:\/\/github.com\/ImpulseRC\/ImpulseRC_Driver_Fixer\" target=\"_blank\" rel=\"noopener noreferrer\">هنا<\/a><\/li><\/ul>"
+    },
+    "defaultSoftwareHead": {
+        "message": "البرنامج"
+    },
+    "defaultSoftwareText": {
+        "message": "عارض سجلات البلاك بوكس مدمج في هذا التطبيق. افتح علامة تبويب <strong>عارض البلاك بوكس<\/strong> لتحليل سجلات رحلاتك.<br \/><br \/>تتوفر مجموعتنا من <a href=\"https:\/\/github.com\/betaflight\/betaflight-tx-lua-scripts\/releases\" target=\"_blank\" rel=\"noopener noreferrer\">برامج TX Lua النصية<\/a> على GitHub.<br \/><br \/>يمكن تنزيل <a href=\"https:\/\/github.com\/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">الشفرة المصدرية<\/a> للبرنامج الثابت ولهذا التطبيق من GitHub.\n"
+    },
+    "defaultContributingHead": {
+        "message": "المساهمة"
+    },
+    "defaultContributingText": {
+        "message": "إذا كنت ترغب في المساعدة على جعل Betaflight أفضل، فهناك عدة طرق للمساهمة، منها:<br \/><ul><li>استخدام معرفتك بـBetaflight لإنشاء أو تحديث المحتوى في <a href=\"https:\/\/betaflight.com\/docs\/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">Wiki<\/a> أو الإجابة عن أسئلة المستخدمين في المنتديات؛<\/li><li><a href=\"https:\/\/betaflight.com\/docs\/development\" target=\"_blank\" rel=\"noopener noreferrer\">المساهمة بالكود<\/a> في Firmware والتطبيق، مثل الميزات الجديدة والإصلاحات والتحسينات؛<\/li><li>اختبار <a href=\"https:\/\/github.com\/Betaflight\/betaflight\/pulls\" target=\"_blank\" rel=\"noopener noreferrer\">الميزات والإصلاحات الجديدة<\/a> وتقديم الملاحظات؛<\/li><li>مساعدة المستخدمين في حل المشكلات التي يبلغون عنها في <a href=\"https:\/\/github.com\/betaflight\/betaflight\/issues\" target=\"_blank\" rel=\"noopener noreferrer\">متتبع المشكلات<\/a> والمشاركة في مناقشات طلبات الميزات؛<\/li><li><a href=\"https:\/\/github.com\/betaflight\/betaflight\/blob\/master\/README.md#translators\" target=\"_blank\" rel=\"noopener noreferrer\">ترجمة<\/a> تطبيق Betaflight إلى لغة جديدة أو المساعدة في صيانة الترجمات الحالية.<\/li><\/ul>"
+    },
+    "defaultFacebookText": {
+        "message": "لدينا أيضًا <a href=\"https:\/\/www.facebook.com\/groups\/betaflightgroup\/\" target=\"_blank\" rel=\"noopener noreferrer\">مجموعة على فيسبوك<\/a>.<br \/>انضم إلينا للحصول على مكان للحديث عن Betaflight، أو طرح أسئلة حول الإعدادات، أو مجرد التواصل مع الطيارين الآخرين."
+    },
+    "defaultDiscordText": {
+        "message": "يتوفر أيضًا <a href=\"https:\/\/discord.betaflight.com\/invite\" target=\"_blank\" rel=\"noopener noreferrer\">خادم ديسكورد الخاص بـ Betaflight<\/a>.<br \/>شارك تجربتك في الطيران، ناقش مواضيع حول Betaflight، ساعد الآخرين أو احصل على بعض المساعدة لنفسك من المجتمع."
+    },
+    "defaultRedditText": {
+        "message": "انضم إلى <a href=\"https:\/\/www.reddit.com\/r\/Betaflight\/\" target=\"_blank\" rel=\"noopener noreferrer\">مجتمع Betaflight على Reddit<\/a>.<br \/>\nناقش الميزات، اطرح الأسئلة، وتواصل مع مجتمع Betaflight على Reddit."
+    },
+    "defaultCommunityHead": {
+        "message": "المجتمع"
+    },
+    "statisticsDisclaimerHead": {
+        "message": "خصوصيتك"
+    },
+    "statisticsDisclaimer": {
+        "message": "يقوم تطبيق Betaflight هذا بجمع إحصاءات استخدام مجهولة الهوية. قد تتضمن بيانات الاستخدام هذه عدد مرات التشغيل، والمنطقة الجغرافية للمستخدمين، وأنواع وحدات التحكم في الطيران، وإصدارات البرنامج الثابت، واستخدام عناصر وواجهات المستخدم وعلامات التبويب، وغيرها. نقوم بجمع هذه البيانات لفهم كيفية استخدام التطبيق واتجاهات المجتمع بشكل أفضل. يساعدنا ذلك على تطوير واجهة مستخدم محسّنة وتجربة عامة أفضل. يمكن للمستخدمين إلغاء الاشتراك في جمع البيانات من خلال تبويب الخيارات. لمزيد من المعلومات حول كيفية جمع بياناتك واستخدامها، يرجى الاطلاع على <a href=\"https:\/\/www.betaflight.com\/privacy\" rel=\"noopener noreferrer\" target=\"_blank\">سياسة الخصوصية<\/a> الخاصة بنا."
+    },
+    "defaultButtonFirmwareFlasher": {
+        "message": "أداة تثبيت البرنامج"
+    },
+    "defaultDonateHead": {
+        "message": "التبرعات مفتوحة المصدر"
+    },
+    "defaultDonateText": {
+        "message": "```html\n<p>يُعد <strong>Betaflight<\/strong> برنامجًا <strong>مفتوح المصدر<\/strong> ومتاحًا مجانًا <strong>دون أي ضمان<\/strong> لجميع المستخدمين.<\/p>\n<p>إذا وجدت Betaflight مفيدًا، فيُرجى التفكير في <strong>دعم<\/strong> تطويره من خلال التبرع.<\/p>\n```"
+    },
+    "defaultDonateBottom": {
+        "message": "<p>إذا كنت ترغب في المساهمة ماليًا بشكل مستمر، يمكنك أن تصبح راعيًا لنا عبر $t(patreonLink.message).<\/p>"
+    },
+    "patreonLink": {
+        "message": "<a href=\"https:\/\/www.patreon.com\/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">باتريون<\/a>",
+        "description": "Patreon is name, and should not require translation"
+    },
+    "defaultDonate": {
+        "message": "تبرع"
+    },
+    "defaultSponsorsHead": {
+        "message": "الرعاة"
+    },
+    "defaultDocumentationHead": {
+        "message": "الوثائق \/ كتيب التعليمات"
+    },
+    "defaultDocumentation": {
+        "message": "وثائق Betaflight متوفرة في ملاحظات الإصدارات والويكي.<br \/><br \/>"
+    },
+    "defaultDocumentation1": {
+        "message": "يمكنك العثور على ويكي Betaflight - وهو مصدر رائع للمعلومات - <a href=\"https:\/\/betaflight.com\/docs\/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">هنا<\/a>."
+    },
+    "defaultDocumentation2": {
+        "message": "ملاحظات الإصدار للبرنامج الثابت يمكن العثور عليها في GitHub في صفحة الإصدارات, <a href=\"https:\/\/github.com\/Betaflight\/Betaflight\/releases\" target=\"_blank\" rel=\"noopener noreferrer\">هنا<\/a>."
+    },
+    "defaultSupportHead": {
+        "message": "الدعم الفني"
+    },
+    "defaultSupportSubline1": {
+        "message": "مصادر الدعم"
+    },
+    "defaultSupportSubline2": {
+        "message": "المطور"
+    },
+    "defaultSupport": {
+        "message": "للدعم الفني يرجى البحث في المنتديات والويكي أولاً أو اتصل بالموفر.<br \/><br \/>"
+    },
+    "defaultSupport1": {
+        "message": "<a href=\"http:\/\/www.rcgroups.com\/forums\/showthread.php?t=2464844&page=1\" target=\"_blank\" rel=\"noopener noreferrer\">موضوع RC Groups<\/a>"
+    },
+    "defaultSupport2": {
+        "message": "<a href=\"https:\/\/betaflight.com\/docs\/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">ويكي Betaflight<\/a>"
+    },
+    "defaultSupport3": {
+        "message": "<a href=\"https:\/\/www.youtube.com\/playlist?list=PLwoDb7WF6c8nT4jjsE4VENEmwu9x8zDiE\" target=\"_blank\" rel=\"noopener noreferrer\">فيديوهات Joshua Bardwell عن Betaflight 4.3<\/a>"
+    },
+    "defaultSupport4": {
+        "message": "<a href=\"https:\/\/github.com\/Betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub<\/a>"
+    },
+    "defaultSupport5": {
+        "message": "<a href=\"https:\/\/discord.betaflight.com\/invite\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight على ديسكورد<\/a>"
+    },
+    "initialSetupButtonCalibrateAccel": {
+        "message": "معايرة أجهزة قياس التسارع"
+    },
+    "initialSetupCalibrateMagText": {
+        "message": "حرك الطائرة <strong>360<\/strong> درجة على جميع محاور الدوران, لديك 30 ثانية لتكمل المهمة"
+    },
+    "initialSetupButtonCalibratingText": {
+        "message": "جارٍ المعايرة..."
+    },
+    "initialSetupButtonReset": {
+        "message": "مسح الإعدادات"
+    },
+    "initialSetupResetText": {
+        "message": "إعادة ضبط وحدة التحكم في الطيران إلى <strong>حالة غير مهيأة.<\/strong>"
+    },
+    "initialSetupButtonBackup": {
+        "message": "نسخ احتياطي لملف JSON"
+    },
+    "initialSetupButtonRestore": {
+        "message": "استعادة JSON"
+    },
+    "initialSetupButtonRebootBootloader": {
+        "message": "تفعيل محمل التمهيد\/DFU"
+    },
+    "initialSetupBackupRestoreHeader": {
+        "message": "النسخ الاحتياطي والاستعادة التجريبية"
+    },
+    "initialSetupBackupRestoreText": {
+        "message": "<strong>قم بعمل نسخة احتياطية<\/strong> لإعداداتك تحسبًا لأي حادث، إعدادات <strong>CLI<\/strong> <span class=\"message-negative\">غير<\/span> مدرجة - استخدم الأمر 'diff all' في CLI لذلك."
+    },
+    "initialSetupRebootBootloaderText": {
+        "message": "إعادة التفعيل في وضع <strong>محمل التمهيد \/ DFU<\/strong>."
+    },
+    "initialSetupButtonResetZaxis": {
+        "message": "إعادة تعيين محور Z، والإزاحة: 0 درجة"
+    },
+    "initialSetupButtonResetZaxisValue": {
+        "message": "إعادة تعيين محور Z، والإزاحة: $1 درجة"
+    },
+    "initialSetupHeading": {
+        "message": "**الاتجاه (Yaw)**:",
+        "description": "Heading [yaw] attitude value shown on Setup tab when no magnetometer is active"
+    },
+    "initialSetupMagHeading": {
+        "message": "الاتجاه المغناطيسي:",
+        "description": "Heading value shown on Setup tab when magnetometer is active"
+    },
+    "initialSetupMixerHead": {
+        "message": "نوع المازج"
+    },
+    "initialSetupThrottleHead": {
+        "message": "ضبط دفع المحرك"
+    },
+    "initialSetupMinimum": {
+        "message": "الحد الأدنى:"
+    },
+    "initialSetupMaximum": {
+        "message": "الحد الأقصى:"
+    },
+    "initialSetupFailsafe": {
+        "message": "الأمان عند الفشل:"
+    },
+    "initialSetupMinCommand": {
+        "message": "الأمر الأدنى:"
+    },
+    "initialSetupBatteryHead": {
+        "message": "البطارية"
+    },
+    "initialSetupMinCellV": {
+        "message": "أقل فولتية للخلية:"
+    },
+    "initialSetupMaxCellV": {
+        "message": "أعلى فولتية للخلية:"
+    },
+    "initialSetupVoltageScale": {
+        "message": "مقياس الفولتية:"
+    },
+    "initialSetupAccelTrimsHead": {
+        "message": "ضبط معايرة مقياس التسارع"
+    },
+    "initialSetupPitch": {
+        "message": "انحدار:"
+    },
+    "initialSetupRoll": {
+        "message": "دوران:"
+    },
+    "initialSetupMagHead": {
+        "message": "مقياس المغناطيسية"
+    },
+    "initialSetupMagDeclination": {
+        "message": "انحراف البوصلة المغناطيسية:"
+    },
+    "initialSetupInfoHead": {
+        "message": "معلومات النظام"
+    },
+    "initialSetupInfoHeadHelp": {
+        "message": "يعرض أعلام وحدة التحكم لفك القفل، معلومات البطارية، ومستوى RSSI.",
+        "description": "Message that pops up to describe the System info section"
+    },
+    "initialSensorInfoHead": {
+        "message": "معلومات المستشعر"
+    },
+    "initialSensorInfoHeadHelp": {
+        "message": "يعرض أجهزة الاستشعار",
+        "description": "Message that pops up to describe the Sensor info section"
+    },
+    "initialSetupBattery": {
+        "message": "فولطية البطارية:"
+    },
+    "initialSetupBatteryValue": {
+        "message": "$1 فولت"
+    },
+    "initialSetupDrawn": {
+        "message": "السعة المستهلكة:"
+    },
+    "initialSetupDrawing": {
+        "message": "سحب التيار:"
+    },
+    "initialSetupBatteryMahValue": {
+        "message": "1ملي أمبير في الساعة"
+    },
+    "initialSetupBatteryAValue": {
+        "message": "أمبير"
+    },
+    "initialSetupCpuLoad": {
+        "message": "حمل المعالج:"
+    },
+    "initialSetupLoopTime": {
+        "message": "معدل حلقة التحكّم:"
+    },
+    "initialSetupCpuTemp": {
+        "message": "درجة حرارة المعالج:"
+    },
+    "initialSetupCpuTempNotSupported": {
+        "message": "لا يوجد دعم من MSP API قبل 1.46"
+    },
+    "initialSetupRSSI": {
+        "message": "RSSI:"
+    },
+    "initialSetupNotInBuild": {
+        "message": "غير مضمن في البناء",
+        "description": "Message that pops up when hardware support is not included in build"
+    },
+    "initialSetupNotDetected": {
+        "message": "لم يتم اكتشافه أو أنه معطل",
+        "description": "Message that pops up when hardware is not detected or disabled"
+    },
+    "initialSetupRSSIValue": {
+        "message": "$1 dBm"
+    },
+    "initialSetupMCU": {
+        "message": "وحدة التحكم الدقيقة:"
+    },
+    "initialSetupSensorHardware": {
+        "message": "المستشعرات:"
+    },
+    "initialSetupSensorGyro": {
+        "message": "الجيروسكوب:"
+    },
+    "initialSetupSensorAcc": {
+        "message": "مقياس التسارع:"
+    },
+    "initialSetupSensorMag": {
+        "message": "مقياس المغناطيسية:"
+    },
+    "initialSetupSensorBaro": {
+        "message": "مقياس الضغط:"
+    },
+    "initialSetupSensorGPS": {
+        "message": "نظام تحديد المواقع:"
+    },
+    "initialSetupSensorSonar": {
+        "message": "السونار:"
+    },
+    "initialSetupSensorOpticalflow": {
+        "message": "التدفق البصري:"
+    },
+    "initialSetupSensorRadar": {
+        "message": "الرادار:"
+    },
+    "initialSetupArmingDisableFlags": {
+        "message": "موانع تفعيل وضع الاستعداد للطيران:"
+    },
+    "initialSetupArmingAllowed": {
+        "message": "وضع الاستعداد للطيران مسموح"
+    },
+    "initialSetupArmingDisableFlagsTooltip": {
+        "message": "قائمة بالأعلام تشير إلى سبب عدم السماح بوضع الاستعداد للطيران حاليًا. مرر الفأرة فوق العلم أو راجع الويكي (صفحة 'تسلسل وضع الاستعداد للطيران والسلامة') لمزيد من المعلومات."
+    },
+    "initialSetupArmingDisableFlagsTooltipNO_GYRO": {
+        "message": "لم يتم اكتشاف جيروسكوب",
+        "description": "Message that pops up to describe the NO_GYRO arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipFAILSAFE": {
+        "message": "السقوط الآمن مفعل",
+        "description": "Message that pops up to describe the FAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRX_FAILSAFE": {
+        "message": "لم يتم اكتشاف إشارة مستقبل صالحة",
+        "description": "Message that pops up to describe the RX_FAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNOT_DISARMED": {
+        "message": "المستقبل تعافى للتو من السقوط الآمن للمستقبل ولكن مفتاح وضع الاستعداد للطيران قيد التشغيل",
+        "description": "Message that pops up to describe the NOT_DISARMED arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBOXFAILSAFE": {
+        "message": "تم تفعيل مفتاح 'FAILSAFE'",
+        "description": "Message that pops up to describe the BOXFAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRUNAWAY_TAKEOFF": {
+        "message": "تم تشغيل منع الإقلاع غير المتحكم به",
+        "description": "Message that pops up to describe the RUNAWAY_TAKEOFF arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCRASH_DETECTED": {
+        "message": "كشف الاصطدام نشط",
+        "description": "Message that pops up to describe the CRASH_DETECTED arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCALIBRATING": {
+        "message": "الطائرة تجري المعايرة حاليًا",
+        "description": "Message that pops up to describe the CALIBRATING arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipTHROTTLE": {
+        "message": "قناة دفع المحرك مرتفعة جدًا",
+        "description": "Message that pops up to describe the THROTTLE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipANGLE": {
+        "message": "الطائرة ليست في مستوى (كافٍ)",
+        "description": "Message that pops up to describe the ANGLE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBOOT_GRACE_TIME": {
+        "message": "تفعيل وضع الاستعداد للطيران مبكرًا جدًا بعد التشغيل",
+        "description": "Message that pops up to describe the BOOT_GRACE_TIME arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNOPREARM": {
+        "message": "مفتاح التحضير للطيران غير مفعل أو لم يتم تبديل التحضير للطيران بعد تعطيل وضع الاستعداد للطيران",
+        "description": "Message that pops up to describe the NOPREARM arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipLOAD": {
+        "message": "حمولة النظام مرتفعة جدًا للطيران الآمن",
+        "description": "Message that pops up to describe the LOAD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipACC_CALIBRATION": {
+        "message": "معايرة مقياس التسارع لا تزال جارية",
+        "description": "Message that pops up to describe the ACC_CALIBRATION arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCLI": {
+        "message": "واجهة الأوامر النصية مفعلة",
+        "description": "Message that pops up to describe the CLI arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCMS_MENU": {
+        "message": "قائمة CMS (قائمة الاعدادات) نشطة - عبر OSD أو عرض آخر -",
+        "description": "Message that pops up to describe the CMS_MENU arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipOSD_MENU": {
+        "message": "قائمة العرض على الشاشة مفعلة",
+        "description": "Message that pops up to describe the OSD_MENU arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBST": {
+        "message": "أداة تبادل المعلومات Black Sheep (مثل TBS Core Pro) غير مشغلة وبذلك تمنع وضع الاستعداد للطيران",
+        "description": "Message that pops up to describe the BST arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipMSP": {
+        "message": "اتصال MSP نشط، على الأرجح مع تطبيق Betaflight",
+        "description": "Message that pops up to describe the MSP arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipPARALYZE": {
+        "message": "تم تفعيل وضع التعطيل",
+        "description": "Message that pops up to describe the PARALYZE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipGPS": {
+        "message": "نمط الإنقاذ باستخدام نظام تحديد المواقع GPS تم إعداده لكن العدد المطلوب من الأقمار الصناعية لم يتم استيفاءه",
+        "description": "Message that pops up to describe the GPS arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRESC": {
+        "message": "تم تفعيل مفتاح الإنقاذ باستخدام نظام تحديد المواقع GPS",
+        "description": "Message that pops up to describe the RESC arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRPMFILTER": {
+        "message": "تم تفعيل الفلترة المعتمدة على سرعة الدوران (RPM)، لكن وحدة تحكّم إلكترونية بالمحرك (ESC) واحدة أو أكثر لا ترسل بيانات DSHOT صالحة. تأكّد من أن وحدات ESC تدعم بيانات DSHOT ثنائية الاتجاه، ومن تثبيت البرنامج الثابت المطلوب عليها.",
+        "description": "Message that pops up to describe the RPMFILTER arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipDSHOT_TELEM": {
+        "message": "تم تفعيل بيانات DSHOT، لكن وحدة تحكّم إلكترونية بالمحرك (ESC) واحدة أو أكثر لا ترسل بيانات DSHOT صالحة. تأكّد من أن وحدات ESC تدعم بيانات DSHOT ثنائية الاتجاه، ومن تثبيت البرنامج الثابت المطلوب عليها.",
+        "description": "Message that pops up to describe the DSHOT_TELEM arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipREBOOT_REQUIRED": {
+        "message": "تغيير في الاعدادات يتطلب إعادة تشغيل",
+        "description": "Message that pops up to describe the REBOOT_REQD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipDSHOT_BITBANG": {
+        "message": "لا يعمل DSHOT البرمجي (Bitbanged DSHOT) بصورة صحيحة، ولذلك لا يمكن التحكّم بالمحرّكات. يُرجّح أن السبب هو تعارض في المؤقّتات مع مميزات أخرى مفعّلة على وحدة التحكّم بالطيران.",
+        "description": "Message that pops up to describe the DSHOT_BBANG arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNO_ACC_CALIBRATION": {
+        "message": "لم يتم معايرة مقياس التسارع وهناك مميزات مفعلة تعتمد عليه. قم بمعايرة مقياس التسارع.",
+        "description": "Message that pops up to describe the NO_ACC_CAL arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipMOTOR_PROTOCOL": {
+        "message": "لم يتم تحديد بروتوكول خرج للمحرّكات.",
+        "description": "Message that pops up to describe the MOTOR_PROTO arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCRASHFLIP": {
+        "message": "مفتاح قلب الطائرة بعد السقوط مفعّل.",
+        "description": "Message that pops to describe the CRASHFLIP arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipALTHOLD": {
+        "message": "تثبيت الارتفاع نشط",
+        "description": "Message that pops up to describe the ALTHOLD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipPOSHOLD": {
+        "message": "تثبيت الموضع نشط",
+        "description": "Message that pops up to describe the POSHOLD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipAUTOPILOT": {
+        "message": "مفتاح وضع الطيار الآلي مفعّل",
+        "description": "Message that pops up to describe the AUTOPILOT arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipARM_SWITCH": {
+        "message": "أحد أسباب منع التشغيل الأخرى نشط عند محاولة تشغيل الطائرة.",
+        "description": "Message that pops up to describe the ARM_SWITCH arming disable flag"
+    },
+    "initialSetupGPSHead": {
+        "message": "نظام تحديد المواقع"
+    },
+    "initialSetupGPSHeadHelp": {
+        "message": "يعرض معلومات GPS، إذا تم تفعيله بشكل صحيح في علامة المنافذ، علامة الإعدادات وعلامة GPS",
+        "description": "Message that pops up to describe the GPS section"
+    },
+    "initialSetupSonarHead": {
+        "message": "مستشعر السونار"
+    },
+    "initialSetupSonarHeadHelp": {
+        "message": "يعرض معلومات مستشعر السونار إذا تم تفعيله بصورة صحيحة في تبويب الإعدادات.",
+        "description": "Message that pops up to describe the Sonar section"
+    },
+    "initialSetupAltitudeSonar": {
+        "message": "الارتفاع"
+    },
+    "initialSetupInstrumentsHead": {
+        "message": "أدوات"
+    },
+    "initialSetupInstrumentsHeadHelp": {
+        "message": "يعرض الاتجاه، و PITCH و YAW في الأدوات",
+        "description": "Message that pops up to describe the Instruments section"
+    },
+    "initialSetupInfoBoardName": {
+        "message": "اللوحة:"
+    },
+    "initialSetupInfoFirmwareVersion": {
+        "message": "البرنامج الثابت:"
+    },
+    "initialSetupInfoAPIversion": {
+        "message": "MSP API:"
+    },
+    "initialSetupInfoBuild": {
+        "message": "معلومات البرنامج الثابت"
+    },
+    "initialSetupInfoFirmwareHelp": {
+        "message": "يعرض معلومات إنشاء البرنامج الثابت، ويتطلب اتصالًا بالإنترنت للوصول إلى خادم البناء.<br>تعرض «الخيارات» الإعدادات المحددة والمستخدمة في البناء السحابي.<br>تعرض روابط «السجل» و«الإعدادات» معلومات البناء السحابي باستخدام المفتاح المخزّن في البرنامج الثابت.<br>عند استخدام بناء محلي، تكون هذه الأقسام فارغة.",
+        "description": "Message that pops up to describe the Build \/ Firmware section"
+    },
+    "initialSetupInfoBuildDate": {
+        "message": "تاريخ البناء:"
+    },
+    "initialSetupInfoBuildInfo": {
+        "message": "معلومات البناء:"
+    },
+    "initialSetupInfoBuildInfoKey": {
+        "message": "مفتاح البناء"
+    },
+    "initialSetupInfoBuildConfig": {
+        "message": "الاعدادات"
+    },
+    "initialSetupInfoBuildDownload": {
+        "message": "تحميل"
+    },
+    "initialSetupInfoBuildFirmware": {
+        "message": "البرامج الثابتة:"
+    },
+    "initialSetupInfoBuildLog": {
+        "message": "سجل"
+    },
+    "initialSetupInfoBuildOptions": {
+        "message": "خيارات"
+    },
+    "initialSetupInfoBuildOptionList": {
+        "message": "الخيارات المحددة في بناء البرامج الثابتة"
+    },
+    "initialSetupInfoBuildEmpty": {
+        "message": "بناء محلي - لا توجد معلومات سحابية"
+    },
+    "initialSetupInfoBuildType": {
+        "message": "نوع البناء:"
+    },
+    "initialSetupInfoBuildLocal": {
+        "message": "البناء المحلي"
+    },
+    "initialSetupInfoBuildCloud": {
+        "message": "بناء السحابة"
+    },
+    "initialSetupNoBuildInfo": {
+        "message": "لا تتوفر معلومات البناء"
+    },
+    "initialSetupNotOnline": {
+        "message": "الخادم غير متاح"
+    },
+    "initialSetupButtonSave": {
+        "message": "حفظ"
+    },
+    "initialSetupModel": {
+        "message": "النموذج:$1"
+    },
+    "initialSetupAttitude": {
+        "message": "$1 درجة"
+    },
+    "initialSetupAccelCalibStarted": {
+        "message": "معايرة مقياس التسارع بدأت"
+    },
+    "initialSetupAccelCalibEnded": {
+        "message": "معايرة مقياس التسارع <span class=\"message-positive\">انتهت<\/span>"
+    },
+    "initialSetupMagCalibStarted": {
+        "message": "معايرة المقياس المغناطيسي بدأت"
+    },
+    "initialSetupMagCalibEnded": {
+        "message": "معايرة المقياس المغناطيسي<span class=\"message-positive\">انتهت<\/span>"
+    },
+    "initialSetupSettingsRestored": {
+        "message": "تمت <strong>استعادة الإعدادات إلى الافتراضي<\/strong>"
+    },
+    "initialSetupNetworkInfo": {
+        "message": "معلومات الشبكة"
+    },
+    "initialSetupNetworkInfoHelp": {
+        "message": "يعرض حالة اتصال الشبكة",
+        "description": "Message that pops up to describe the Network Connection section"
+    },
+    "initialSetupNetworkInfoStatus": {
+        "message": "الحالة:"
+    },
+    "initialSetupNetworkInfoStatusOnline": {
+        "message": "متصل"
+    },
+    "initialSetupNetworkInfoStatusOffline": {
+        "message": "غير متصل"
+    },
+    "initialSetupNetworkInfoStatusSlow": {
+        "message": "بطيء"
+    },
+    "initialSetupNetworkType": {
+        "message": "النوع:"
+    },
+    "initialSetupNetworkRtt": {
+        "message": "RTT:"
+    },
+    "initialSetupNetworkDownlink": {
+        "message": "رابط التنزيل:"
+    },
+    "featureNone": {
+        "message": "&lt;اختر واحدًا&gt;"
+    },
+    "featureRX_PPM": {
+        "message": "PPM\/CPPM (سلك واحد)"
+    },
+    "featureINFLIGHT_ACC_CAL": {
+        "message": "معايرة التوازن أثناء الطيران"
+    },
+    "featureRX_SERIAL": {
+        "message": "منفذ تسلسلي من خلال UART"
+    },
+    "featureMOTOR_STOP": {
+        "message": "لا تقم بتدوير المحركات عند تفعيل وضع الاستعداد للطيران"
+    },
+    "featureMOTOR_STOPTip": {
+        "message": "هذه الميزة معطلة عند تفعيل وضع الطيران (AIRMODE)"
+    },
+    "featureSERVO_TILT": {
+        "message": "محرك الجيمبال"
+    },
+    "featureSERVO_TILTTip": {
+        "message": "تعمل هذه الميزة على تفعيل وضع CAMSTAB، والذي يمكن استخدامه لتثبيت ما يصل إلى محورين ثابتين باستخدام مقياس التسارع"
+    },
+    "featureSOFTSERIAL": {
+        "message": "تفعيل منافذ تسلسلية افتراضية"
+    },
+    "featureSOFTSERIALTip": {
+        "message": "قم بإعداد المنافذ من نافذة المنافذ بعد التفعيل."
+    },
+    "featureGPS": {
+        "message": "نظام تحديد المواقع للملاحة وتبادل المعلومات فقط"
+    },
+    "featureGPSTip": {
+        "message": "تفعيل\/تعطيل بيانات GPS. إذا تعذّر تفعيل GPS، فتأكد من تعيين منفذ له في تبويب \"المنافذ\"",
+        "description": "Message that pops up to describe the GPS feature"
+    },
+    "featureSONAR": {
+        "message": "السونار"
+    },
+    "featureSONARTip": {
+        "message": "تفعيل مقياس المسافة الصوتي (سونار) لقياس المسافة إلى الأرض بالسنتيمتر"
+    },
+    "featureTELEMETRY": {
+        "message": "مخرج Telemetry"
+    },
+    "featureTELEMETRYTip": {
+        "message": "تفعيل إخراج القياس عن بعد لإرساله إلى جهاز الإرسال"
+    },
+    "feature3D": {
+        "message": "النمط ثلاثي الأبعاد (يستخدم مع متحكمات السرعة القابلة لعكس الاتجاه)"
+    },
+    "feature3DTip": {
+        "message": "تفعيل وضع ثلاثي الأبعاد للاستخدام مع وحدات التحكم الإلكترونية القابلة للعكس، قم بتكوينه في علامة التبويب \"المحركات\""
+    },
+    "featureRX_PARALLEL_PWM": {
+        "message": "PWM (سلك واحد لكل قناة)"
+    },
+    "featureRX_MSP": {
+        "message": "بروتوكول MSP (التحكم عبر منفذ MSP)"
+    },
+    "featureRSSI_ADC": {
+        "message": "مدخل RSSI التناظري"
+    },
+    "featureLED_STRIP": {
+        "message": "دعم شريط LED متعدد الألوان RGB"
+    },
+    "featureLED_STRIPTip": {
+        "message": "تفعيل دعم شريط LED متعدد الألوان RGB، قم بتكوينه في علامة تبويب شريط LED"
+    },
+    "featureDISPLAY": {
+        "message": "شاشة عرض OLED"
+    },
+    "featureDISPLAYTip": {
+        "message": "إذا تم تفعيل هذه الميزة، ولم يتم توصيل أي جهاز عرض (أو لم يتم تفعيل جهاز العرض)، فسيكون هناك تأخير لمدة 10 ثوانٍ تقريبًا في كل إعادة تفعيل لوحدة التحكم في الطيران."
+    },
+    "featureOSD": {
+        "message": "العرض على الشاشة"
+    },
+    "featureOSDTip": {
+        "message": "تفعيل OSD، تكوينه في علامة التبويب OSD"
+    },
+    "featureCHANNEL_FORWARDING": {
+        "message": "أعد توجيه القنوات الإضافية إلى مخارج السيرفو"
+    },
+    "featureTRANSPONDER": {
+        "message": "مستجيب السباق"
+    },
+    "featureTRANSPONDERTip": {
+        "message": "فعّل دعم Transponder في Firmware. اضبط المزوّد (<code>set transponder_provider = [ILAP|ARCITIMER|ERLT]<\/code>) والبيانات (<code>set transponder_data = &lt;bytes&gt;<\/code>) عبر CLI، ثم نفّذ <code>save<\/code>. نفّذ <code>get transponder<\/code> لعرض القيم الحالية."
+    },
+    "featureAIRMODE": {
+        "message": "نمط Airmode مفعل بصورة مستمرة"
+    },
+    "featureRX_SPI": {
+        "message": "SPI Rx (مثل Rx المدمج)"
+    },
+    "escSensorSerialPort": {
+        "message": "المنفذ التسلسلي لبيانات القياس عن بُعد من ESC"
+    },
+    "escSensorSerialPortHelp": {
+        "message": "يتم قراءة القياس عن بعد باستخدام ESC على جهاز استشعار ESC نفسه من API 1.49؛ تبويب المنفذ فقط يعرضه."
+    },
+    "featureESC_SENSOR": {
+        "message": "استخدم تيلمترى ESC من نوع KISS\/BLHeli_32 <b>عبر سلك منفصل<\/b>"
+    },
+    "featureANTI_GRAVITY": {
+        "message": "تفعيل بصورة دائمة"
+    },
+    "featureANTI_GRAVITYTip": {
+        "message": "إذا تم تعطيل هذا، يمكن استخدام وضع \"ANTI GRAVITY\" لتفعيل مضاد الجاذبية باستخدام مفتاح."
+    },
+    "featureDYNAMIC_FILTER": {
+        "message": "الفلتر الديناميكي للجيروسكوب"
+    },
+    "configurationFeatureEnabled": {
+        "message": "مفعل"
+    },
+    "configurationFeatureName": {
+        "message": "الميزة"
+    },
+    "configurationFeatureDescription": {
+        "message": "الوصف"
+    },
+    "configurationMixer": {
+        "message": "المازج"
+    },
+    "configurationFeatures": {
+        "message": "مميزات أخرى"
+    },
+    "configurationFeatureHelp": {
+        "message": "الدعم"
+    },
+    "configurationReceiver": {
+        "message": "المستقبل"
+    },
+    "configurationReceiverMode": {
+        "message": "نوع المستقبل"
+    },
+    "configurationTelemetry": {
+        "message": "البيانات التليمترية"
+    },
+    "telemetryInstanceTitle": {
+        "message": "البيانات التليمترية"
+    },
+    "telemetryInstanceProtocol": {
+        "message": "بروتوكول"
+    },
+    "telemetryInstancePort": {
+        "message": "منفذ تسلسلي"
+    },
+    "telemetryInstanceBaud": {
+        "message": "معدل الباود"
+    },
+    "rcdeviceSectionTitle": {
+        "message": "التحكم في الكاميرا"
+    },
+    "rcdeviceSerialPort": {
+        "message": "منفذ تسلسلي"
+    },
+    "rcdeviceSerialPortHelp": {
+        "message": "منفذ UART الموصول بكاميرا تستخدم بروتوكول RunCam. ابتداءً من API 1.49، يُضبط المنفذ من الجهاز نفسه؛ أما علامة تبويب المنافذ فتعرضه فقط.\n"
+    },
+    "configurationTelemetryHelp": {
+        "message": "خرج البيانات التليمترية من جهاز الاستقبال"
+    },
+    "configurationRSSI": {
+        "message": "قوة الإشارة"
+    },
+    "configurationRSSIHelp": {
+        "message": "RSSI هو قياس لشدة الإشارة ومفيد جدًا حتى تعرف متى تكون طائرتك خارج النطاق أو إذا كانت تعاني  من تداخل لاسلكي."
+    },
+    "configurationEscFeatures": {
+        "message": "مميزات ESC\/المحرك"
+    },
+    "configurationFeaturesHelp": {
+        "message": "<strong>ملاحظة:<\/strong> ليست جميع المميزات صالحة. عندما يكتشف برنامج وحدة تحكم الطيران المميزات غير صالحة، سيتم تعطيل المميزات المتضاربة.<br \/><strong>ملاحظة:<\/strong> قم باعداد المنافذ التسلسلية <span class=\"message-negative\">قبل<\/span> تمكين المميزات التي ستستخدم هذه المنافذ."
+    },
+    "configurationSerialRXHelp": {
+        "message": "&#8226; يجب تعيين UART الخاص بالمستقبل إلى 'Serial Rx' (في علامة <i>المنافذ<\/i>)<br>&#8226; حدد تنسيق البيانات الصحيح من القائمة المنسدلة أدناه:"
+    },
+    "configurationSpiRxHelp": {
+        "message": "<strong>ملاحظة:<\/strong> مزود SPI RX سيعمل فقط إذا كانت الأجهزة المطلوبة موجودة على اللوحة أو متصلة بناقل SPI."
+    },
+    "configurationActiveImu": {
+        "message": "وحدة القياس بالقصور الذاتي نشطة"
+    },
+    "configurationMagAlignmentHelp": {
+        "message": "محاذاة المقياس المغناطيسي هي اتجاه مستشعر مقياس المغناطيسية على لوحة وحدة تحكم الطيران. الافتراضي عادةً صحيح، ولكن إذا كان لديك بناء مخصص أو وحدة تحكم طيران باتجاه مغناطيسي مختلف، فقد تحتاج إلى تعديل هذا الإعداد."
+    },
+    "configurationMagDeclination": {
+        "message": "الانحراف المغناطيسي"
+    },
+    "configurationMagDeclinationInput": {
+        "message": "درجات الانحراف"
+    },
+    "configurationMagDeclinationHelp": {
+        "message": "الانحراف المغناطيسي هو الزاوية بين الشمال المغناطيسي والشمال الحقيقي. وهو مختلف لكل موقع على الأرض. يمكنك العثور على الانحراف لموقعك على الإنترنت"
+    },
+    "configurationRangefinder": {
+        "message": "كاشف المدى",
+        "description": "Don't translate!!!"
+    },
+    "configurationRangefinderHelp": {
+        "message": "تفعيل مقياس المدى لقياس المسافة إلى الأرض بالسنتيمتر"
+    },
+    "configurationRangefinderType": {
+        "message": "النوع"
+    },
+    "rangefinderSerialPort": {
+        "message": "المنفذ التسلسلي Rangefinder "
+    },
+    "rangefinderSerialPortHelp": {
+        "message": "منفذ UART الموصول بمستشعر قياس المسافة. ابتداءً من API 1.49، يُضبط المنفذ من المستشعر نفسه؛ أما علامة تبويب المنافذ فتعرضه فقط.\n"
+    },
+    "opticalflowSerialPort": {
+        "message": "منفذ التدفق Optical Flow"
+    },
+    "opticalflowSerialPortHelp": {
+        "message": "منفذ UART الموصول بمستشعر التدفق البصري. إذا كانت الوحدة ترسل بيانات التدفق وقياس المسافة معًا، فيجب ضبط منفذ كل وظيفة على حدة.\n"
+    },
+    "configurationOpticalflow": {
+        "message": "التدفق البصري",
+        "description": "Don't translate!!!"
+    },
+    "configurationOpticalflowHelp": {
+        "message": "تفعيل مستشعر التدفق البصري"
+    },
+    "configurationBoardAlignment": {
+        "message": "محاذاة اللوحة"
+    },
+    "configurationBoardAlignmentRoll": {
+        "message": "تهيئة ROLL"
+    },
+    "configurationBoardAlignmentPitch": {
+        "message": "تهيئة PITCH"
+    },
+    "configurationBoardAlignmentYaw": {
+        "message": "تهيئة YAW"
+    },
+    "configurationMagAlignment": {
+        "message": "محاذاة مقياس المغناطيسية"
+    },
+    "configurationBoardAlignmentHelp": {
+        "message": "تحديد زاوية دوران لوحة التحكّم بالدرجات، للسماح بتركيبها جانبيًا أو مقلوبة أو بزاوية مختلفة. عند استخدام مستشعرات خارجية، استخدم إعدادات محاذاة المستشعرات (الجيروسكوب ومقياس التسارع والبوصلة) لتحديد اتجاه كل مستشعر بصورة مستقلة عن اتجاه اللوحة."
+    },
+    "boardAlignmentWizard-Launch": {
+        "message": "الكشف التلقائي"
+    },
+    "boardAlignmentWizard-DialogTitle": {
+        "message": "معالج محاذاة لوحة التحكّم"
+    },
+    "boardAlignmentWizard-Intro": {
+        "message": "هذا المعالج يكشف كيف يتم تركيب وحدة تحكم الطيران الخاصة بك عن طريق توجيهك من خلال أربع حركات بسيطة. ضع الطائرة بدون طيار على سطح مسطح  ثم اتبع الطلبات."
+    },
+    "boardAlignmentWizard-Start": {
+        "message": "البداية"
+    },
+    "boardAlignmentWizard-Step": {
+        "message": "خطوة"
+    },
+    "boardAlignmentWizard-HintFlat": {
+        "message": "ضع الطائرة بدون طيار  (باتجاه الشاشة)."
+    },
+    "boardAlignmentWizard-HintPitchDown": {
+        "message": "ميل الأنف إلى الأسفل حوالي 45 درجة ، لذا تتجه الكاميرا نحو الأرض."
+    },
+    "boardAlignmentWizard-HintRollRight": {
+        "message": "يميل الجانب الأيمن إلى الأسفل حوالي 45 درجة "
+    },
+    "boardAlignmentWizard-HintYawCW": {
+        "message": "تدوير الطائرة بدون طيار حوالي 45 درجة باتجاه عقارب الساعة (كما يتضح من أعلاه)."
+    },
+    "boardAlignmentWizard-HintLevel": {
+        "message": "إرجاع الطائرة إلى الوضع المستوى."
+    },
+    "boardAlignmentWizard-HoldSteady": {
+        "message": "أمسك باستمرار..."
+    },
+    "boardAlignmentWizard-Settling": {
+        "message": "جارٍ الاستقرار..."
+    },
+    "boardAlignmentWizard-Tilting": {
+        "message": "استمر في الإمالة"
+    },
+    "boardAlignmentWizard-LevelOut": {
+        "message": "أعد الطائرة إلى الوضع المستوي"
+    },
+    "boardAlignmentWizard-AxisDetected": {
+        "message": "تم اكتشاف المحور — أبقِ الطائرة ثابتة"
+    },
+    "boardAlignmentWizard-YawProgress": {
+        "message": "الدوران"
+    },
+    "boardAlignmentWizard-Computing": {
+        "message": "جارٍ حساب المحاذاة..."
+    },
+    "boardAlignmentWizard-ResultTitle": {
+        "message": "المحاذاة المكتشفة"
+    },
+    "boardAlignmentWizard-ResultNoChange": {
+        "message": "تبدو محاذاة لوحة التحكم صحيحة — لا حاجة إلى أي تغييرات."
+    },
+    "boardAlignmentWizard-ResultCurrent": {
+        "message": "الحالي"
+    },
+    "boardAlignmentWizard-ResultDetected": {
+        "message": "المكتشف"
+    },
+    "boardAlignmentWizard-Back": {
+        "message": "رجوع"
+    },
+    "boardAlignmentWizard-Apply": {
+        "message": "تطبيق"
+    },
+    "boardAlignmentWizard-Cancel": {
+        "message": "إلغاء"
+    },
+    "boardAlignmentWizard-Retry": {
+        "message": "حاول مرة أخرى"
+    },
+    "boardAlignmentWizard-CaptureNow": {
+        "message": "التقاط الآن"
+    },
+    "boardAlignmentWizard-LowConfidence": {
+        "message": "دقة الاكتشاف منخفضة — يرجى التحقق من النتيجة مرة أخرى."
+    },
+    "boardAlignmentWizard-NoAccelerometer": {
+        "message": "يلزم وجود مقياس تسارع لتشغيل هذا المعالج."
+    },
+    "boardAlignmentWizard-AccNeedsCalibration": {
+        "message": "يرجى معايرة مقياس التسارع قبل تشغيل هذا المعالج."
+    },
+    "boardAlignmentWizard-Error-missing_samples": {
+        "message": "لم يتم جمع بعض العينات. يرجى المحاولة مرة أخرى."
+    },
+    "boardAlignmentWizard-Error-no_gravity": {
+        "message": "مقياس التسارع لا يقرأ الجاذبية. تأكد من أن FC متصل وليس في الحركة."
+    },
+    "boardAlignmentWizard-Error-no_pitch_tilt": {
+        "message": "لم يتم الكشف عن  PITCH . الرجاء إعادة المحاولة وإمالة أنف الطائرة إلى الأسفل."
+    },
+    "boardAlignmentWizard-Error-no_roll_tilt": {
+        "message": "لم يتم الكشف عن  ROLL . الرجاء إعادة المحاولة وإمالة أنف الطائرة إلى الأسفل."
+    },
+    "boardAlignmentWizard-Error-gesture_direction_mismatch": {
+        "message": "تمت إحدى حركات الإمالة في الاتجاه الخاطئ. تحقق من اتجاهي Pitch وRoll وحاول مرة أخرى."
+    },
+    "boardAlignmentWizard-StepFlat": {
+        "message": "مسطح"
+    },
+    "boardAlignmentWizard-StepPitch": {
+        "message": "الميل الأمامي والخلفي (Pitch)"
+    },
+    "boardAlignmentWizard-StepRoll": {
+        "message": "الميل الجانبي (Roll)"
+    },
+    "boardAlignmentWizard-StepYaw": {
+        "message": "الدوران (Yaw)"
+    },
+    "boardAlignmentWizard-Confirmed": {
+        "message": "تم الالتقاط"
+    },
+    "configurationGyro1AlignmentRoll": {
+        "message": "$t(configurationBoardAlignmentRoll.message)",
+        "description": "Don't translate!!!"
+    },
+    "configurationGyro1AlignmentPitch": {
+        "message": "$t(configurationBoardAlignmentPitch.message)",
+        "description": "Don't translate!!!"
+    },
+    "configurationGyro1AlignmentYaw": {
+        "message": "$t(configurationBoardAlignmentYaw.message)",
+        "description": "Don't translate!!!"
+    },
+    "configurationGyro2AlignmentRoll": {
+        "message": "$t(configurationBoardAlignmentRoll.message)",
+        "description": "Don't translate!!!"
+    },
+    "configurationGyro2AlignmentPitch": {
+        "message": "$t(configurationBoardAlignmentPitch.message)",
+        "description": "Don't translate!!!"
+    },
+    "configurationGyro2AlignmentYaw": {
+        "message": "$t(configurationBoardAlignmentYaw.message)",
+        "description": "Don't translate!!!"
+    },
+    "configurationSensorGyroToUse": {
+        "message": "GYRO\/ACCEL"
+    },
+    "configurationSensorGyroToUseFirst": {
+        "message": "الأول"
+    },
+    "configurationSensorGyroToUseSecond": {
+        "message": "الثاني"
+    },
+    "configurationSensorGyroToUseBoth": {
+        "message": "كلاهما"
+    },
+    "configurationSensorAlignmentGyro1": {
+        "message": "الجيروسكوب الأول"
+    },
+    "configurationSensorAlignmentGyro2": {
+        "message": "الجيروسكوب الثاني"
+    },
+    "configurationSensorAlignmentDefaultOption": {
+        "message": "افتراضي"
+    },
+    "configurationSensorAlignmentCustom": {
+        "message": "مُخصّص"
+    },
+    "configurationAccelTrimRoll": {
+        "message": "ضبط انحراف مقياس التسارع حول محور Roll"
+    },
+    "configurationAccelTrimPitch": {
+        "message": "ضبط انحراف مقياس التسارع حول محور PITCH"
+    },
+    "configurationArming": {
+        "message": "وضع التشغيل "
+    },
+    "configurationArmingHelp": {
+        "message": "بعض خيارات وضع التشغيل قد تتطلب تفعيل مقياس التسارع"
+    },
+    "configurationReverseMotorSwitch": {
+        "message": "اتجاه المحركات معكوس"
+    },
+    "configurationReverseMotorSwitchHelp": {
+        "message": "يضبط هذا الخيار المازج ليتوافق مع دوران المحرّكات بالاتجاه المعكوس وتركيب المراوح وفقًا لذلك. <strong>تحذير:<\/strong> لا يعكس هذا الخيار اتجاه دوران المحرّكات فعليًا. استخدم أداة إعداد وحدات ESC أو بدّل ترتيب أي سلكين بين وحدة ESC والمحرّك لعكس اتجاه الدوران. كذلك، انزع المراوح وتأكد من أن المحرّكات تدور بالاتجاهات الموضّحة في الرسم أعلاه قبل محاولة التسليح.\n\n\n"
+    },
+    "configurationAutoDisarmDelay": {
+        "message": "إلغاء تشغيل المحرّكات بعد مدة [بالثواني]"
+    },
+    "configurationAutoDisarmDelayHelp": {
+        "message": "تعطيل تشغيل المحركات بعد التأخير المحدد [ثواني] (يتطلب ميزة MOTOR_STOP)"
+    },
+    "configurationGyroCalOnFirstArm": {
+        "message": "معايرة الجيروسكوب عند أول تفعيل لتشغيل المحركات"
+    },
+    "configurationGyroCalOnFirstArmHelp": {
+        "message": "عند التفعيل، سيتم معايرة الجيروسكوب عند أول تهيئة بعد التشغيل. يمكن أن يساعد هذا في تقليل انحراف الجيروسكوب أثناء الطيران."
+    },
+    "configurationMotorIdle": {
+        "message": "خمول المحرك (%)"
+    },
+    "configurationMotorIdleHelp": {
+        "message": "يضبط سرعة خمول المحرّكات أثناء التشغل عندما تكون دواسة الوقود منخفضة (أقل من min_check).<br\/><br\/><strong class=\"message-positive\">الخمول الديناميكي غير مفعّل<\/strong><br\/><br\/>يتلقى كل محرّك قيمة min_command مضافًا إليها نسبة خمول المحرّك.<br\/><br\/><b>الخمول منخفض جدًا<\/b>: قد لا تبدأ المحرّكات بالدوران بصورة موثوقة، أو تتسارع ببطء، أو تفقد التزامن أثناء حركات FLIP أو الدوران.<br\/><br\/><b>الخمول مرتفع جدًا<\/b>: قد تبدو الطائرة وكأنها تطفو.<br\/><br\/><b>ملاحظة<\/b>: يجب معايرة وحدات ESC التناظرية بحيث تبدأ المحرّكات بالدوران عند قيمة أعلى قليلًا من min_command.<br\/><br\/><strong class=\"message-positive\">الخمول الديناميكي مفعّل<\/strong><br\/><br\/>عند التشغيل ، تُرسل قيمة الخمول العادية إلى كل محرّك حتى يبدأ بالدوران.<br\/><br\/>بعد بدء الدوران، تُضبط إشارة المحرّك للوصول إلى سرعة الدوران المستهدفة (RPM).<br\/><br\/>قبل الإقلاع، تُحدَّد إشارة المحرّك بنسبة خمول المحرّك، وقد لا تتحقق سرعة الدوران المحددة. هذا أمر طبيعي. عند رفع دواسة الوقود فوق نسبة airmode_motor_start_throttle، يرتفع الحد بدرجة كبيرة، ويُفترض الوصول إلى سرعة الدوران المحددة عند الخمول.<br\/><br\/><b>الخمول منخفض جدًا<\/b>: قد لا تبدأ المحرّكات بالدوران بصورة موثوقة.<br\/><br\/><b>الخمول مرتفع جدًا<\/b>: قد تهتز الطائرة قبل الإقلاع، وذلك فقط إذا كانت قيمة الخمول الديناميكي مرتفعة أيضًا.<br\/><br\/><b>ملاحظة<\/b>: يتطلب الخمول الديناميكي استخدام DShot وبيانات DShot التليمترية."
+    },
+    "configurationMotorPoles": {
+        "message": "عدد أقطاب المحرك",
+        "description": "One of the fields of the ESC\/Motor configuration"
+    },
+    "configurationMotorPolesLong": {
+        "message": "$t(configurationMotorPoles.message) (عدد المغناطيسات على الجزء الدوار من المحرك)",
+        "description": "One of the fields of the ESC\/Motor configuration"
+    },
+    "configurationMotorPolesHelp": {
+        "message": "عدد الأقطاب هو عدد المغناطيسات على الجزء الدوار من المحرك. لا حسب الجزء الثابت حيث توجد الأسلاك. عادةً ما تحتوي محركات 5\" على 14 مغناطيسًا والمحركات 3\" أو أصغر تحتوي على 12 مغناطيسًا.",
+        "description": "Help text for the Motor poles field of the ESC\/Motor configuration"
+    },
+    "configurationMotorIdleRpmHelp": {
+        "message": "هذه هي قيمة الخمول الديناميكي من ملف PID النشط. عندما يتم تعيين الخمول الديناميكي على الصفر، سيطبق فقط خمول المحرك الثابت. قم بتغيير إعدادات الخمول الديناميكي في علامة ضبط PID.",
+        "description": "Help text for dynamic idle setting"
+    },
+    "configurationThrottleMinimum": {
+        "message": "الحد الأدنى لدواسة الوقود  (أدنى قيمة لوحدة التحكم الإلكترونية للسرعة عند تفعيل وضع تشغيل المحركات)"
+    },
+    "configurationThrottleMinimumHelp": {
+        "message": "هذه هي قيمة \"الخمول\" التي يتم إرسالها إلى وحدات التحكم في المحركات ESCs عند تهيئة الطائرة ووضع عصا دواسة الوقود في الحد الأدنى. قم بزيادة القيمة للحصول على سرعة خمول أعلى. كما يجب رفع القيمة في حالة حدوث عدم تزامن!"
+    },
+    "configurationThrottleMaximum": {
+        "message": "الحد الأقصى لدواسة الوقود (أعلى قيمة لوحدة التحكم الإلكترونية للسرعة عند تفعيل وضع تشغيل المحركات)"
+    },
+    "configurationThrottleMinimumCommand": {
+        "message": "الأمر الأدنى (قيمة وحدة التحكم الإلكترونية للسرعة عند عدم تفعيل وضع تشغيل المحركات)"
+    },
+    "configurationThrottleMinimumCommandHelp": {
+        "message": "هذه هي القيمة التي يتم إرسالها إلى وحدات التحكم الإلكترونية للسرعة عندما تكون الطائرة غير في وضع الغاء تشغيل المحركات. عيّن هذه القيمة إلى قيمة تتوقف عندها المحركات (1000 لمعظم وحدات التحكم الإلكترونية للسرعة)."
+    },
+    "configurationEscProtocolDisabled": {
+        "message": "الرجاء تحديد بروتوكول خرج المحرك المناسب لوحدات التحكم الإلكترونية للسرعة الخاصة بك. $t(escProtocolDisabledMessage.message)"
+    },
+    "escProtocolDisabledMessage": {
+        "message": "<strong>تحذير:<\/strong> اختيار بروتوكول خرج المحرك غير مدعوم من قبل وحدات التحكم الإلكترونية للسرعة الخاصة بك يمكن أن يؤدي إلى <strong>بدء دوران وحدات التحكم الإلكترونية للسرعة بمجرد توصيل البطارية<\/strong>. لهذا السبب، <strong>تأكد دائمًا من إزالة المراوح قبل توصيل البطارية لأول مرة بعد تغيير بروتوكول خرج المحرك<\/strong>."
+    },
+    "configurationDshotBeeper": {
+        "message": "إعدادات نغمة تنبيه المحركات (DShot Beacon)"
+    },
+    "configurationUseDshotBeeper": {
+        "message": "استخدام المحركات لإصدار نغمات تنبيه عند إلغاء التشغيل"
+    },
+    "configurationDshotBeaconTone": {
+        "message": "نغمة المنبة"
+    },
+    "configurationDshotBeaconHelp": {
+        "message": "يستخدم تنبيه DShot وحدات الـ ESC والمحركات لإصدار الصوت؛ لذلك لا يمكن تشغيله أثناء دوران المحركات.\n\nفي Betaflight 3.4 والإصدارات الأحدث، إذا حاولت التشغيل أثناء عمل التنبيه، فسيؤخر النظام التشغيل لمدة ثانيتين بعد آخر نغمة. يمنع هذا تنبيه DShot من التداخل مع أوامر DShot المُرسلة عند التشغيل .\n\n<strong>تحذير:<\/strong> يمرّر تنبيه DShot تيارًا كهربائيًا عبر المحركات أثناء تشغيله، وقد يؤدي رفع قوة التنبيه أكثر من اللازم إلى سخونة مفرطة وتلف المحركات و\/أو وحدات الـ ESC. استخدم BLHeli Configurator أو BLHeliSuite لضبط قوة التنبيه واختبارها بعناية"
+    },
+    "configurationBeeper": {
+        "message": "اعداد المنبة"
+    },
+    "beeperGYRO_CALIBRATED": {
+        "message": "يصدر صوتًا عند معايرة الجيروسكوب"
+    },
+    "beeperRX_LOST": {
+        "message": "يصدر صوتًا عند إطفاء الإرسال TX"
+    },
+    "beeperRX_LOST_LANDING": {
+        "message": "يصدر صوت SOS عند تفعيل وضع التشغيل وإيقاف تشغيل TX أو فقد الإشارة (هبوط تلقائي\/تعطيل تلقائي لوضع الغاء تشغيل المحركات)"
+    },
+    "beeperDISARMING": {
+        "message": "أصدر نغمة عند تعطيل وضع الغاء تشغيل المحركات"
+    },
+    "beeperARMING": {
+        "message": "أصدر نغمة عند تفعيل وضع تشغيل المحركات"
+    },
+    "beeperARMING_GPS_FIX": {
+        "message": "أصدر نغمة تنبيه خاصة عند تفعيل وضع تشغيل المحركات ونظام تحديد المواقع متصل بالأقمار"
+    },
+    "beeperBAT_CRIT_LOW": {
+        "message": "أصوات تحذيرية عند قرب نفاذ البطارية (تكرار)"
+    },
+    "beeperBAT_LOW": {
+        "message": "أصوات تحذيرية عند قرب نفاذ البطارية (تكرار)"
+    },
+    "beeperGPS_STATUS": {
+        "message": "استخدم عدد الأصوات للإشارة إلى عدد الأقمار التي تم الاتصال بها"
+    },
+    "beeperRX_SET": {
+        "message": "أصدر تنبيه عند إعداد القناة الإضافية للتنبيه"
+    },
+    "beeperACC_CALIBRATION": {
+        "message": "تأكيد اكتمال معايرة مقياس التسارع"
+    },
+    "beeperACC_CALIBRATION_FAIL": {
+        "message": "فشل معايرة مقياس التسارع"
+    },
+    "beeperREADY_BEEP": {
+        "message": "أصدر نغمة عند اتصال وجهوزية نظام تحديد المواقع"
+    },
+    "beeperDISARM_REPEAT": {
+        "message": "إصدار نغمات عندما تكون عصا التحكم بوضع عدم تفعيل وضع الغاء تشغيل المحركات"
+    },
+    "beeperARMED": {
+        "message": "نغمة تحذيرية عند تفعيل وضع تشغيل المحركات مع إيقاف المحركات عند وضع الخمول (كرر حتى تعطيل وضع الغاء تشغيل المحركات أو زيادة دفع المحرك)"
+    },
+    "beeperSYSTEM_INIT": {
+        "message": "نغمات بدء التشغيل عند تشغيل لوحة التحكم"
+    },
+    "beeperUSB": {
+        "message": "أصدر نغمة عند تشغيل متحكم الطيران بواسطة USB. أوقف النغمة إذا لم ترغب بها وأنت على طاولة العمل"
+    },
+    "beeperBLACKBOX_ERASE": {
+        "message": "أصدر نغمة عند اكتمال مسح الصندوق الأسود"
+    },
+    "beeperCRASH_FLIP": {
+        "message": "التنبيه عندما يكون وضع الأنقلاب بعد السقوط نشط"
+    },
+    "beeperCAM_CONNECTION_OPEN": {
+        "message": "إصدار نغمة تنبيه عند الدخول إلى قائمة التحكم بالكاميرا ذات الأزرار الخمسة"
+    },
+    "beeperCAM_CONNECTION_CLOSE": {
+        "message": "إصدار نغمة تنبيه عند الخروج من قائمة التحكم بالكاميرا ذات الأزرار الخمسة"
+    },
+    "beeperRC_SMOOTHING_INIT_FAIL": {
+        "message": "إصدار نغمة تنبيه عند التشغيل إذا لم تكتمل تهيئة فلاتر تنعيم إشارات جهاز التحكم (RC Smoothing)"
+    },
+    "configurationBeeperEnableAll": {
+        "message": "تفعيل الكل"
+    },
+    "configurationBeeperDisableAll": {
+        "message": "تعطيل الكل"
+    },
+    "configuration3d": {
+        "message": "مميزات الـ ESC والمحركات في وضع 3D"
+    },
+    "configuration3dDeadbandLow": {
+        "message": "الحد السفلي للمنطقة المحايدة في وضع 3D"
+    },
+    "configuration3dDeadbandHigh": {
+        "message": "الحد الاعلى للمنطقة المحايدة في وضع 3D"
+    },
+    "configuration3dNeutral": {
+        "message": "النقطة المحايدة في وضع 3D"
+    },
+    "configuration3dDeadbandThrottle": {
+        "message": "نطاق دواسة الوقود المحايدة في وضع 3D"
+    },
+    "configurationSystem": {
+        "message": "إعدادات النظام"
+    },
+    "configurationLoopTime": {
+        "message": "وقت دورة وحدة تحكم الطيران"
+    },
+    "configurationCalculatedCyclesSec": {
+        "message": "دورات\/الثانية [هرتز]"
+    },
+    "configurationSpeedGyroNoGyro": {
+        "message": "لا يوجد جيروسكوب",
+        "description": "When no gyro is configured this appears in place of the speed of the gyro in kHz"
+    },
+    "configurationSpeedPidNoGyro": {
+        "message": "الجيروسكوب \/ {{value}}",
+        "description": "When no gyro is configured this appears in place of the speed of the PID in kHz. Try to keep it short."
+    },
+    "configurationKHzUnitLabel": {
+        "message": "{{value}} كيلوهرتز",
+        "description": "Value for some options that show the speed of gyro, pid, etc. in kHz"
+    },
+    "configurationLoopTimeHelp": {
+        "message": "<strong>ملاحظة:<\/strong> تأكد من قدرة FC على العمل بهذه السرعات! تحقق من استقرار استخدام CPU وزمن الدورة. قد يتطلب تغيير هذا الإعداد إعادة توليف PID. نصيحة: عطّل مقياس التسارع والمستشعرات الأخرى لتحسين الأداء."
+    },
+    "configurationGPS": {
+        "message": "الإعدادات"
+    },
+    "configurationGPSHelp": {
+        "message": "إعداد البروتوكول لجهاز GPS (تذكر إعداد المنفذ في علامة المنافذ)، استخدم Auto baud (أو إعداد السرعة في علامة المنافذ) والتكوينات الأخرى",
+        "description": "Help text GPS configuration"
+    },
+    "configurationGPSProtocol": {
+        "message": "البروتوكول"
+    },
+    "configurationGPSBaudrate": {
+        "message": "معدل الباود"
+    },
+    "configurationGPSubxSbas": {
+        "message": "نظام التعزيز الأرضي"
+    },
+    "gpsSerialPort": {
+        "message": "منفذ تسلسلي"
+    },
+    "gpsSerialPortHelp": {
+        "message": "UART وحدة GPS موصولة سلكيا. تغيير يتطلب إعادة تشغيل."
+    },
+    "gpsSerialBaud": {
+        "message": "معدل الباود"
+    },
+    "gpsSerialBaudHelp": {
+        "message": "سرعة الاتصال المتوقع أن تعمل بها وحدة GPS. يجرّب Betaflight سرعات أخرى أيضًا إذا تعذّر الاتصال بها، لذا تمثل هذه القيمة نقطة بداية وليست إعدادًا ثابتًا.\n"
+    },
+    "gpsSerialPortSaveFailed": {
+        "message": "تعذر تعيين منفذ GPS التسلسلي، لذلك لم يتم حفظ أي شيء."
+    },
+    "gpsCanDevice": {
+        "message": "ناقل CAN"
+    },
+    "gpsCanDeviceHelp": {
+        "message": "ناقل CAN الموصول به وحدات DroneCAN. يخص هذا الإعداد نظام DroneCAN بالكامل؛ لذلك سيؤدي تغييره إلى نقل جميع أجهزة DroneCAN، وليس جهاز GPS فقط. يتطلب تغيير هذا الإعداد إعادة التشغيل.\n"
+    },
+    "gpsCanDeviceSaveFailed": {
+        "message": "تعذر تعيين منفذ GPS التسلسلي، لذلك لم يتم حفظ أي شيء."
+    },
+    "configurationGPSAutoBaud": {
+        "message": "الباود التلقائي"
+    },
+    "configurationGPSAutoConfig": {
+        "message": "التكوين التلقائي"
+    },
+    "configurationGPSGalileo": {
+        "message": "استخدام جاليليو",
+        "description": "Option to use Galileo in the GPS configuration"
+    },
+    "configurationGPSGalileoHelp": {
+        "message": "عند التمكين، سيتتبع وحدة GPS أيضًا نظام الأقمار الصناعية جاليليو، مما يؤدي عادةً إلى قفل المزيد من الأقمار الصناعية. في Betaflight 4.2.x أو إصدار أقدم، فإنه يعطل أيضًا نظام التعزيز QZSS.",
+        "description": "Help text for the option to use Galileo in the GPS configuration"
+    },
+    "configurationGPSHomeOnce": {
+        "message": "تعيين نقطة العودة مرة واحدة فقط",
+        "description": "Option to set the Home Point with the first arm only, not with each arm in the GPS Configuration"
+    },
+    "configurationGPSHomeOnceHelp": {
+        "message": "عند التمكين، سيتم استخدام أول تفعيل لوضع الاستعداد للطيران بعد توصيل البطارية فقط كنقطة عودة. إذا لم يتم التمكين، في كل مرة يتم فيها تفعيل وضع الاستعداد للطيران للطائرة، سيتم تحديث نقطة العودة.",
+        "description": "Help text for the option to set the Home Point with the first arm only, not with each arm in the GPS Configuration"
+    },
+    "configurationGPSNotInBuild": {
+        "message": "دعم GPS غير مُضمّن في إصدار البرنامج الثابت هذا. أعد بناء البرنامج الثابت مع تفعيل خيار GPS ضمن خيارات البناء لتتمكن من إعداده واستخدامه.\n",
+        "description": "Shown in the GPS Configuration box when the connected firmware was built without the GPS build option"
+    },
+    "configurationSerialRX": {
+        "message": "مزود المستقبل التسلسلي"
+    },
+    "portsPortNone": {
+        "message": "لا شيء"
+    },
+    "receiverSerialPort": {
+        "message": "منفذ تسلسلي"
+    },
+    "receiverSerialPortHelp": {
+        "message": "منفذ UART الموصول به جهاز الاستقبال التسلسلي. يتحدد معدل البود وفقًا لبروتوكول جهاز الاستقبال، لذلك لا يوجد ما يلزم ضبطه هنا. يتطلب تغيير المنفذ إعادة تشغيل الجهاز.\n"
+    },
+    "receiverSerialPortSaveFailed": {
+        "message": "لا يمكن تعيين منفذ التسلسل، لذلك لم يتم حفظ أي شيء."
+    },
+    "someRXTypesDisabled": {
+        "message": "بعض مزودي المستقبلات غير مدعومين بتكوين البناء الحالي."
+    },
+    "serialRXNotSupported": {
+        "message": "مزود المستقبل المحدد غير مدعوم بتكوين البناء الحالي. حدد مزودًا آخر أو قم بتحديث البرنامج الثابت مع بروتوكول الراديو الصحيح المحدد في تكوين البناء."
+    },
+    "configurationSpiRX": {
+        "message": "مزود مستقبل SPI Bus"
+    },
+    "configurationSaved": {
+        "message": "تم حفظ الإعدادات"
+    },
+    "configurationButtonSave": {
+        "message": "احفظ ثم أعد التشغيل"
+    },
+    "dialogClose": {
+        "message": "إغلاق"
+    },
+    "dialogDynFiltersChangeTitle": {
+        "message": "تغيير قيم Notch الديناميكية"
+    },
+    "dialogDynFiltersChangeNote": {
+        "message": "<span class=\"message-negative\"><b>تحذير: هذا التغيير سيمكّن\/يعطّل فلتر based on RPM، مما يزيد\/يقلل من التأخير\/فعالية الفلتر.<\/b><\/span><br><br>هل تريد إعادة تعيين فلاتر notch الديناميكية إلى القيم الموصى بها؟"
+    },
+    "portsIdentifier": {
+        "message": "المعرف"
+    },
+    "portsConfiguration": {
+        "message": "التكوين\/MSP"
+    },
+    "portsSerialRx": {
+        "message": "مستقبل تسلسلي"
+    },
+    "portsSerialRxHelp": {
+        "message": "تمكين أو تعطيل مستقبل التحكم عن بعد التسلسلي (RX) على UART المحدد. مسموح بواحد فقط."
+    },
+    "portsSensorIn": {
+        "message": "إدخال المستشعر"
+    },
+    "portsTelemetryOut": {
+        "message": "مخرج Telemetry"
+    },
+    "portsPeripherals": {
+        "message": "الأجهزة الطرفية"
+    },
+    "portsHelp": {
+        "message": "<strong>ملاحظة:<\/strong> ليست جميع المجموعات صالحة. عندما يكتشف برنامج وحدة تحكم الطيران هذا، سيتم إعادة تعيين تكوين المنفذ التسلسلي."
+    },
+    "portsVtxTableNotSet": {
+        "message": "<span class=\"message-negative\">تحذير:<\/span> لم يتم إعداد جدول VTX بشكل صحيح وبدونه لن يكون التحكم في VTX ممكنًا. يرجى إعداد جدول VTX في علامة $t(tabVtx.message)."
+    },
+    "portsMSPHelp": {
+        "message": "<strong>ملاحظة:<\/strong> <span class=\"message-negative\">لا<\/span> تعطل MSP على المنفذ التسلسلي الأول إلا إذا كنت تعرف ما تفعله. قد تضطر إلى إعادة برمجة ومسح التكوين الخاص بك إذا قمت بذلك."
+    },
+    "portsReadOnlyHelp": {
+        "message": "<strong>ملاحظة:<\/strong> يعيّن هذا البرنامج الثابت المنافذ التسلسلية لكل ميزة من علامة التبويب الخاصة بها، لذلك فإن هذا العرض للقراءة فقط. يعرض المنفذ الذي تستخدمه كل ميزة حاليًا؛ لتغيير التعيين، انتقل إلى علامة التبويب الخاصة بالميزة.\n"
+    },
+    "portsFirmwareUpgradeRequired": {
+        "message": "تحديث البرنامج الثابت <span class=\"message-negative\">مطلوبة<\/span>. تكوينات المنفذ التسلسلي للبرنامج الثابت بالإصدار &lt; 1.8.0 غير مدعومة."
+    },
+    "portsButtonSave": {
+        "message": "احفظ ثم أعد التشغيل"
+    },
+    "portsTelemetryDisabled": {
+        "message": "معطل"
+    },
+    "portsFunction_MSP": {
+        "message": "MSP"
+    },
+    "portsFunction_GPS": {
+        "message": "نظام تحديد المواقع"
+    },
+    "portsFunction_TELEMETRY_FRSKY": {
+        "message": "FrSky"
+    },
+    "portsFunction_TELEMETRY_HOTT": {
+        "message": "HoTT"
+    },
+    "portsFunction_TELEMETRY_LTM": {
+        "message": "LTM"
+    },
+    "portsFunction_TELEMETRY_MAVLINK": {
+        "message": "MAVLink"
+    },
+    "portsFunction_TELEMETRY_MSP": {
+        "message": "MSP"
+    },
+    "portsFunction_TELEMETRY_SMARTPORT": {
+        "message": "منفذ ذكي"
+    },
+    "portsFunction_TELEMETRY_IBUS": {
+        "message": "iBUS"
+    },
+    "portsFunction_TELEMETRY_JETIXBUS": {
+        "message": "JETIXBUS"
+    },
+    "portsFunction_TELEMETRY_CRSF": {
+        "message": "CRSF"
+    },
+    "portsFunction_TELEMETRY_SRXL": {
+        "message": "SRXL"
+    },
+    "portsFunction_ESC_SENSOR": {
+        "message": "مستشعر متحكم السرعة"
+    },
+    "portsFunction_RX_SERIAL": {
+        "message": "مستقبل تسلسلي"
+    },
+    "portsFunction_BLACKBOX": {
+        "message": "تسجيلات الصندوق الأسود"
+    },
+    "portsFunction_TBS_SMARTAUDIO": {
+        "message": "جهاز الفيديو (TBS SmartAudio)"
+    },
+    "portsFunction_IRC_TRAMP": {
+        "message": "جهاز الفيديو (IRC Tramp)"
+    },
+    "portsFunction_RUNCAM_DEVICE_CONTROL": {
+        "message": "الكاميرا (بروتوكول RunCam)"
+    },
+    "portsFunction_FRSKY_OSD": {
+        "message": "العرض على الشاشة (بروتوكول FrSky)"
+    },
+    "portsFunction_VTX_MSP": {
+        "message": "جهاز الفيديو (MSP + Displayport)"
+    },
+    "portsFunction_GIMBAL": {
+        "message": "مثبّت الكاميرا\n"
+    },
+    "portsFunction_OSD_CUSTOM_TEXT": {
+        "message": "نص مخصص OSD"
+    },
+    "pidTuningProfileOption": {
+        "message": "ملف التعريف 1"
+    },
+    "pidTuningRateProfileOption": {
+        "message": "ملف القيم $1"
+    },
+    "portsFunction_LIDAR_TF": {
+        "message": "رادار ليزري Benewake"
+    },
+    "pidTuningUpgradeFirmwareToChangePidController": {
+        "message": "<span class=\"message-negative\">تم تعطيل تغيير متحكم PID — يمكنك تغييره عبر واجهة CLI.<\/span> لديك برنامج ثابت بإصدار API <span class=\"message-negative\">$1<\/span>، لكن هذه الوظيفة تتطلب الإصدار <span class=\"message-positive\">$2<\/span>."
+    },
+    "pidTuningSubTabPid": {
+        "message": "إعدادات ملف تعريف PID"
+    },
+    "pidTuningSubTabRates": {
+        "message": "إعدادات ملف تعريف Rates"
+    },
+    "pidTuningSubTabFilter": {
+        "message": "إعدادات الفلتر"
+    },
+    "pidProfileName": {
+        "message": "اسم ملف تعريف PID"
+    },
+    "pidProfileNameHelp": {
+        "message": "اسم ملف تعريف PID الذي يمكن أن يصف الظروف التي تم ضبطه لها: بطارية أخف\/أثقل، وجود\/عدم وجود كاميرا فعلية، ارتفاع أعلى، إلخ."
+    },
+    "rateProfileName": {
+        "message": "اسم ملف القيم"
+    },
+    "rateProfileNameHelp": {
+        "message": "اسم ملف القيم الذي يمكن أن يصف نوع الطيران الذي تم إعداده له: التصوير السينمائي، السباق، الطيران الحر، إلخ."
+    },
+    "pidTuningShowAllPids": {
+        "message": "إظهار جميع ملفات التعريف الشخصي"
+    },
+    "pidTuningHideUnusedPids": {
+        "message": "إخفاء قيم PID غير المستخدمة"
+    },
+    "pidTuningNonProfilePidSettings": {
+        "message": "إعدادات وحدة تحكم PID المستقلة عن ملف التعريف"
+    },
+    "pidTuningAntiGravity": {
+        "message": "نمط مقاومة الجاذبية"
+    },
+    "pidTuningAntiGravityMode": {
+        "message": "نمط",
+        "description": "Anti Gravity mode selection parameter"
+    },
+    "pidTuningAntiGravityModeOptionSmooth": {
+        "message": "Smooth",
+        "description": "One of the modes of anti gravity"
+    },
+    "pidTuningAntiGravityModeOptionStep": {
+        "message": "خطوة",
+        "description": "One of the modes of anti gravity"
+    },
+    "pidTuningAntiGravityGain": {
+        "message": "المكسب",
+        "description": "Anti Gravity Gain Parameter"
+    },
+    "pidTuningAntiGravityGainHelp": {
+        "message": "يعزز مصطلح I ويزيد P أثناء تغييرات دفع المحرك السريعة.<br><br>قيمة 8.0 تعني تعزيزًا لمصطلح I بحوالي 8 مرات",
+        "description": "Anti Gravity Gain Parameter Help Icon"
+    },
+    "pidTuningAntiGravityThres": {
+        "message": "العتبة",
+        "description": "Anti Gravity Threshold Parameter"
+    },
+    "pidTuningAntiGravityHelp": {
+        "message": "تعمل ميزة Anti Gravity على تعزيز قيمة I — وفي إصدار 4.3 أيضًا قيمة P — أثناء تغيّرات الدواسة السريعة ولفترة قصيرة بعدها، مما يساعد على زيادة ثبات وضعية الدرون أثناء الرفع والخفض السريع للثروتل.\n\nقد تساعد قيم Gain الأعلى على تحسين الثبات في الدرونات ذات سلطة تحكم منخفضة أو التي يكون فيها مركز الثقل غير متوازن أو مزاح عن المنتصف."
+    },
+    "pidTuningDerivative": {
+        "message": "<b>المشتق (D)<\/b>",
+        "description": "Table header of the Derivative feature in the PIDs tab"
+    },
+    "pidTuningDMaxFeatureTitle": {
+        "message": "إعدادات التخميد الديناميكي \/ D الأعلى",
+        "description": "Title for the options panel for the D Max feature"
+    },
+    "pidTuningDMaxSettingTitle": {
+        "message": "التخميد الديناميكي",
+        "description": "Sidebar title for the options panel for the D Max feature"
+    },
+    "pidTuningDMaxGain": {
+        "message": "المكسب",
+        "description": "Gain of the D Max feature"
+    },
+    "pidTuningDMaxGainHelp": {
+        "message": "يزيد مكسب D Max من حساسية النظام الذي يزيد D عندما تدور الطائرة بسرعة أو تهتز في تيار المروحة.<br><br>تجعل قيم المكسب الأعلى D ترتفع بسهولة أكبر من القيم المنخفضة، مما يرفع D نحو D الأعلى بسرعة أكبر. قد تعمل القيم مثل 40 أو حتى 50 بشكل جيد لتجهيزات الطيران الحر النظيفة.<br><br>لن ترفع القيم المنخفضة D نحو D Max إلا في الحركات السريعة حقًا، وقد تناسب تجهيزات السباق بشكل أفضل عن طريق تقليل تأخر D.<br><br>تحذير: يجب ضبط إما المكسب أو التقدم فوق 20 تقريبًا، وإلا فلن يزيد D كما ينبغي. سيؤدي ضبط كلاهما على الصفر إلى قفل D عند القيمة الأساسية.",
+        "description": "D Max feature helpicon message"
+    },
+    "pidTuningDMaxAdvance": {
+        "message": "متقدم",
+        "description": "Advance of the D Max feature"
+    },
+    "pidTuningDMaxAdvanceHelp": {
+        "message": "تضيف قيمة D Max Advance حساسية إضافية لعامل Gain عندما يتم تحريك عصي التحكم بسرعة.\n\nلا تستجيب قيمة Advance لحركة الجايرو أو لمشكلة Propwash. وهي تتدخل أبكر من عامل Gain، وقد تكون مفيدة أحيانًا للطائرات ذات سلطة التحكم الضعيفة التي تتأخر بشكل ملحوظ عند بداية الحركة.\n\nبشكل عام، يُفضّل تركها على 0.\n\nتحذير: يجب أن تكون إحدى القيمتين Advance أو Gain أعلى من حوالي 20 حتى ترتفع قيمة D بالشكل المطلوب. إذا تم ضبط القيمتين على 0، فستبقى قيمة D ثابتة عند القيمة الأساسية.",
+        "description": "D Max feature helpicon message"
+    },
+    "pidTuningDMaxFeatureHelp": {
+        "message": "تعمل ميزة D Max على زيادة قيمة D أثناء الحركات السريعة للجايرو و\/أو عصي التحكم.\n\nعامل Gain يرفع قيمة D عندما يدور الدرون بسرعة أو عندما يتعرض للاهتزاز الناتج عن Propwash. وفي أغلب الحالات يكون Gain وحده كافيًا.\n\nعامل Advance يرفع قيمة D باتجاه قيمة D Max أثناء إدخالات العصا. غالبًا لا تكون هناك حاجة له، ويُفضّل ضبطه على 0. وقد يكون مفيدًا في الطائرات ذات سلطة التحكم الضعيفة والتي تميل إلى تجاوز الحركة المطلوبة بشكل كبير.\n\nقيم Gain الأعلى، مثل 40، قد تكون أنسب للفريستايل لأنها ترفع قيمة D بشكل أسرع عند الحاجة.\n\nتحذير: يجب أن تكون إحدى القيمتين Gain أو Advance أعلى من حوالي 20 حتى ترتفع قيمة D بالشكل المطلوب. إذا تم ضبط القيمتين على 0، فستبقى قيمة D ثابتة عند القيمة الأساسية.",
+        "description": "D Max feature helpicon message"
+    },
+    "pidTuningPidSettings": {
+        "message": "إعدادات وحدة تحكم PID"
+    },
+    "pidTuningMotorSettings": {
+        "message": "إعدادات دواسة الوقود  والمحرك"
+    },
+    "pidTuningMiscSettings": {
+        "message": "إعدادات متنوعة"
+    },
+    "receiverRcSmoothing": {
+        "message": "تنعيم الإشارة اللاسلكية"
+    },
+    "receiverRcSmoothingAuto": {
+        "message": "تلقائي"
+    },
+    "receiverRcSmoothingManual": {
+        "message": "يدوي"
+    },
+    "receiverRcSmoothingAutoFactor": {
+        "message": "عامل النقطة المحددة التلقائي",
+        "description": "Setpoint Auto Factor parameter for RC smoothing"
+    },
+    "receiverRcSmoothingAutoFactorHelp": {
+        "message": "يضبط عامل الحساب التلقائي للنقطة المحددة، 10 هو عامل نسبة التأخير الافتراضي. ستزيد زيادة الرقم من تنعيم مدخلات الإشارة اللاسلكية، مع إضافة المزيد من التأخير. قد يكون هذا مفيدًا لاتصالات RC غير الموثوقة أو للطيران السينمائي.<br>كن حذرًا مع الأرقام التي تقترب من 50، سيصبح تأخير الإدخال ملحوظًا.<br>استخدم الأمر rc_smoothing_info في واجهة الأوامر النصية بينما جهاز الإرسال والاستقبال قيد التشغيل لرؤية نقاط قطع تنعيم RC المحسوبة تلقائيًا.",
+        "description": "Setpoint Auto Factor parameter help message"
+    },
+    "receiverRcSmoothingAutoFactorHelp2": {
+        "message": "يضبط تنعيم RC للنقطة المحددة. 30 هو الإعداد الافتراضي. تقوم القيم الأعلى بتنعيم مدخلات RC أكثر - على سبيل المثال 60 للطيران الحر عالي الدقة أو 90-120 للطيران السينمائي. ملاحظة: ستتسبب القيم التي تزيد عن 50 في تأخير ملحوظ للعصا. ستقوم القيم الأقل، مثل 20-25، بنقل بعض خطوات تحكم RC إلى إشارات المحرك، مما يزيد من حرارة المحرك قليلاً، لكنه سيقلل من تأخير RC قليلاً. قد يكون هذا مفيدًا للسباق.",
+        "description": "Setpoint Auto Factor parameter help message"
+    },
+    "receiverRcSmoothingAutoFactorThrottle": {
+        "message": "عامل دواسة الوقود التلقائي",
+        "description": "Throttle Auto Factor parameter for RC smoothing"
+    },
+    "receiverRcSmoothingAutoFactorThrottleHelp": {
+        "message": "يضبط عامل حساب دواسة الوقود ، 10 هو عامل نسبة التأخير الافتراضي. ستزيد زيادة الرقم من تنعيم مدخلات دواسة الوقود ، مع إضافة المزيد من التأخير. قد يكون هذا مفيدًا لاتصالات RC غير الموثوقة أو للطيران السينمائي.<br>كن حذرًا مع الأرقام التي تقترب من 50، سيصبح تأخير الإدخال ملحوظًا.<br>استخدم الأمر rc_smoothing_info في واجهة الأوامر النصية بينما جهاز الإرسال والاستقبال قيد التشغيل لرؤية نقاط قطع تنعيم RC المحسوبة تلقائيًا.",
+        "description": "Throttle Auto Factor parameter help message"
+    },
+    "receiverRcFeedforwardTypeSelect": {
+        "message": "نوع فلتر قطع الـ Feedforward"
+    },
+    "receiverRcSetpointTypeSelect": {
+        "message": "نوع فلتر قطع الـ Setpoint"
+    },
+    "receiverThrottleTypeSelect": {
+        "message": "نوع قطع دواسة الوقود"
+    },
+    "receiverRcSmoothingInterpolation": {
+        "message": "الاستيفاء"
+    },
+    "receiverRcSmoothingFilter": {
+        "message": "الفلتر"
+    },
+    "rcSmoothingSetpointCutoffHelp": {
+        "message": "تردد القطع بالهرتز المستخدم بواسطة فلتر Setpoint. سيؤدي استخدام قيم أقل إلى مدخلات أكثر سلاسة وهي أكثر ملاءمة لبروتوكولات المستقبل الأبطأ. يجب على معظم المستخدمين ترك هذا عند 0 بما يتوافق مع \"تلقائي\"."
+    },
+    "rcSmoothingFeedforwardCutoffHelp": {
+        "message": "تردد القطع بالهرتز المستخدم بواسطة فلتر Feedforward. سيؤدي استخدام قيم أقل إلى مدخلات أكثر سلاسة وهي أكثر ملاءمة لبروتوكولات المستقبل الأبطأ. يجب على معظم المستخدمين ترك هذا عند 0 بما يتوافق مع \"تلقائي\"."
+    },
+    "rcSmoothingChannelsSmoothedHelp": {
+        "message": "القنوات التي ينطبق عليها التنعيم"
+    },
+    "receiverRcSmoothingSetpointManual": {
+        "message": "يحدد ما إذا كان سيتم حساب تردد قطع فلتر Setpoint تلقائيًا (موصى به) أو تحديده يدويًا من قبل المستخدم. لا يُوصى باستخدام \"يدوي\" لبروتوكولات المستقبل مثل Crossfire التي يمكن أن تتغير أثناء الطيران."
+    },
+    "receiverRcSmoothingFeedforwardManual": {
+        "message": "يحدد ما إذا كان سيتم حساب تردد قطع فلتر Feedforward  تلقائيًا (موصى به) أو تحديده يدويًا من قبل المستخدم. لا يُوصى باستخدام \"يدوي\" لبروتوكولات المستقبل مثل Crossfire التي يمكن أن تتغير أثناء الطيران."
+    },
+    "receiverRcSmoothingThrottleManual": {
+        "message": "يحدد ما إذا كان سيتم حساب تنعيم RC تلقائيًا (موصى به) أو تحديده يدويًا من قبل المستخدم. لا يُوصى باستخدام \"يدوي\" لبروتوكولات المستقبل مثل Crossfire التي يمكن أن تتغير أثناء الطيران."
+    },
+    "rcSmoothingThrottleCutoffHelp": {
+        "message": "تردد القطع بالهرتز المستخدم بواسطة فلتر تنعيم دواسة الوقود . سيؤدي استخدام قيم أقل إلى مدخلات أكثر سلاسة وهي أكثر ملاءمة لبروتوكولات المستقبل الأبطأ. يجب على معظم المستخدمين ترك هذا عند 0 بما يتوافق مع \"تلقائي\"."
+    },
+    "receiverRcSmoothingSetpointHz": {
+        "message": "تردد قطع Setpoint"
+    },
+    "receiverRcSmoothingThrottleCutoffHz": {
+        "message": "تردد قطع دواسة الوقود"
+    },
+    "receiverRcSmoothingFeedforwardCutoff": {
+        "message": "تردد قطع Feedforward"
+    },
+    "receiverRcFeedforwardType": {
+        "message": "نوع فلتر Feedforward"
+    },
+    "receiverRcSmoothingFeedforwardTypeAuto": {
+        "message": "Auto"
+    },
+    "pidTuningDtermSetpointTransition": {
+        "message": "انتقال Setpoint  للمشتق D"
+    },
+    "pidTuningDtermSetpoint": {
+        "message": "وزن Setpoint للمشتق D"
+    },
+    "pidTuningDtermSetpointTransitionHelp": {
+        "message": "باستخدام هذا الإعداد، يمكن تقليل وزن نقطة الضبط لـ D بالقرب من منتصف العصي، مما يجعل نهاية حركات Flip وRoll أكثر سلاسة.\n\nتمثل القيمة مقدار انحراف العصا:\n\n0 = العصا في المنتصف.\n1 = أقصى انحراف للعصا.\n\nعندما تتجاوز العصا النقطة المحددة، يبقى D Setpoint Weight عند قيمته المضبوطة. وعندما تكون أسفلها، ينخفض تدريجيًا حتى يصل إلى 0 عند منتصف العصا.\n\nالقيمة 1: أقصى تأثير للتنعيم.\nالقيمة 0: يبقى الوزن ثابتًا في كامل نطاق العصا دون تقليل."
+    },
+    "pidTuningDtermSetpointHelp": {
+        "message": "يحدد هذا المعامل تأثير تسارع العصا ضمن المكون التفاضلي.<br>القيمة 0 هي طريقة القياس القديمة حيث يتابع D الجيروسكوب فقط. القيمة 1 هي طريقة الخطأ القديمة، التي تستخدم نسبة متابعة متساوية للجيروسكوب والعصا.<br>القيم الأقل تمنح استجابة عصا أبطأ وأكثر سلاسة، بينما القيم الأعلى توفر استجابة أسرع لتسارع العصا.<br>لاحظ أنه يُوصى باستخدام استيفاء RC عند استخدام قيم أعلى لتجنب حدوث صدمات تحكم تسبب ضوضاء."
+    },
+    "pidTuningDtermSetpointTransitionWarning": {
+        "message": "<span class=\"message-negative\"><strong>$t(warningTitle.message):<\/strong> لا يُوصى بشدة باستخدام انتقال Setpoint  للمشتق D أكبر من 0 وأقل من 0.1. قد يؤدي القيام بذلك إلى عدم الاستقرار وتقليل استجابة العصا أثناء عبور العصا لنقطة المركز.<\/span>"
+    },
+    "pidTuningFeedforwardGroup": {
+        "message": ""
+    },
+    "pidTuningFeedforwardGroupHelp": {
+        "message": "تضبط Feedforward استجابة العصا.<br \/><br \/> تتيح لك هذه الخيارات ضبطها لتوفير أي شيء من استجابات عصا حادة وفورية للسباق، أو استجابات ناعمة وسلسة لأغراض التصوير السينمائي \/ عالي الدقة."
+    },
+    "pidTuningFeedforwardJitter": {
+        "message": "تقليل الاهتزاز"
+    },
+    "pidTuningFeedforwardJitterHelp": {
+        "message": "يقلل تقليل الاهتزاز من Feedforward عندما تتحرك العصي ببطء، بغض النظر عن موضعها.<br><br>يسمح هذا بطيران سلس وخالٍ من الاهتزاز عند عمل منحنيات بطيئة وسلسة، مع توفير Feedforward كامل دون أي تأخير عندما تتحرك العصي بسرعة. لا يلزم الانتقال، ويجب ضبطه على صفر، عندما يكون تقليل الاهتزاز نشطًا.<br><br>الافتراضي هو 7. القيم الأعلى، مثل 10-12، جيدة لأغراض التصوير السينمائي أو الطيران الحر عالي الدقة، 5 قد يكون أفضل للسباق مع روابط RC سريعة."
+    },
+    "pidTuningFeedforwardSmoothFactor": {
+        "message": "النعومة"
+    },
+    "pidTuningFeedforwardSmoothnessHelp": {
+        "message": "يُعد تنعيم الـFeedforward ضروريًا لتقليل التشويش في منحنى الـFeedforward.\n\nالأفضل استخدام أقل قيمة تمنحك منحنى سلسًا:\n\nروابط 50–150Hz: القيمة الافتراضية 25 مناسبة.\nروابط 250Hz: استخدم 40–50.\nروابط 500Hz: استخدم 60–65."
+    },
+    "pidTuningFeedforwardAveraging": {
+        "message": "المتوسط"
+    },
+    "pidTuningFeedforwardAveragingHelp": {
+        "message": "يأخذ متوسط Feedforward متوسط آخر خطوتين أو ثلاث خطوات Feedforward. يؤدي هذا إلى تنعيم أثر Feedforward، لكنه يضيف بعض التأخير.<br><br>يكون أكثر فعالية عندما يكون هناك اهتزاز متتابع لأعلى\/لأسفل في الإشارة، وهو شائع مع روابط RC الأسرع.<br><br>يلزم حساب متوسط بنقطتين لروابط 500 هرتز وروابط 250 هرتز ذات الضوضاء، أو للطيران السينمائي \/ عالي الدقة. يحتاج Crossfire (قبل CRSFShot) إلى متوسط بثلاث نقاط في وضع 150 هرتز."
+    },
+    "pidTuningOptionOff": {
+        "message": "إيقاف"
+    },
+    "pidTuningOptionOn": {
+        "message": "تشغيل"
+    },
+    "pidTuningFeedforwardAveragingOption2Point": {
+        "message": "نقطتان"
+    },
+    "pidTuningFeedforwardAveragingOption3Point": {
+        "message": "3 نقاط"
+    },
+    "pidTuningFeedforwardAveragingOption4Point": {
+        "message": "4 نقاط"
+    },
+    "pidTuningFeedforwardBoost": {
+        "message": "الدفع"
+    },
+    "pidTuningFeedforwardBoostHelp": {
+        "message": "يضيف دفع اFeedforward دفعة إضافية استجابة لتسارع أو تباطؤ العصا.<br><br>يقلل هذا من تأخر الجيروسكوب الناتج عن تأخير تسارع المحرك، ويقلل من تجاوز الهدف عندما تتباطأ العصي عن طريق سحب المحركات بقوة للخلف.<br><br>يعمل الدفع الافتراضي لمعظم التجهيزات. قد يفضل طيارون السباق زيادته قليلاً. يمكن ضبط الدفع بدقة عن طريق تحليل السجلات بعناية."
+    },
+    "pidTuningFeedforwardMaxRateLimit": {
+        "message": "الحد الأقصى لمعدل الدفع"
+    },
+    "pidTuningFeedforwardMaxRateLimitHelp": {
+        "message": "يقطع Feedforward عندما تتحرك العصي نحو أقصى انحراف، لتقليل تجاوز الهدف في بداية الشقلبة أو الدوران.<br><br>لا يفعل شيئًا في نهاية الشقلبة أو الدوران. تجعل القيم الأقل التخفيض يبدأ في وقت أبكر.<br><br>عادة لا تتطلب هذه القيمة التعديل. أفضل قيمة هي أعلى قيمة متوافقة مع تجاوز الهدف المقبول في بداية الدورانات أو الشقلبات."
+    },
+    "pidTuningFeedforwardTransition": {
+        "message": "الانتقال"
+    },
+    "pidTuningFeedforwardTransitionHelp": {
+        "message": "يقلل Feedforward خطيًا عندما تكون العصي قريبة من المركز. <br><br>في الإصدار 4.2 وأقدم، يمكن استخدام الانتقال لتوفير استجابات عصا أكثر سلاسة حول موضع مركز العصا.<br><br>في الإصدار 4.3، لا يُوصى باستخدام الانتقال، حيث تم 'استبداله' بوظيفة تقليل الاهتزاز.<br><br>تعطل القيمة 0 الانتقال. تقطع القيمة 0.3 Feedforward إلى الصفر عندما تكون العصي في المركز تماما، لكنها تزيد إلى المستوى الطبيعي الكامل عندما تكون العصي >30% خارج المركز."
+    },
+    "pidTuningProportional": {
+        "message": "<b>النسبي (P)<\/b>"
+    },
+    "pidTuningProportionalHelp": {
+        "message": "مدى تتبع الجهاز للعصي (Setpoint) بإحكام.<br \/><br \/>توفر القيمة (المكاسب) الأعلى تتبعًا أكثر إحكامًا، ولكن يمكن أن تسبب تجاوزًا للهدف إذا كانت مرتفعة جدًا بالنسبة إلى D، ويمكن أن تسبب تذبذبات في المنعطفات ذات دفع المحرك العالي. فكر في P على أنه الزنبرك في السيارة.",
+        "description": "Proportional Term helpicon message on PID table titlebar"
+    },
+    "pidTuningIntegral": {
+        "message": "<b>التكاملي (I)<\/b>"
+    },
+    "pidTuningIntegralHelp": {
+        "message": "يتحكم I Gain في الانحرافات الصغيرة والمستمرة.\n\nيشبه P، لكنه يتراكم تدريجيًا وببطء حتى يصبح الخطأ صفرًا. وهو مهم لتعويض المؤثرات المستمرة مثل:\n\nعدم تمركز مركز الثقل.\nالرياح المستمرة.\nأي قوة خارجية تدفع الدرون بعيدًا عن المسار المطلوب.\n\nرفع I Gain يحسّن ثبات الدرون وتتبع الأوامر، خصوصًا أثناء المنعطفات، لكن زيادته قد تجعل الطيران قاسيًا وتسبب اهتزازات بطيئة، خاصةً إذا كانت قيمة I مرتفعة مقارنةً بـ P أو كانت استجابة الدرون ضعيفة.",
+        "description": "Integral Term helpicon message on PID table titlebar"
+    },
+    "pidTuningDMax": {
+        "message": "<b>D الأعلى<\/b>"
+    },
+    "pidTuningDMaxHelp": {
+        "message": "يوفر D Max تخميدًا أقوى أثناء المناورات السريعة التي قد تسبب تجاوز الحركة المطلوبة Overshoot.\n\nيسمح باستخدام قيمة D Min أساسية أقل من المعتاد، مما يساعد على:\n\nإبقاء المحركات أبرد.\nجعل دخول الدرون في المنعطف أسرع.\nرفع D تلقائيًا عند الحاجة لمنع التجاوز في الـ Flip أو عند عكس الاتجاه بسرعة.\n\nيكون أكثر فائدة لدرونات السباق، والدرونات كثيرة الاهتزازات، أو التي تمتلك استجابة ضعيفة للمحركات والمراوح.",
+        "description": "D Max Term helpicon message on PID table titlebar"
+    },
+    "pidTuningDerivativeHelp": {
+        "message": "يتحكم D-Term في قوة تخميد أي حركة تؤثر في الدرون:\n\nعند تحريك العصا: يخفف اندفاع الأمر ويمنع التجاوز.\nعند وجود مؤثر خارجي مثل Propwash أو هبة رياح: يخفف تأثير الاضطراب.\n\nرفع D Gain يزيد التخميد ويقلل تجاوز الحركة الناتج عن P-Term وFeedforward.\n\nلكن D-Term شديد الحساسية لاهتزازات الجايرو عالية التردد، وقد يضخم الضوضاء بمقدار 10 إلى 100 مرة. وإذا كانت قيمته مرتفعة أو الفلاتر غير كافية، فقد ترتفع حرارة المحركات أو تحترق.\n\nيمكن تشبيه D-Term بممتص الصدمات في السيارة، لكن عيبه أنه يضخم ضوضاء الجايرو عالية التردد.",
+        "description": "Derivative Term helpicon message on PID table titlebar"
+    },
+    "pidTuningFeedforward": {
+        "message": "<b>F<\/b>Feedforward"
+    },
+    "pidTuningFeedforwardHelp": {
+        "message": "يُعد Feedforward عامل دفع إضافيًا يعتمد بالكامل على حركة العصا، ويساعد الدرون على الدخول بسرعة في الحركات السريعة.\n\nلا يسبب Feedforward اهتزازات مستمرة من تلقاء نفسه.\nيسمح باستخدام P أقل مع الحفاظ على استجابة مشابهة للعصا.\nيعوّض مقاومة D-Term الطبيعية لحركات العصا.\n\nالقيم المنخفضة أو 0 تعطي استجابة أكثر سلاسة، لكنها أبطأ وأكثر تأخرًا عن حركة العصا.",
+        "description": "Feedforward Term helpicon message on PID table titlebar"
+    },
+    "pidTuningMaxRateWarning": {
+        "message": "<span class=\"message-negative\"><b>تحذير:<\/b><\/span> يمكن أن تؤدي المعدلات العالية جدًا إلى فقدان المزامنة من التباطؤ السريع."
+    },
+    "pidTuningRcRate": {
+        "message": "معدل الإشارة اللاسلكية"
+    },
+    "pidTuningMaxVel": {
+        "message": "السرعة القصوى [درجة\/ثانية]"
+    },
+    "pidTuningRate": {
+        "message": "المعدل"
+    },
+    "pidTuningSuperRate": {
+        "message": "المعدل الفائق"
+    },
+    "pidTuningRatesPreview": {
+        "message": "معاينة المعدلات"
+    },
+    "pidTuningRatesModelPreview": {
+        "message": "معاينة نموذج Rates"
+    },
+    "pidTuningRatesTuningHelp": {
+        "message": "المعدلات وExpo: تحدد إحساس واستجابة العصا بناءً على هذه الإعدادات. استخدم الرسم البياني ونموذج الدرون ثلاثي الأبعاد المباشر للوصول إلى إعدادات Rates المناسبة لك."
+    },
+    "pidTuningRcExpo": {
+        "message": "المنحنى الأُسّي للعصا (RC Expo)"
+    },
+    "pidTuningTpaGroup": {
+        "message": "TPA"
+    },
+    "pidTuningTPAMode": {
+        "message": "وضع TPA"
+    },
+    "pidTuningTPA": {
+        "message": "TPA"
+    },
+    "pidTuningTPARate": {
+        "message": "معدل TPA (%)"
+    },
+    "pidTuningTPABreakPoint": {
+        "message": "نقطة توقف TPA (μs)"
+    },
+    "pidTuningTPAPD": {
+        "message": "PD"
+    },
+    "pidTuningTPAD": {
+        "message": "D"
+    },
+    "pidTuningThrottleCurvePreview": {
+        "message": "معاينة منحنى دواسة الوقود"
+    },
+    "pidTuningThrottleLimitType": {
+        "message": "حد دواسة الوقود"
+    },
+    "pidTuningThrottleLimitPercent": {
+        "message": "نسبة حد دواسة الوقود %"
+    },
+    "pidTuningThrottleLimitTypeOff": {
+        "message": "إيقاف"
+    },
+    "pidTuningThrottleLimitTypeScale": {
+        "message": "قياس"
+    },
+    "pidTuningThrottleLimitTypeClip": {
+        "message": "قص"
+    },
+    "pidTuningThrottleLimitTypeTip": {
+        "message": "حدّد نوع تقييد دواسة الوقود . يعمل الخيار <b>OFF<\/b> على تعطيل هذه الميزة، بينما يعيد الخيار <b>SCALE<\/b> توزيع نطاق دواسة الوقود من 0 إلى النسبة المحددة على كامل حركة العصا، ويضع الخيار <b>CLIP<\/b> حدًا أقصى دواسة الوقود، بحيث لا يكون لحركة العصا فوق هذا الحد أي تأثير إضافي."
+    },
+    "pidTuningThrottleLimitPercentTip": {
+        "message": "اضبط نسبة حد دواسة الوقود المطلوبة. سيؤدي الضبط على 100% إلى تعطيل الميزة."
+    },
+    "pidTuningFilter": {
+        "message": "الفلتر"
+    },
+    "pidTuningFilterFrequency": {
+        "message": "التردد"
+    },
+    "pidTuningRatesCurve": {
+        "message": "معاينة المعدلات"
+    },
+    "throttle": {
+        "message": "دواسة الوقود"
+    },
+    "pidTuningButtonSave": {
+        "message": "حفظ"
+    },
+    "pidTuningButtonRefresh": {
+        "message": "تحديث"
+    },
+    "pidTuningProfileHead": {
+        "message": "ملف التعريف"
+    },
+    "pidTuningControllerHead": {
+        "message": "وحدة تحكم PID"
+    },
+    "pidTuningCopyProfile": {
+        "message": "نسخ ملف التعريف"
+    },
+    "pidTuningCopyRateProfile": {
+        "message": "نسخ ملف القيم"
+    },
+    "dialogCopyProfileText": {
+        "message": "نسخ القيم من ملف التعريف الحالي إلى"
+    },
+    "dialogCopyRateProfileText": {
+        "message": "نسخ القيم من ملف القيم الحالي إلى"
+    },
+    "dialogCopyProfileTitle": {
+        "message": "نسخ قيم ملف التعريف"
+    },
+    "dialogCopyProfileNote": {
+        "message": "سيتم مسح القيم المجمعة في ملف تعريف الهدف والكتابة فوقها."
+    },
+    "dialogCopyProfileConfirm": {
+        "message": "نسخ"
+    },
+    "dialogCopyProfileClose": {
+        "message": "إلغاء"
+    },
+    "pidTuningResetPidProfile": {
+        "message": "إعادة تعيين ملف التعريف هذا"
+    },
+    "pidTuningPidProfileReset": {
+        "message": "تم تحميل القيم الافتراضية لملف تعريف PID الحالي."
+    },
+    "pidTuningReceivedProfile": {
+        "message": "ضبط متحكم الطيران لملف التعريف: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningReceivedRateProfile": {
+        "message": "ضبط متحكم الطيران لملف القيم: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningLoadedProfile": {
+        "message": "تم تحميل ملف التعريف: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningLoadedRateProfile": {
+        "message": "تم تحميل ملف القيم: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningDataRefreshed": {
+        "message": "PID data <strong>refreshed<\/strong>"
+    },
+    "tuningHelp": {
+        "message": "<b>نصائح الضبط<\/b><br \/><span class=\"message-negative\">مهم:<\/span> من الضروري التحقق من درجات حرارة المحركات خلال الرحلات الأولى. كلما ارتفعت قيمة الفلتر، قد يتحسن أداء الطيران، لكن ذلك يسمح أيضًا بوصول مزيد من الضوضاء إلى المحركات. <br>تُعدّ القيمة الافتراضية البالغة 100 هرتز مثالية، ولكن في التجميعات الأكثر ضوضاءً، يمكنك تجربة خفض فلتر D-term إلى 50 هرتز، وربما خفض فلتر الجيروسكوب أيضًا."
+    },
+    "tuningHelpSliders": {
+        "message": "استخدم أشرطة التمرير لضبط الفلاتر. يجب تعطيل أشرطة التمرير لإجراء التغييرات يدويًا.<br>يؤدي تحريك أشرطة التمرير إلى اليمين إلى رفع قيم تردد القطع، وقد يحسّن معالجة الـ Propwash، لكنه يسمح بمرور مزيد من الضوضاء إلى المحركات، مما يرفع حرارتها.<br>ستعمل معظم التجميعات النظيفة التي تستخدم فلترة RPM بشكل جيد عند وضع شريط تمرير مرشح الترددات المنخفضة للجيروسكوب في أقصى اليمين، أو عند تفعيل مرشح الترددات المنخفضة الثاني فقط ووضع أشرطة التمرير في المنتصف.<br><strong>تحذير:<\/strong> توخَّ الحذر الشديد عند تحريك أشرطة تمرير D إلى اليمين! تحقّق من درجة حرارة المحركات بعد كل تغيير!<br><strong>ملاحظة:<\/strong> سيؤدي تغيير ملفات التعريف إلى تغيير إعدادات فلتر D-term فقط. إعدادات فلتر الجيروسكوب واحدة لجميع ملفات التعريف.\n",
+        "description": "Filter tuning subtab note"
+    },
+    "filterWarning": {
+        "message": "<span class=\"message-negative\"><b>تحذير:<\/b><\/span> مستوى الفلترة المستخدم منخفض بشكل خطير. من المحتمل أن يجعل ذلك الطائرة صعبة التحكم، وقد يؤدي إلى طيران غير منضبط. يُوصى بشدة بأن <b>تفعّل واحدًا على الأقل من فلتر الترددات المنخفضة الديناميكي للجيروسكوب أو فلتر الترددات المنخفضة الأول للجيروسكوب، وواحدًا على الأقل من فلتر الترددات المنخفضة الديناميكي لـ D-term أو فلتر الترددات المنخفضة الأول لـ D-term<\/b>."
+    },
+    "pidTuningSliders": {
+        "message": "أشرطة ضبط PID"
+    },
+    "pidTuningSliderPidsMode": {
+        "message": "الوضع:",
+        "description": "Pidtuning slider mode can be OFF, RP or RPY"
+    },
+    "pidTuningSliderModeHelp": {
+        "message": "<strong>وضع أشرطة تمرير ضبط PID<\/strong><br><br>يمكن أن يكون وضع أشرطة تمرير ضبط PID كالتالي:<br><br>• OFF - بدون أشرطة تمرير، أدخل القيم يدويًا<br>• RP - تتحكم أشرطة التمرير في الالتفاف والميلان فقط، وأدخل قيم الانعراج يدويًا<br>• RPY - تتحكم أشرطة التمرير في جميع قيم PID<br><br><span class=\"message-negative\"><b>تحذير:<\/b><\/span> سيؤدي الانتقال من وضع RP إلى وضع RPY إلى استبدال إعدادات الانعراج بإعدادات البرنامج الثابت.\n"
+    },
+    "receiverHelpModelId": {
+        "message": "إذا ضبطت خيار مطابقة النموذج أدناه على رقم غير 255، فيمكنك تحديد رقم جهاز الاستقبال في صفحة إعداد النموذج في OpenTX\/EdgeTX، ثم تفعيل مطابقة النموذج من برنامج ELRS LUA النصي لهذا النموذج. تتراوح قيمة مطابقة النموذج من 0 إلى 63 شاملًا.<br \/>راجع وثائق ELRS لمزيد من المعلومات.\n"
+    },
+    "receiverModelId": {
+        "message": "معرف مطابقة النموذج"
+    },
+    "receiverHelp": {
+        "message": "&#8226; <b><strong><a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Failsafe#testing-failsafe\" target=\"_blank\" rel=\"noopener noreferrer\">تأكد دائمًا من أن Failsafe يعمل بشكل صحيح!<\/a><\/strong><\/b> توجد الإعدادات في علامة Failsafe، والذي يتطلب Expert Mode.<br>\n&#8226; <b>استخدم أحدث إصدار من Firmware لجهاز الإرسال Tx!<\/b><br>\n&#8226; <strong><a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Rx#disabling-the-opentx-edgetx-adc-filter\" target=\"_blank\" rel=\"noopener noreferrer\">عطّل Hardware ADC Filter<\/a><\/strong> في جهاز الإرسال إذا كنت تستخدم OpenTX أو EdgeTX.<br>\nBasic Setup: اضبط إعدادات 'Receiver' بشكل صحيح. اختر 'Channel Map' المناسب لجهاز الإرسال. تأكد من أن أشرطة Roll وPitch وبقية الأشرطة تتحرك بشكل صحيح. اضبط نقاط نهاية القنوات أو قيم النطاق في جهاز الإرسال إلى حوالي 1000 إلى 2000، واضبط نقطة المنتصف على 1500. لمزيد من المعلومات، راجع <strong><a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Rx\" target=\"_blank\" rel=\"noopener noreferrer\">الوثائق<\/a><\/strong>."
+    },
+    "receiverFailsafeActiveTitle": {
+        "message": "نظام الامان نشط"
+    },
+    "receiverFailsafeActiveWarning": {
+        "message": "متحكم الطيران في وضع Failsafe. قيم القنوات المعروضة أدناه هي خرج Failsafe وليست القيم المباشرة القادمة من Receiver. تحقق من رابط Receiver وإعدادات Failsafe."
+    },
+    "receiverThrottleMid": {
+        "message": "منتصف دواسة الوقود"
+    },
+    "receiverThrottleExpo": {
+        "message": "المنحنى الأُسّي لدواسة الوقود"
+    },
+    "receiverThrottleHover": {
+        "message": "نقطة التحويم"
+    },
+    "receiverStickRange": {
+        "message": "نطاق عصا التحكم"
+    },
+    "receiverStickMin": {
+        "message": "عتبة 'أدنى قيمة للعصا'"
+    },
+    "receiverHelpStickMin": {
+        "message": "أقصى قيمة للعصا (بالميكروثانية) ليتم التعرّف عليها كمنخفضة \/ إلى اليسار عند إدخال الأوامر (MIN_CHECK)."
+    },
+    "receiverStickCenter": {
+        "message": "مركز العصا"
+    },
+    "receiverHelpStickCenter": {
+        "message": "القيمة (بالميكروثانية) المستخدمة لتحديد ما إذا كانت العصا في المركز."
+    },
+    "receiverStickMax": {
+        "message": "عتبة 'العصا المرتفعة'\n"
+    },
+    "receiverHelpStickMax": {
+        "message": "أدنى قيمة (بالميكروثانية) لكي يتم التعرف على العصا على أنها مرتفعة \/ يمينية لإدخال الأمر."
+    },
+    "receiverDeadband": {
+        "message": "النطاق الميت للمتحكم عن بعد"
+    },
+    "receiverHelpDeadband": {
+        "message": "هذه هي القيم (بالميكروثانية) التي يمكن أن يختلف بها إدخال RC قبل اعتباره صالحًا. لأجهزة الإرسال ذات الاهتزاز على المخرجات، يمكن زيادة هذه القيمة إذا كانت مدخلات RC تنتفض أثناء الخمول."
+    },
+    "receiverYawDeadband": {
+        "message": "النطاق الميت للـ YAW"
+    },
+    "receiverHelpYawDeadband": {
+        "message": "هذه هي القيم (بالميكروثانية) التي يمكن أن يختلف بها إدخال RC قبل اعتباره صالحًا. لأجهزة الإرسال ذات الاهتزاز على المخرجات، يمكن زيادة هذه القيمة إذا كانت مدخلات RC تنتفض أثناء الخمول. <strong>هذا الإعداد للـ YAW فقط.<\/strong>"
+    },
+    "recevier3dDeadbandThrottle": {
+        "message": "النطاق الميت لدواسة الوقود بنظام ثلاثي الأبعاد"
+    },
+    "receiverHelp3dDeadbandThrottle": {
+        "message": "هذه هي القيم (بالميكروثانية). لتوسيع المنطقة المحايدة، قم بزيادة القيمة. <strong>هذا الإعداد لدواسة الوقود بنظام ثلاثي الابعاد فقط.<\/strong>"
+    },
+    "receiverChannelMap": {
+        "message": "خريطة القناة"
+    },
+    "receiverChannelDefaultOption": {
+        "message": "افتراضي"
+    },
+    "receiverChannelMapTitle": {
+        "message": "يمكنك تحديد خريطة القنوات المخصصة الخاصة بك بالنقر داخل المربع"
+    },
+    "receiverRssiChannel": {
+        "message": "قناة قوة إشارة المستقبل"
+    },
+    "receiverRssiChannelDisabledOption": {
+        "message": "معطل"
+    },
+    "receiverRefreshRateTitle": {
+        "message": "معدل تحديث الرسم البياني"
+    },
+    "receiverResetRefreshRate": {
+        "message": "إعادة تعيين"
+    },
+    "receiverResetRefreshRateTitle": {
+        "message": "إعادة تعيين معدل التحديث"
+    },
+    "receiverRowContainerRoll": {
+        "message": "ROLL [A]:",
+        "description": "Roll label in signal graph"
+    },
+    "receiverRowContainerPitch": {
+        "message": "PITCH [E]:",
+        "description": "Pitch label in signal graph"
+    },
+    "receiverRowContainerYaw": {
+        "message": "YAW [R]:",
+        "description": "Yaw label in signal graph"
+    },
+    "receiverRowContainerThrottle": {
+        "message": "دفع المحرك [T]:",
+        "description": "Throttle label in signal graph"
+    },
+    "receiverButtonSave": {
+        "message": "حفظ"
+    },
+    "receiverButtonRefresh": {
+        "message": "تحديث"
+    },
+    "receiverButtonBind": {
+        "message": "ربط المستقبل"
+    },
+    "receiverButtonBindMessage": {
+        "message": "تم إرسال طلب الربط إلى متحكم الطيران."
+    },
+    "receiverButtonBindingPhrase": {
+        "message": "عبارة الربط"
+    },
+    "receiverButtonSticks": {
+        "message": "محاكي الراديو",
+        "description": "Button that opens a window with a radio emulator on the receiver tab. Actually only enabled for MSP protocol"
+    },
+    "receiverDataRefreshed": {
+        "message": "تم <strong>تحديث<\/strong> بيانات ضبط RC"
+    },
+    "receiverModelPreview": {
+        "message": "المعاينة"
+    },
+    "receiverMspWarningText": {
+        "message": "تتيح أذرع التحكم هذه تشغيل Betaflight واختباره دون وجود جهاز إرسال أو جهاز استقبال. ومع ذلك، <strong>هذه الميزة غير مخصصة للطيران، ويجب عدم تركيب المراوح.<\/strong><br \/><br \/>لا تضمن هذه الميزة تحكمًا موثوقًا بطائرتك. <strong>من المرجح حدوث إصابة خطيرة إذا تُركت المراوح مركبة.<\/strong>"
+    },
+    "receiverMspEnableButton": {
+        "message": "تمكين عناصر التحكم"
+    },
+    "auxiliaryHelp": {
+        "message": "اضبط الأوضاع هنا باستخدام مجموعة من النطاقات و\/أو الروابط إلى أوضاع أخرى (الروابط مدعومة في BF 4.0 والإصدارات الأحدث). استخدم <strong>النطاقات<\/strong> لتحديد مفاتيح جهاز الإرسال وتعيينات الأوضاع المقابلة لها. سيُفعّل الوضع عندما تكون قراءة قناة جهاز الاستقبال بين الحدين الأدنى والأقصى للنطاق. استخدم <strong>رابطًا<\/strong> لتفعيل وضع عند تفعيل وضع آخر. <strong>الاستثناءات:<\/strong> لا يمكن ربط وضع ARM بوضع آخر أو ربط وضع آخر به، كما لا يمكن ربط الأوضاع بأوضاع أخرى تم إعدادها باستخدام رابط (الروابط المتسلسلة). يمكن استخدام عدة نطاقات\/روابط لتفعيل أي وضع. إذا تم تحديد أكثر من نطاق\/رابط لوضع ما، فيمكن ضبط كل منها على <strong>AND<\/strong> أو <strong>OR<\/strong>. سيتم تفعيل الوضع عندما:<br \/>- تكون جميع النطاقات\/الروابط المضبوطة على <strong>AND<\/strong> نشطة؛ أو<br \/>- يكون نطاق\/رابط واحد على الأقل من المضبوطة على <strong>OR<\/strong> نشطًا.<br \/><br \/>تذكّر حفظ إعداداتك باستخدام زر الحفظ.\n"
+    },
+    "auxiliaryToggleUnused": {
+        "message": "إخفاء الأوضاع غير المستخدمة"
+    },
+    "auxiliaryMin": {
+        "message": "الحد الأدنى"
+    },
+    "auxiliaryMax": {
+        "message": "الحد الأقصى"
+    },
+    "auxiliaryDisabled": {
+        "message": "(معطل)",
+        "description": "Text to add to the ARM mode (maybe others in the future) in the MODES TAB when it has been disabled for some external reason"
+    },
+    "auxiliaryAddRange": {
+        "message": "إضافة نطاق"
+    },
+    "auxiliaryAddLink": {
+        "message": "إضافة رابط"
+    },
+    "auxiliaryButtonSave": {
+        "message": "حفظ"
+    },
+    "auxiliaryAutoChannelSelect": {
+        "message": "تلقائي"
+    },
+    "auxiliaryLinkNone": {
+        "message": "لا شيء"
+    },
+    "auxiliaryModeLogicOR": {
+        "message": "OR"
+    },
+    "auxiliaryModeLogicAND": {
+        "message": "AND"
+    },
+    "auxiliaryHelpMode_3DDISABLE": {
+        "message": "يمكن اتجاه دوران المحرك العكسي لتوفير دفع سلبي والسماح بالطيران المقلوب. تصبح دواسة الوقود من -100 إلى +100 بدلاً من 0 إلى 100",
+        "description": "Help text to 3D mode"
+    },
+    "auxiliaryHelpMode_ACROTRAINER": {
+        "message": "وضع طيران يحدد زاوية الطائرة عند الطيران في وضع ACRO",
+        "description": "Help text to ACRO TRAINER mode"
+    },
+    "auxiliaryHelpMode_ARM": {
+        "message": "يمكن إخراج المحرك ويسمح للطائرة بالطيران.  <span class=\"message-negative\">تنبيه:<\/span> قد يرغب الطيار في تكوين <b>BOXPREARM<\/b> (تشغيل من مرحلتين) لأسباب تتعلق بالسلامة.",
+        "description": "Help text to ARM mode"
+    },
+    "auxiliaryHelpMode_ANGLE": {
+        "message": "في هذا الوضع المسوي تلقائيًا، تتحكم قناتي ROLL و PITCH في الزاوية بين المحور ذي الصلة والعمودي، مما يحقق طيرانًا مسويًا بمجرد ترك العصي في المركز",
+        "description": "Help text to ANGLE mode"
+    },
+    "auxiliaryHelpMode_ANTIGRAVITY": {
+        "message": "يزيد وضع الطيران من مصطلحي P و I أثناء حركات دواسة الوقود السريعة لتحسين تتبع العصا وتجنب انحراف الأنف عند تغييرات دواسة الوقود السريعة",
+        "description": "Help text to ANTIGRAVITY mode"
+    },
+    "auxiliaryHelpMode_AIRMODE": {
+        "message": "يسمح AirMode بالحفاظ على استقرار الطائرة عند Throttle منخفض. لمزيد من المعلومات راجع <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Modes#airmode\" target=\"_blank\" rel=\"noopener noreferrer\">AirMode<\/a> على Betaflight.com.",
+        "description": "Help text to AIRMODE mode"
+    },
+    "auxiliaryHelpMode_ALTHOLD": {
+        "message": "يقوم <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Position-Hold-2025-12#altitude-hold\" target=\"_blank\" rel=\"noopener noreferrer\">Altitude Hold<\/a> بتنظيم ارتفاع الطائرة بشكل نشط باستخدام المستشعرات الخارجية مع Angle Mode (الوضع المستقر).",
+        "description": "Help text for ALTITUDE HOLD mode"
+    },
+    "auxiliaryHelpMode_AUTOPILOT": {
+        "message": "يُتيح وضع الطيار الآلي التحكم الذاتي في الطيران، بالجمع بين تثبيت الارتفاع وتثبيت الموقع للحفاظ على تحويم ثابت أو اتّباع مسار طيران مُحدَّد مسبقاً.",
+        "description": "Help text for AUTOPILOT mode"
+    },
+    "auxiliaryHelpMode_BEEPER": {
+        "message": "تمكين الصفير - مفيد لتحديد موقع الطائرة المحطمة",
+        "description": "Help text to BEEPER mode"
+    },
+    "auxiliaryHelpMode_BEEPERMUTE": {
+        "message": "تعطيل\/تمكين الجرس بما في ذلك التحذير والحالة ووضع BEEPER",
+        "description": "Help text to BEEPERMUTE mode"
+    },
+    "auxiliaryHelpMode_BEEPERON": {
+        "message": "تمكين وضع BEEPER ON",
+        "description": "Help text to BEEPER ON mode"
+    },
+    "auxiliaryHelpMode_BEEPGPSSATELLITECOUNT": {
+        "message": "تمكين وضع BEEP GPS SATELLITE COUNT",
+        "description": "Help text to BEEP GPS SATELLITE COUNT mode"
+    },
+    "auxiliaryHelpMode_BLACKBOX": {
+        "message": "تمكين تسجيل الصندوق الأسود",
+        "description": "Help text to BLACKBOX mode"
+    },
+    "auxiliaryHelpMode_BLACKBOXERASE": {
+        "message": "مسح سجل الصندوق الأسود",
+        "description": "Help text to BLACKBOX ERASE mode"
+    },
+    "auxiliaryHelpMode_BOXPREARM": {
+        "message": "يمكن وضع BOXPREARM",
+        "description": "Help text to BOXPREARM mode"
+    },
+    "auxiliaryHelpMode_CALIB": {
+        "message": "بدء المعايرة أثناء الطيران",
+        "description": "Help text to CALIB mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL1": {
+        "message": "استخدم للتبديل بين CAMERA CONTROL 1 المخصص. تحقق في الدليل الخاص بالشركة المصنعة",
+        "description": "Help text to customized CAMERA CONTROL 1 mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL2": {
+        "message": "استخدم للتبديل بين CAMERA CONTROL 2 المخصص. تحقق في الدليل الخاص بالشركة المصنعة",
+        "description": "Help text to customized CAMERA CONTROL 2 mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL3": {
+        "message": "استخدم للتبديل بين CAMERA CONTROL 3 المخصص. تحقق في الدليل الخاص بالشركة المصنعة",
+        "description": "Help text to customized CAMERA CONTROL 3 mode"
+    },
+    "auxiliaryHelpMode_CAMSTAB": {
+        "message": "يمكن وضع تثبيت الكاميرا",
+        "description": "Help text to CAMSTAB mode"
+    },
+    "auxiliaryHelpMode_CHIRP": {
+        "message": "يُفعّل وضع Chirp",
+        "description": "Help text for CHIRP mode"
+    },
+    "auxiliaryHelpMode_FAILSAFE": {
+        "message": "أدخل المرحلة الثانية من نظام الأمان عند الفشل يدويًا",
+        "description": "Help text to FAILSAFE mode"
+    },
+    "auxiliaryHelpMode_FLIPOVERAFTERCRASH": {
+        "message": "عكس المحركات لقلب الطائرة المقلوبة رأسًا على عقب بعد تحطم (مطلوب DShot)",
+        "description": "Help text to FLIP OVER AFTER CRASH mode"
+    },
+    "auxiliaryHelpMode_FPVANGLEMIX": {
+        "message": "تطبيق دوران الانعراج بالنسبة لكاميرا FPV مثبتة بزاوية محددة مسبقًا",
+        "description": "Help text to FPV ANGLE MIX mode"
+    },
+    "auxiliaryHelpMode_GPSBEEPSATELLITECOUNT": {
+        "message": "استخدم للإشارة إلى عدد أقمار GPS التي تم العثور عليها عن طريق الصفير بهذا العدد من المرات",
+        "description": "Help text to GPS BEEP SATELLITE COUNT mode"
+    },
+    "auxiliaryHelpMode_GPSRESCUE": {
+        "message": "مكن 'إنقاذ GPS' لإعادة الطائرة إلى الموقع الذي تم تشغيلها فيه آخر مرة",
+        "description": "Help text to GPS RESCUE mode"
+    },
+    "auxiliaryHelpMode_HEADADJ": {
+        "message": "ضبط الاتجاه - يحدد أصل YAW جديد لوضع HEADFREE",
+        "description": "Help text to HEAD ADJ mode"
+    },
+    "auxiliaryHelpMode_HEADFREE": {
+        "message": "وضع طيران حيث يتم محاذاة YAW مع إطار مرجعي خارجي (غالبًا حيث يواجه الطيار) بدلاً من الطائرة. مصمم للمبتدئين لكن نادرًا ما يتم استخدامه، نوصي بوضع ANGLE",
+        "description": "Help text to HEADFREE mode"
+    },
+    "auxiliaryHelpMode_HORIZON": {
+        "message": "يعمل هذا الوضع الهجين تمامًا مثل وضع ANGLE مع عصي ROLL و PITCH  في المركز (مما يمكن الطيران المسوي تلقائيًا)، ثم يتصرف بشكل متزايد أكثر وأكثر مثل وضع RATE الافتراضي عندما تتحرك العصي بعيدًا عن موضع المركز",
+        "description": "Help text to HORIZON mode"
+    },
+    "auxiliaryHelpMode_LAUNCHCONTROL": {
+        "message": "نظام مساعدة بداية السباق",
+        "description": "Help text to LAUNCH CONTROL mode"
+    },
+    "auxiliaryHelpMode_LEDLOW": {
+        "message": "إيقاف إخراج الشريط الضوئي",
+        "description": "Help text to LEDLOW mode"
+    },
+    "auxiliaryHelpMode_MAG": {
+        "message": "قفل الاتجاه على اتجاه البوصلة المغناطيسية (تحكم البوصلة)",
+        "description": "Help text to MAG mode"
+    },
+    "auxiliaryHelpMode_MSPOVERRIDE": {
+        "message": "تمكين وضع MSP Override",
+        "description": "Help text to MSP OVERRIDE mode"
+    },
+    "auxiliaryHelpMode_OSDDISABLE": {
+        "message": "Enable\/Disable On-Screen-Display",
+        "description": "Help text to OSD mode"
+    },
+    "auxiliaryHelpMode_PASSTHRU": {
+        "message": "تمرير ROLL وYAW وPITCH  مباشرة من المستقبل إلى المشغلات في مزيج الطائرة",
+        "description": "Help text to PASSTHRU mode"
+    },
+    "auxiliaryHelpMode_PARALYZE": {
+        "message": "تعطيل الطائرة المحطمة بشكل دائم حتى يتم إعادة تشغيل الطاقة",
+        "description": "Help text to PARALYZE mode"
+    },
+    "auxiliaryHelpMode_PIDAUDIO": {
+        "message": "استخدم للتبديل بين PIDAUDIO",
+        "description": "Help text to PIDAUDIO mode"
+    },
+    "auxiliaryHelpMode_POSHOLD": {
+        "message": "وضع تثبيت الموضع",
+        "description": "Help text to POSHOLD mode"
+    },
+    "auxiliaryHelpMode_PREARM": {
+        "message": "عند التشغيل، انتظر حتى يتم تنشيط هذا المفتاح قبل التشغيل الفعلي",
+        "description": "Help text to PREARM mode"
+    },
+    "auxiliaryHelpMode_READY": {
+        "message": "تمت الإضافة في BF4.4، يمكنك الآن إظهار 'جاهز' في العرض على الشاشة باستخدام مفتاح. هذا تحسين متخصص لمواقف السباق حيث تكون جميع إشارات الفيديو للطيار على شاشة مركزية واحدة. يمكن للطيار قلب مفتاح للإشارة إلى أنه جاهز للطيران، وتظهر كلمة جاهز على العرض على الشاشة. يمكن لمدير السباق بعد ذلك معرفة ما إذا كان جميع الطيارين جاهزين من خلال النظر إلى الشاشة المركزية. عند التشغيل، تختفي كلمة جاهز.",
+        "description": "Help text to READY mode"
+    },
+    "auxiliaryHelpMode_STICKCOMMANDSDISABLE": {
+        "message": "تعطيل\/تمكين أمر العصا",
+        "description": "Help text to STICK COMMANDS DISABLE mode"
+    },
+    "auxiliaryHelpMode_SERVO1": {
+        "message": "استخدم للتبديل بين SERVO1",
+        "description": "Help text to SERVO1 mode"
+    },
+    "auxiliaryHelpMode_SERVO2": {
+        "message": "استخدم للتبديل بين SERVO2",
+        "description": "Help text to SERVO2 mode"
+    },
+    "auxiliaryHelpMode_SERVO3": {
+        "message": "استخدم للتبديل بين SERVO3",
+        "description": "Help text to SERVO3 mode"
+    },
+    "auxiliaryHelpMode_TELEMETRY": {
+        "message": "تمكين إرسال البيانات عبر المفتاح",
+        "description": "Help text to TELEMETRY mode"
+    },
+    "auxiliaryHelpMode_USER1": {
+        "message": "يُستخدم لتفعيل أو تعطيل USER1 المخصص. يتحكم في خرج قابل للتخصيص عبر PINIO.\n",
+        "description": "Help text to customized USER1 mode"
+    },
+    "auxiliaryHelpMode_USER2": {
+        "message": "يُستخدم لتفعيل أو تعطيل USER2 المخصص. يتحكم في خرج قابل للتخصيص عبر PINIO.",
+        "description": "Help text to customized USER2 mode"
+    },
+    "auxiliaryHelpMode_USER3": {
+        "message": "يُستخدم لتفعيل أو تعطيل USER3 المخصص. يتحكم في خرج قابل للتخصيص عبر PINIO.\n",
+        "description": "Help text to customized USER3 mode"
+    },
+    "auxiliaryHelpMode_USER4": {
+        "message": "يُستخدم لتفعيل أو تعطيل USER4 المخصص. يتحكم في خرج قابل للتخصيص عبر PINIO.\n",
+        "description": "Help text to customized USER4 mode"
+    },
+    "auxiliaryHelpMode_VTXCONTROLDISABLE": {
+        "message": "تعطيل التحكم في إعدادات جهاز الفيديو من خلال العرض على الشاشة",
+        "description": "Help text to VTX CONTROL DISABLE mode"
+    },
+    "auxiliaryHelpMode_VTXPOWER": {
+        "message": "التنقل بين مستويات طاقة جهاز الفيديو (إذا كان مدعومًا من قبل VTX)",
+        "description": "Help text to VTX POWER mode"
+    },
+    "auxiliaryHelpMode_VTXPITMODE": {
+        "message": "تحويل جهاز الفيديو إلى وضع الحفرة (طاقة إخراج منخفضة، إذا كان مدعومًا)",
+        "description": "Help text to VTX PIT MODE mode"
+    },
+    "auxiliaryHelpMode_LAPTIMERRESET": {
+        "message": "إعادة ضبط مؤقت اللفات الخاص transponder ",
+        "description": "Help text to LAP TIMER RESET mode"
+    },
+    "adjustmentsHelp": {
+        "message": "قم اعداد مفاتيح الضبط. راجع قسم 'in-flight adjustments' في الدليل للحصول على التفاصيل. التغييرات التي تجريها وظائف الضبط لا يتم حفظها تلقائيًا."
+    },
+    "adjustmentsColumnEnable": {
+        "message": "إذا مفعل"
+    },
+    "adjustmentsColumnUsingSlot": {
+        "message": "باستخدام الخانة"
+    },
+    "adjustmentsColumnWhenChannel": {
+        "message": "عندما تكون القناة"
+    },
+    "adjustmentsColumnIsInRange": {
+        "message": "في النطاق"
+    },
+    "adjustmentsColumnThenApplyFunction": {
+        "message": "ثم تطبق الوظيفة"
+    },
+    "adjustmentsColumnViaChannel": {
+        "message": "عبر القناة"
+    },
+    "adjustmentsColumnMode": {
+        "message": "الوضع"
+    },
+    "adjustmentsModeStep": {
+        "message": "خطوة"
+    },
+    "adjustmentsModeAbsolute": {
+        "message": "مطلق"
+    },
+    "adjustmentsModeSelection": {
+        "message": "اختيار"
+    },
+    "adjustmentsColumnAdjustmentCenter": {
+        "message": "المركز (القيمة)"
+    },
+    "adjustmentsColumnAdjustmentScale": {
+        "message": "المقياس (القيمة|%)"
+    },
+    "adjustmentsCenterHelp": {
+        "message": "يحدد نقطة المنتصف أو القيمة المرجعية التي تستخدمها وظيفة الضبط.<br \/><br \/><strong>تعديلات أشرطة التمرير:<\/strong><br \/>بالنسبة إلى تعديلات أشرطة التمرير، اضبط مركز الضبط على 0. سيُستخدم الموضع الحالي لشريط التمرير للضبط بالزيادة أو النقصان.<br \/><br \/><strong>تعديلات الاختيار:<\/strong><br \/>اضبط مركز الضبط على 0، أو على قيمة محددة بالميكروثانية (uS) إذا أردت إزاحة النقطة المرجعية للمفتاح عن 1500uS عند بدء ضبط RC.<br \/><br \/><strong>التعديلات المتدرجة:<\/strong><br \/>اضبط مركز الضبط على 0 لاستخدام القيمة الحالية للعنصر الذي يتم ضبطه.<br \/><br \/><strong>التعديلات المطلقة:<\/strong><br \/>لاستخدام طريقة الضبط المطلق، يجب ضبط كل من مركز الضبط والمقياس لتحديد القيمة والنطاق المطلوبين. يُحسب النطاق كالتالي: المركز ± المقياس. على سبيل المثال، يؤدي ضبط مركز الضبط على 50 ومقياس الضبط على 25 إلى إنشاء نطاق من 25 إلى 75، مع تعيين موضع المنتصف (للمفتاح أو POT) إلى 50.<br \/><br \/>تفضّل بزيارة <a href=\"https:\/\/www.betaflight.com\/docs\/wiki\/guides\/current\/Inflight-Adjustments\" target=\"_blank\" rel=\"noopener noreferrer\">هذه الصفحة<\/a> لمزيد من المعلومات.\n",
+        "description": "Tooltip help text for the Adjustment Center column"
+    },
+    "adjustmentsScaleHelp": {
+        "message": "يتحكم في مقياس الضبط أو نطاقه؛ وتؤدي القيم الأعلى إلى زيادة نطاق الضبط أو حساسيته.<br \/><br \/><strong>تعديلات أشرطة التمرير:<\/strong><br \/>بالنسبة إلى تعديلات أشرطة التمرير، يتحكم مقياس الضبط في نطاق الضبط وحساسيته. تعادل القيمة 50 نسبة 50% من نطاق شريط التمرير. يؤدي ضبطه على 0 إلى استخدام المقياس الافتراضي لأشرطة التمرير.<br \/><br \/><strong>تعديلات الاختيار:<\/strong><br \/>بالنسبة إلى تعديلات الاختيار، اضبط مقياس الضبط على 0 لاستخدام السلوك الافتراضي، أو حدد قيمة بالميكروثانية (uS) لتقييد النطاق. على سبيل المثال: اضبط مركز الضبط على 1000 (uS) ومقياس الضبط على 500 (uS) لاستخدام مفتاح ثلاثي المواضع كمفتاح ثنائي المواضع.<br \/><br \/><strong>التعديلات المتدرجة والمطلقة:<\/strong><br \/>بالنسبة إلى التعديلات المتدرجة والمطلقة، يحدد مقياس الضبط النطاق أعلى وأسفل مركز الضبط. على سبيل المثال، تنشئ القيمة 25 نطاق ضبط قدره ±25 من قيمة مركز الضبط، أو من القيمة الحالية إذا تم ضبط مركز الضبط على 0.<br \/><strong>ملاحظة:<\/strong> لاستخدام طريقة الضبط المطلق مع مقياس جهد، يجب تحديد قيمة لمقياس الضبط.<br \/><br \/>تفضّل بزيارة <a href=\"https:\/\/www.betaflight.com\/docs\/wiki\/guides\/current\/Inflight-Adjustments\" target=\"_blank\" rel=\"noopener noreferrer\">هذه الصفحة<\/a> لمزيد من المعلومات.\n",
+        "description": "Tooltip help text for the Adjustment Scale column"
+    },
+    "adjustmentsSlot0": {
+        "message": "الخانة 1"
+    },
+    "adjustmentsSlot1": {
+        "message": "الخانة 2"
+    },
+    "adjustmentsSlot2": {
+        "message": "الخانة 3"
+    },
+    "adjustmentsSlot3": {
+        "message": "الخانة 4"
+    },
+    "adjustmentsMin": {
+        "message": "الحد الأدنى"
+    },
+    "adjustmentsMax": {
+        "message": "الحد الأقصى"
+    },
+    "adjustmentsFunction0": {
+        "message": "لا تغيير"
+    },
+    "adjustmentsFunction1": {
+        "message": "ضبط معدل الإشارة اللاسلكية"
+    },
+    "adjustmentsFunction2": {
+        "message": "ضبط كسب الإشارة اللاسلكية"
+    },
+    "adjustmentsFunction3": {
+        "message": "ضبط المنحنى الأُسّي لدواسة الوقود"
+    },
+    "adjustmentsFunction4": {
+        "message": "ضبط معدل PITCH و ROLL"
+    },
+    "adjustmentsFunction5": {
+        "message": "ضبط معدل YAW"
+    },
+    "adjustmentsFunction6": {
+        "message": "الضبط النسبي  PITCH و ROLL"
+    },
+    "adjustmentsFunction7": {
+        "message": "الضبط التكاملي PITCH و ROLL"
+    },
+    "adjustmentsFunction8": {
+        "message": "ضبط المشتق PITCH و  ROLL"
+    },
+    "adjustmentsFunction9": {
+        "message": "الضبط النسبي YAW"
+    },
+    "adjustmentsFunction10": {
+        "message": "ضبط التكاملي YAW"
+    },
+    "adjustmentsFunction11": {
+        "message": "ضبط المشتق YAW"
+    },
+    "adjustmentsFunction12": {
+        "message": "تحديد ملف القيم"
+    },
+    "adjustmentsFunction13": {
+        "message": "ضبط معدل PITCH"
+    },
+    "adjustmentsFunction14": {
+        "message": "ضبط معدل ROLL"
+    },
+    "adjustmentsFunction15": {
+        "message": "ضبط النسبي PITCH"
+    },
+    "adjustmentsFunction16": {
+        "message": "ضبط التكاملي PITCH"
+    },
+    "adjustmentsFunction17": {
+        "message": "ضبط المشتق PITCH"
+    },
+    "adjustmentsFunction18": {
+        "message": "ضبط النسبي ROLL"
+    },
+    "adjustmentsFunction19": {
+        "message": "ضبط التكاملي ROLL"
+    },
+    "adjustmentsFunction20": {
+        "message": "ضبط المشتق ROLL"
+    },
+    "adjustmentsFunction21": {
+        "message": "معدل الإشارة اللاسلكية YAW"
+    },
+    "adjustmentsFunction22": {
+        "message": "ضبط F للـ PITCH  & ROLL"
+    },
+    "adjustmentsFunction23": {
+        "message": "انتقال FF"
+    },
+    "adjustmentsFunction24": {
+        "message": "ضبط قوة الأفق"
+    },
+    "adjustmentsFunction25": {
+        "message": "تحديد الصوت لـ PID"
+    },
+    "adjustmentsFunction26": {
+        "message": "ضبط FF  للـ PITCH"
+    },
+    "adjustmentsFunction27": {
+        "message": "ضبط F للـ ROLL\n"
+    },
+    "adjustmentsFunction28": {
+        "message": "ضبط FF للـYAW"
+    },
+    "adjustmentsFunction29": {
+        "message": "تحديد ملف تعريف العرض على الشاشة"
+    },
+    "adjustmentsFunction30": {
+        "message": "تحديد ملف تعريف الإضاءة"
+    },
+    "adjustmentsFunction31": {
+        "message": "ضبط سطوع الإضاءة"
+    },
+    "adjustmentsFunction32": {
+        "message": "المضاعف الرئيسي للأشرطة"
+    },
+    "adjustmentsFunction33": {
+        "message": "اختيار ملف تعريف البطارية",
+        "description": "Allows switching battery profiles via RC channel"
+    },
+    "adjustmentsSave": {
+        "message": "Save"
+    },
+    "adjustmentsShowAll": {
+        "message": "عرض جميع الخانات"
+    },
+    "adjustmentsHideEmpty": {
+        "message": "إخفاء الخانات الفارغة"
+    },
+    "adjustmentsSlotsActive": {
+        "message": "{{active}} من {{total}} خانات مفعّلة"
+    },
+    "servosFirmwareUpgradeRequired": {
+        "message": "يتطلب SERVO برنامجًا ثابتًا >= 1.10.0 ودعم الهدف."
+    },
+    "servosChangeDirection": {
+        "message": "غير الاتجاه في جهاز الإرسال ليتطابق"
+    },
+    "servosForwardChannel": {
+        "message": "تمرير القناة {{channel}} إلى Servo {{servo}}"
+    },
+    "servosName": {
+        "message": "الاسم"
+    },
+    "servosMid": {
+        "message": "المنتصف"
+    },
+    "servosMin": {
+        "message": "الأدنى"
+    },
+    "servosMax": {
+        "message": "الأقصى"
+    },
+    "servosAngleAtMin": {
+        "message": "الزاوية عند الحد الأدنى"
+    },
+    "servosAngleAtMax": {
+        "message": "الزاوية عند الحد الأقصى"
+    },
+    "servosRateAndDirection": {
+        "message": "المعدل والاتجاه"
+    },
+    "servosRate": {
+        "message": "المعدل:",
+        "description": "Label for 'Rate:' direction"
+    },
+    "servosLiveMode": {
+        "message": "تمكين الوضع المباشر"
+    },
+    "servosButtonSave": {
+        "message": "حفظ"
+    },
+    "servosNormal": {
+        "message": "عادي"
+    },
+    "servosReverse": {
+        "message": "عكس"
+    },
+    "gpsHead": {
+        "message": "عام"
+    },
+    "gpsHeadHelp": {
+        "message": "عرض معلومات نظام تحديد المواقع المختلفة. تظهر العناوين فقط عند استخدام البوصلة الإلكترونية.",
+        "description": "Help text for gpsHead"
+    },
+    "gpsMapHead": {
+        "message": "الموقع الحالي"
+    },
+    "gpsMapSatelliteView": {
+        "message": "عرض القمر الصناعي"
+    },
+    "gpsMapHybridView": {
+        "message": "العرض الهجين"
+    },
+    "gpsMapStreetView": {
+        "message": "عرض الشارع"
+    },
+    "gpsMapZoomIn": {
+        "message": "تكبير"
+    },
+    "gpsMapZoomOut": {
+        "message": "تصغير"
+    },
+    "gpsMapToggleFullscreen": {
+        "message": "ملء الشاشة"
+    },
+    "gpsMapRetry": {
+        "message": "إعادة المحاولة"
+    },
+    "gpsMapMessage1": {
+        "message": "يرجى التحقق من اتصالك بالإنترنت"
+    },
+    "gpsMapMessage2": {
+        "message": "في انتظار تثبيت GPS ثلاثي الأبعاد…"
+    },
+    "gps3dFix": {
+        "message": "تثبيت ثلاثي الأبعاد:"
+    },
+    "gpsFixTrue": {
+        "message": "صحيح"
+    },
+    "gpsFixFalse": {
+        "message": "خطأ"
+    },
+    "gpsPositionUnit": {
+        "message": "درجة",
+        "description": "Unit for GPS position."
+    },
+    "gpsAltitude": {
+        "message": "الارتفاع:"
+    },
+    "gpsLatitude": {
+        "message": "خط العرض:",
+        "description": "Show GPS position - Latitude"
+    },
+    "gpsLongitude": {
+        "message": "خط الطول:",
+        "description": "Show GPS position - Longitude"
+    },
+    "gpsHeading": {
+        "message": "الاتجاه (IMU \/ GPS):",
+        "description": "Show IMU \/ GPS heading - Attitude \/ GPS course over ground"
+    },
+    "gpsSpeed": {
+        "message": "السرعة:"
+    },
+    "gpsSats": {
+        "message": "عدد الأقمار الصناعية:",
+        "description": "Show number of fixed GPS Satellites"
+    },
+    "gpsDistToHome": {
+        "message": "المسافة إلى نقطة المنزل:"
+    },
+    "gpsPositionalDop": {
+        "message": "دقة الموضع:"
+    },
+    "gpsMagneticDeclination": {
+        "message": "$t(configurationMagDeclination):",
+        "description": "Do not translate"
+    },
+    "gpsSignalStrHead": {
+        "message": "معلومات الإشارة"
+    },
+    "gpsSignalStrHeadHelp": {
+        "message": "عرض قوة الإشارة وجودتها وحالتها لكل مصدر GPS تم اكتشافه",
+        "description": "Help text for gpsSignalStrHead"
+    },
+    "gpsSignalStr": {
+        "message": "قوة الإشارة"
+    },
+    "gpsSignalLost": {
+        "message": "يضيء رمز GPS فقط عندما يتم تأكيد الاتصال بوحدة GPS.<br \/><br \/>سيكون أحمر في البداية، ويتغير إلى الأصفر عند تحقيق التثبيت ثلاثي الأبعاد.<br \/><br \/>إذا لم يضيء رمز GPS، فتحقق من التوصيلات والتكوين الخاصين بك، وتأكد من أن وحدة GPS تتلقى الطاقة.<br \/><br \/>يوفر أمر 'status' في واجهة الأوامر النصية مزيدًا من المعلومات حول حالة اتصال GPS."
+    },
+    "gpsSignalGnssId": {
+        "message": "معرف GNSS"
+    },
+    "gpsSignalSatId": {
+        "message": "معرف القمر الصناعي"
+    },
+    "gpsSignalQuality": {
+        "message": "الجودة"
+    },
+    "gnssQualityNoSignal": {
+        "message": "لا توجد إشارة"
+    },
+    "gnssQualitySearching": {
+        "message": "جاري البحث"
+    },
+    "gnssQualityAcquired": {
+        "message": "تم الاكتساب"
+    },
+    "gnssQualityUnusable": {
+        "message": "غير قابل للاستخدام"
+    },
+    "gnssQualityLocked": {
+        "message": "مقفل"
+    },
+    "gnssQualityFullyLocked": {
+        "message": "مقفل بالكامل"
+    },
+    "gnssUsedUnused": {
+        "message": "غير مستخدم"
+    },
+    "gnssUsedUsed": {
+        "message": "مستخدَم"
+    },
+    "gnssHealthyUnknown": {
+        "message": "غير معروف"
+    },
+    "gnssHealthyHealthy": {
+        "message": "سليم"
+    },
+    "gnssHealthyUnhealthy": {
+        "message": "غير سليم"
+    },
+    "flightPlanWaypointList": {
+        "message": "قائمة النُقَط"
+    },
+    "flightPlanNoWaypoints": {
+        "message": "لا توجد نُقَط محدّدة. انقر على الخريطة أو استخدم النموذج لإضافة نُقَط."
+    },
+    "flightPlanAddWaypoint": {
+        "message": "إضافة نقطة"
+    },
+    "flightPlanEditWaypoint": {
+        "message": "تعديل نقطة"
+    },
+    "flightPlanLatitude": {
+        "message": "خط العرض <span class=\"units\">°<\/span>"
+    },
+    "flightPlanLongitude": {
+        "message": "خط الطول <span class=\"units\">°<\/span>"
+    },
+    "flightPlanAltitude": {
+        "message": "الارتفاع <span class=\"units\">ft AMSL<\/span>"
+    },
+    "flightPlanSpeed": {
+        "message": "السرعة <span class=\"units\">knots<\/span>"
+    },
+    "flightPlanType": {
+        "message": "نوع النقطة"
+    },
+    "flightPlanTypeFlyover": {
+        "message": "المرور فوق النقطة"
+    },
+    "flightPlanTypeFlyby": {
+        "message": "المرور بجانب النقطة"
+    },
+    "flightPlanTypeHold": {
+        "message": "التحليق والثبات"
+    },
+    "flightPlanTypeLand": {
+        "message": "هبوط"
+    },
+    "flightPlanTypeTakeoff": {
+        "message": "إقلاع"
+    },
+    "flightPlanTypeAltChange": {
+        "message": "تغيير الارتفاع",
+        "description": "Modifier waypoint type: changes the altitude of the next positional waypoint"
+    },
+    "flightPlanTypeDelay": {
+        "message": "تأخير",
+        "description": "Modifier waypoint type: pauses traversal for a duration"
+    },
+    "flightPlanTypeYawRate": {
+        "message": "الحد الأقصى لمعدل Yaw",
+        "description": "Modifier waypoint type: caps the yaw rate of the next positional waypoint"
+    },
+    "flightPlanDuration": {
+        "message": "مدة الثبات <span class=\"units\">دقيقة<\/span>"
+    },
+    "flightPlanDurationAria": {
+        "message": "مدة الثبات بالدقائق",
+        "description": "Plain-text aria-label variant of flightPlanDuration for screen readers"
+    },
+    "flightPlanDelayDuration": {
+        "message": "مدة التأخير <span class=\"units\">دقيقة<\/span>"
+    },
+    "flightPlanDelayDurationAria": {
+        "message": "مدة التأخير بالدقائق",
+        "description": "Plain-text aria-label variant of flightPlanDelayDuration for screen readers"
+    },
+    "flightPlanYawRate": {
+        "message": "معدل Yaw <span class=\"units\">°\/s<\/span>"
+    },
+    "flightPlanYawRateAria": {
+        "message": "معدل Yaw بالدرجات في الثانية",
+        "description": "Plain-text aria-label variant of flightPlanYawRate for screen readers"
+    },
+    "flightPlanPattern": {
+        "message": "نمط الثبات"
+    },
+    "flightPlanPatternCircle": {
+        "message": "دائرة"
+    },
+    "flightPlanPatternFigure8": {
+        "message": "شكل 8"
+    },
+    "flightPlanPatternOrbit": {
+        "message": "مدار"
+    },
+    "flightPlanMap": {
+        "message": "خريطة خُطَّة الطيران"
+    },
+    "flightPlanMapInstructions": {
+        "message": "انقر لإضافة نقاط مسار. اسحب علامات نقاط المسار لتحريكها."
+    },
+    "flightPlanLoading": {
+        "message": "يرجى الانتظار..."
+    },
+    "flightPlanClear": {
+        "message": "مسح"
+    },
+    "flightPlanLoad": {
+        "message": "تحميل"
+    },
+    "flightPlanSaveToFC": {
+        "message": "حفظ إلى FC"
+    },
+    "flightPlanLoaded": {
+        "message": "تم تحميل خُطَّة الطيران بنجاح"
+    },
+    "flightPlanSaved": {
+        "message": "تم حفظ خُطَّة الطيران بنجاح"
+    },
+    "flightPlanCleared": {
+        "message": "تم مسح خُطَّة الطيران"
+    },
+    "flightPlanLoadFromFC": {
+        "message": "تحميل من متحكم الطيران"
+    },
+    "flightPlanLoadedFromFC": {
+        "message": "تم تحميل خطة الطيران من متحكم الطيران"
+    },
+    "flightPlanSavedToFC": {
+        "message": "تم حفظ خطة الطيران في متحكم الطيران"
+    },
+    "flightPlanFCLoadError": {
+        "message": "فشل تحميل خطة الطيران من متحكم الطيران"
+    },
+    "flightPlanFCSaveError": {
+        "message": "فشل حفظ خطة الطيران في متحكم الطيران"
+    },
+    "flightPlanFCEmpty": {
+        "message": "لم يتم العثور على نقاط مسار في متحكم الطيران"
+    },
+    "flightPlanClearedFC": {
+        "message": "تم مسح خطة الطيران من متحكم الطيران"
+    },
+    "flightPlanLoadError": {
+        "message": "فشل تحميل خطة الطيران"
+    },
+    "flightPlanSaveError": {
+        "message": "فشل حفظ خطة الطيران"
+    },
+    "flightPlanInvalidLatitude": {
+        "message": "خط العرض غير صالح (يجب أن يكون بين -90 و90)"
+    },
+    "flightPlanInvalidLongitude": {
+        "message": "خط الطول غير صالح (يجب أن يكون بين -180 و180)"
+    },
+    "flightPlanInvalidAltitude": {
+        "message": "الارتفاع غير صالح (يجب أن يكون صفرًا أو قيمة موجبة)"
+    },
+    "flightPlanInvalidDuration": {
+        "message": "المدة غير صالحة (يجب أن تكون صفرًا أو قيمة موجبة)"
+    },
+    "flightPlanInvalidYawRate": {
+        "message": "معدل Yaw غير صالح (يجب أن يكون صفرًا أو قيمة موجبة)"
+    },
+    "flightPlanConfirmDelete": {
+        "message": "هل أنت متأكد من حذف نقطة المسار هذه؟"
+    },
+    "flightPlanDeleteWaypointTitle": {
+        "message": "حذف نقطة المسار"
+    },
+    "flightPlanDeleteWaypointConfirm": {
+        "message": "هل أنت متأكد من حذف المسار ؟ لا يمكن التراجع عن هذا الإجراء."
+    },
+    "flightPlanConfirmClear": {
+        "message": "هل أنت متأكد من أنك تريد مسح جميع نقاط المسار ؟ لا يمكن التراجع عن هذا الإجراء."
+    },
+    "flightPlanClearTitle": {
+        "message": "مسح خطة الطيران"
+    },
+    "flightPlanLoadPromptTitle": {
+        "message": "تحميل خطة الطيران من متحكم الطيران؟"
+    },
+    "flightPlanLoadPromptBody": {
+        "message": "تم الاتصال بوحدة تحكم الطيران . هل تريد استبدال خطة الطيران الحالية بواحدة مخزنة على وحدة التحكم ؟ الاختيار لن يحفظ خطتك الحالية "
+    },
+    "flightPlanKeepLocal": {
+        "message": "الاحتفاظ بالخطة الحالية"
+    },
+    "flightPlanElevationProfile": {
+        "message": "مخطط الارتفاع"
+    },
+    "flightPlanDistance": {
+        "message": "المسافة الإجمالية"
+    },
+    "flightPlanFlightTime": {
+        "message": "مدة الطيران"
+    },
+    "flightPlanMinAlt": {
+        "message": "أدنى ارتفاع"
+    },
+    "flightPlanMaxAlt": {
+        "message": "أقصى ارتفاع"
+    },
+    "flightPlanNoWaypointsForProfile": {
+        "message": "أضف نقاط مسار لعرض مخطط الارتفاع"
+    },
+    "flightPlanGroundElev": {
+        "message": "ارتفاع سطح الأرض"
+    },
+    "flightPlanMaxGroundElev": {
+        "message": "أقصى ارتفاع لسطح الأرض"
+    },
+    "flightPlanAvgGround": {
+        "message": "متوسط ارتفاع سطح الأرض"
+    },
+    "flightPlanMaxGround": {
+        "message": "أقصى ارتفاع لسطح الأرض"
+    },
+    "flightPlanAlt": {
+        "message": "الارتفاع"
+    },
+    "flightPlanDist": {
+        "message": "المسافة"
+    },
+    "motorsVoltage": {
+        "message": "الفولتية:"
+    },
+    "motorsADrawing": {
+        "message": "التيار:"
+    },
+    "motorsmAhDrawn": {
+        "message": "التيار المسحوب:"
+    },
+    "motorsVoltageValue": {
+        "message": "$1 فولت"
+    },
+    "motorsADrawingValue": {
+        "message": "$1 أمبير"
+    },
+    "motorsmAhDrawnValue": {
+        "message": "$1 ملي أمبير ساعة"
+    },
+    "motorsText": {
+        "message": "المحركات"
+    },
+    "motorNumber1": {
+        "message": "المحرك - 1"
+    },
+    "motorNumber2": {
+        "message": "المحرك - 2"
+    },
+    "motorNumber3": {
+        "message": "المحرك - 3"
+    },
+    "motorNumber4": {
+        "message": "المحرك - 4"
+    },
+    "motorNumber5": {
+        "message": "المحرك - 5"
+    },
+    "motorNumber6": {
+        "message": "المحرك - 6"
+    },
+    "motorNumber7": {
+        "message": "المحرك - 7"
+    },
+    "motorNumber8": {
+        "message": "المحرك - 8"
+    },
+    "servosText": {
+        "message": "Servos"
+    },
+    "servoNumber1": {
+        "message": "Servo - 1"
+    },
+    "servoNumber2": {
+        "message": "Servo - 2"
+    },
+    "servoNumber3": {
+        "message": "Servo - 3"
+    },
+    "servoNumber4": {
+        "message": "Servo - 4"
+    },
+    "servoNumber5": {
+        "message": "Servo - 5"
+    },
+    "servoNumber6": {
+        "message": "Servo - 6"
+    },
+    "servoNumber7": {
+        "message": "Servo - 7"
+    },
+    "servoNumber8": {
+        "message": "Servo - 8"
+    },
+    "motorsResetMaximumButton": {
+        "message": "إعادة تعيين"
+    },
+    "motorsResetMaximum": {
+        "message": "إعادة تعيين الحد الأقصى الإضافي للوقت"
+    },
+    "motorsSensorAccelSelect": {
+        "message": "مستشعر التسارع"
+    },
+    "motorsTelemetryHelp": {
+        "message": "تظهر هذه الأرقام معلومات إرسال البيانات المستلمة من وحدات تحكم السرعة إذا كانت متاحة. يمكنها عرض السرعة الفعلية للمحركات (R، بالدورة في الدقيقة RPM)، ومعدل الخطأ (E) لرابط إرسال البيانات ودرجة الحرارة (T) لوحدات تحكم السرعة.",
+        "description": "Help text for the telemetry values in the motors tab."
+    },
+    "motorsRPM": {
+        "message": "R: {{motorsRpmValue}}",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Keep the letters as prefix. Shows the RPM of the motor if telemetry is available."
+    },
+    "motorsRPMError": {
+        "message": "E: {{motorsErrorValue}}%",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the error of motor telemetry if available."
+    },
+    "motorsESCTemperature": {
+        "message": "T: {{motorsESCTempValue}}&deg;C",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the ESC temperature if available."
+    },
+    "motorsMaster": {
+        "message": "الرئيسي"
+    },
+    "motorsNotice": {
+        "message": "<strong>وضع اختبار المحركات \/ تنبيه التشغيل:<\/strong><br \/><br \/><strong class=\"message-negative\">تحذير: خطر التعرض لإصابة خطيرة! أزل جميع المراوح!<\/strong><br \/><br \/><ul><li>• ستبدأ المحركات بالدوران عند التشغيل أو عند رفع أشرطة التمرير<\/li><li>• سيظل وضع اختبار المحركات نشطًا بعد الانتقال إلى علامة تبويب أخرى<\/li><li>• سيؤدي الضغط على أي مفتاح إلى إيقاف المحركات، ولكن فقط ضمن علامة تبويب المحركات<\/li><li>• قد لا يؤدي فصل كابل USB إلى إيقاف المحركات!<\/li><\/ul>\n"
+    },
+    "motorsEnableControl": {
+        "message": "<strong>أنا أدرك المخاطر<\/strong>، تمت إزالة المراوح - تمكين التحكم في المحرك والتشغيل، وتعطيل منع الإقلاع غير المنضبط."
+    },
+    "motorsDialogMixerReset": {
+        "message": "<strong>تم اكتشاف مشكلة في وضع المازج<\/strong><br \/><br \/>يحتاج نموذج {{mixerName}} إلى <strong class=\"message-positive\">{{mixerMotors}}<\/strong> من موارد المحركات، بينما يوفر الإعداد الحالي للبرنامج الثابت <strong class=\"message-positive\">{{outputs}}<\/strong> من المخارج القابلة للاستخدام في الوضع المحدد.<br \/><br \/>إذا كنت تستخدم وضع مازج مخصصًا، فيجب تحديد mmix مخصص قبل تغيير وضع المازج.<br \/><br \/>يرجى التحقق من إعداداتك وإضافة موارد المحركات المطلوبة.\n"
+    },
+    "motorsDialogSettingsChanged": {
+        "message": "تم اكتشاف تغييرات في التكوين.<br \/><br \/><strong class=\"message-negative-italic\">تم تعطيل وضع اختبار المحرك حتى يتم حفظ الإعدادات.<\/strong>"
+    },
+    "motorsDialogSettingsChangedOk": {
+        "message": "موافق"
+    },
+    "motorOutputReorderDialogClose": {
+        "message": "إلغاء"
+    },
+    "motorOutputReorderDialogAgree": {
+        "message": "بدء"
+    },
+    "motorsRemapDialogTitle": {
+        "message": "إعادة ترتيب المحركات"
+    },
+    "motorOutputReorderDialogOpen": {
+        "message": "إعادة ترتيب المحركات"
+    },
+    "motorOutputReorderDialogSelectSpinningMotor": {
+        "message": "انقر على المحرك الدوار..."
+    },
+    "motorOutputReorderDialogRemapIsDone": {
+        "message": "جاهز! تحقق من ترتيب دوران المحركات بالنقر على الصورة."
+    },
+    "motorsRemapDialogUnderstandRisks": {
+        "message": "<strong>أنا أدرك المخاطر<\/strong>،<br \/>تمت إزالة جميع المراوح."
+    },
+    "motorsRemapDialogRiskNotice": {
+        "message": "<strong>إشعار السلامة<\/strong><br \/><strong class=\"message-negative\">قم بإزالة جميع المراوح لمنع الإصابة!<\/strong><br \/>ستقوم المحركات <strong>بالدوران!<\/strong>"
+    },
+    "motorsRemapDialogExplanations": {
+        "message": "<strong>تنبيه معلومات<\/strong><br \/>ستبدأ المحركات بالدوران واحدًا تلو الآخر، وستتمكن من تحديد المحرك الذي يدور. يجب توصيل البطارية واختيار بروتوكول ESC الصحيح. يمكن لهذه الأداة إعادة ترتيب المحركات النشطة حاليًا فقط. تتطلب عمليات إعادة التعيين الأكثر تعقيدًا استخدام أمر Resource في CLI. راجع <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Remapping-Motors-with-Resource-Command\" target=\"_blank\" rel=\"noopener noreferrer\">صفحة الويكي هذه<\/a>.\n"
+    },
+    "motorsRemapDialogSave": {
+        "message": "حفظ"
+    },
+    "motorsRemapDialogStartOver": {
+        "message": "البدء من جديد"
+    },
+    "motorsButtonReset": {
+        "message": "إعادة تعيين"
+    },
+    "motorsButtonSave": {
+        "message": "حفظ وإعادة التشغيل"
+    },
+    "escDshotDirectionDialog-Title": {
+        "message": "اتجاه المحرك - <strong class=\"message-negative-italic\">تحذير: تأكد من إزالة المراوح!<\/strong>"
+    },
+    "escDshotDirectionDialog-SelectMotor": {
+        "message": "حدد محركًا واحدًا أو جميع المحركات"
+    },
+    "escDshotDirectionDialog-SelectMotorSafety": {
+        "message": "ستدور المحركات عند تحديدها!"
+    },
+    "escDshotDirectionDialog-RiskNotice": {
+        "message": "<strong>إشعار السلامة<\/strong><br \/><strong class=\"message-negative-italic\">قم بإزالة جميع المراوح لمنع الإصابة!<\/strong><br \/>ستقوم المحركات <strong>بالدوران<\/strong> فورًا عند تحديدها!"
+    },
+    "escDshotDirectionDialog-UnderstandRisks": {
+        "message": "<strong>أنا أدرك المخاطر<\/strong>،<br \/>تمت إزالة جميع المراوح."
+    },
+    "escDshotDirectionDialog-InformationNotice": {
+        "message": "<strong>إشعار المعلومات<\/strong><br \/>لتغيير اتجاهات المحرك، يجب توصيل البطارية ويجب إعداد بروتوكول ESC الصحيح في علامة تبويب $t(tabMotorTesting.message). لاحظ أن ليس جميع وحدات تحكم السرعة التي تعمل بـ Dshot ستعمل مع هذه النافذة. تحقق من البرنامج الثابت لوحدة تحكم السرعة الخاصة بك."
+    },
+    "escDshotDirectionDialog-NormalInformationNotice": {
+        "message": "عيّن اتجاه دوران المحرك عن طريق تحديد وتدوير كل محرك على حدة."
+    },
+    "escDshotDirectionDialog-WizardInformationNotice": {
+        "message": "يعيد تعيين جميع اتجاهات دوران المحرك، ثم يسمح للمستخدم باختيار أيها سيتم عكسه."
+    },
+    "escDshotDirectionDialog-Open": {
+        "message": "اتجاه المحرك"
+    },
+    "escDshotDirectionDialog-CommandNormal": {
+        "message": "عادي"
+    },
+    "escDshotDirectionDialog-CommandReverse": {
+        "message": "عكس"
+    },
+    "escDshotDirectionDialog-CommandSpin": {
+        "message": "اختبار المحرك"
+    },
+    "escDshotDirectionDialog-ReleaseButtonToStop": {
+        "message": "حرر الزر للتوقف"
+    },
+    "escDshotDirectionDialog-ReleaseToStop": {
+        "message": "حرر للتوقف"
+    },
+    "escDshotDirectionDialog-Start": {
+        "message": "بشكل فردي"
+    },
+    "escDshotDirectionDialog-StartWizard": {
+        "message": "المساعد"
+    },
+    "escDshotDirectionDialog-SetDirectionHint": {
+        "message": "غير اتجاه المحرك (المحركات) المحدد"
+    },
+    "escDshotDirectionDialog-SetDirectionHintSafety": {
+        "message": "ستدور المحركات عند ضبط الاتجاه!"
+    },
+    "escDshotDirectionDialog-SettingsAutoSaved": {
+        "message": "يتم حفظ اتجاه المحرك عند التحديد"
+    },
+    "escDshotDirectionDialog-WrongProtocolText": {
+        "message": "تعمل الميزة فقط مع وحدات تحكم السرعة التي تدعم بروتوكول DSHOT.<br \/>تحقق من دعم وحدة تحكم السرعة لبروتوكول DSHOT وغيرها في علامة تبويب $t(tabMotorTesting.message)."
+    },
+    "escDshotDirectionDialog-WrongMixerText": {
+        "message": "عدد المحركات هو 0.<br \/>تحقق من إعداد Mixer الحالي في علامة ${t(tabMotorTesting.message)} أو قم بإعداد Mixer مخصص عبر CLI. راجع <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Mixer\" target=\"_blank\" rel=\"noopener noreferrer\">صفحة Wiki هذه<\/a>."
+    },
+    "escDshotDirectionDialog-WrongFirmwareText": {
+        "message": "قم بتحديث البرنامج الثابت.<br \/> تأكد من استخدام أحدث برنامج ثابت: Betaflight 4.3 أو أحدث."
+    },
+    "escDshotDirectionDialog-WizardActionHint": {
+        "message": "انقر على أرقام المحركات بشكل فردي لتغيير اتجاه الدوران"
+    },
+    "escDshotDirectionDialog-WizardActionHintSecondLine": {
+        "message": "تحقق من أن جميع المحركات تدور بشكل صحيح"
+    },
+    "escDshotDirectionDialog-SpinWizard": {
+        "message": "بدء \/ تدوير المحركات"
+    },
+    "escDshotDirectionDialog-StopWizard": {
+        "message": "إيقاف المحركات"
+    },
+    "sensorsInfo": {
+        "message": "ضع في اعتبارك أن استخدام فترات تحديث سريعة وعرض رسوم بيانية متعددة في نفس الوقت يستهلك الكثير من الموارد وسيستنزف بطاريتك بسرعة إذا كنت تستخدم جهاز كمبيوتر محمول.<br \/>نوصي بعرض الرسوم البيانية لأجهزة الاستشعار التي تهتم بها فقط مع استخدام فترات تحديث معقولة."
+    },
+    "sensorsRefresh": {
+        "message": "تحديث الصفحة:"
+    },
+    "sensorsGlobalRefresh": {
+        "message": "تحديث الكل:"
+    },
+    "sensorsScale": {
+        "message": "المقياس:"
+    },
+    "sensorsScaleAuto": {
+        "message": "تلقائي"
+    },
+    "sensorsGyroSelect": {
+        "message": "الجيروسكوب"
+    },
+    "sensorsAccelSelect": {
+        "message": "مستشعر التسارع"
+    },
+    "sensorsMagSelect": {
+        "message": "البوصلة المغناطيسية"
+    },
+    "sensorsAltitudeSelect": {
+        "message": "الارتفاع"
+    },
+    "sensorsSonarSelect": {
+        "message": "السونار"
+    },
+    "sensorsDebugSelect": {
+        "message": "تصحيح الأخطاء"
+    },
+    "sensorsGyroTitle": {
+        "message": "الجيروسكوب - درجة\/ثانية"
+    },
+    "sensorsAccelTitle": {
+        "message": "مستشعر التسارع - g"
+    },
+    "sensorsMagTitle": {
+        "message": "المقياس المغناطيسي"
+    },
+    "sensorsAltitudeTitle": {
+        "message": "الارتفاع - متر"
+    },
+    "sensorsAltitudeHint": {
+        "message": "يُحسب الارتفاع من خلال دمج خرج مقياس الضغط الجوي (إن كان متوفرًا) مع خرج الارتفاع من GPS (إن كان متوفرًا). إذا كان جهاز GPS متصلًا وتمكن من تحديد الموقع، فسيُعرض الارتفاع المطلق فوق مستوى سطح البحر عند عدم التسليح. وعند التسليح، سيُعرض الارتفاع النسبي إلى الموقع الذي تم عنده التسليح.\n"
+    },
+    "sensorsSonarTitle": {
+        "message": "السونار - سم"
+    },
+    "sensorsDebugTitle": {
+        "message": "تصحيح الأخطاء"
+    },
+    "cliInfo": {
+        "message": "<strong>ملاحظة:<\/strong> ستؤدي مغادرة علامة تبويب CLI أو الضغط على «قطع الاتصال» إلى إرسال الأمر \"<strong>exit<\/strong>\" إلى اللوحة <strong>تلقائيًا<\/strong>. مع أحدث إصدار من البرنامج الثابت، سيؤدي ذلك إلى <strong>إعادة تشغيل<\/strong> وحدة التحكم، وستُفقد التغييرات غير المحفوظة.<p><strong><span class=\"message-negative\">تحذير:<\/span><\/strong> قد تتسبب بعض أوامر CLI في إرسال إشارات غير محددة عبر أطراف خرج المحركات. وقد يؤدي ذلك إلى دوران المحركات إذا كانت البطارية متصلة. لذلك يُوصى بشدة بالتأكد من <strong>عدم توصيل أي بطارية قبل إدخال الأوامر في CLI<\/strong>.\n"
+    },
+    "cliInputPlaceholder": {
+        "message": "اكتب أمرك هنا. اضغط على Tab للإكمال التلقائي."
+    },
+    "cliInputPlaceholderBuilding": {
+        "message": "يرجى الانتظار أثناء بناء ذاكرة التخزين المؤقت للإكمال التلقائي ..."
+    },
+    "cliEnter": {
+        "message": "تم اكتشاف وضع CLI"
+    },
+    "cliDevEnter": {
+        "message": "تم اكتشاف وضع المطور CLI فقط"
+    },
+    "cliReboot": {
+        "message": "تم اكتشاف إعادة تشغيل CLI"
+    },
+    "cliSaveToFileBtn": {
+        "message": "حفظ إلى ملف"
+    },
+    "cliClearOutputHistoryBtn": {
+        "message": "مسح سجل الإخراج"
+    },
+    "cliCopyToClipboardBtn": {
+        "message": "نسخ إلى الحافظة"
+    },
+    "cliCopySuccessful": {
+        "message": "تم النسخ!"
+    },
+    "cliLoadFromFileBtn": {
+        "message": "تحميل من ملف"
+    },
+    "cliSupportRequestBtn": {
+        "message": "إرسال بيانات الدعم"
+    },
+    "cliConfirmSnippetDialogTitle": {
+        "message": "تم تحميل الملف <strong>{{fileName}}<\/strong>. راجع الأوامر المحملة"
+    },
+    "cliConfirmSnippetNote": {
+        "message": "<strong>ملاحظة<\/strong>: يمكنك مراجعة الأوامر وتحريرها قبل التنفيذ."
+    },
+    "cliConfirmSnippetBtn": {
+        "message": "تنفيذ"
+    },
+    "cliSnippetPreviewLabel": {
+        "message": "معاينة المقتطف"
+    },
+    "cliPanelTitle": {
+        "message": "واجهة الأوامر النصية"
+    },
+    "cliCommand": {
+        "message": "أدخل الأمر هنا"
+    },
+    "loggingNote": {
+        "message": "سيتم تسجيل البيانات في علامة التبويب هذه <span class=\"message-negative\">فقط<\/span>. ستؤدي مغادرة علامة التبويب إلى <span class=\"message-negative\">إلغاء<\/span> التسجيل، وسيعود التطبيق إلى حالته الطبيعية.<br \/> يمكنك تحديد فترة التحديث العامة؛ ولأسباب تتعلق بالأداء، ستُكتب البيانات إلى ملف السجل كل <strong>1<\/strong> ثانية.\n"
+    },
+    "loggingPropertiesTitle": {
+        "message": "خصائص السجل"
+    },
+    "loggingSamplingInterval": {
+        "message": "فاصل أخذ العينات:"
+    },
+    "loggingSamplesSaved": {
+        "message": "عدد العينات المحفوظة:"
+    },
+    "loggingLogSize": {
+        "message": "حجم الملف:"
+    },
+    "loggingLogName": {
+        "message": "اسم السجل:"
+    },
+    "loggingButtonLogFile": {
+        "message": "حدد ملف السجل"
+    },
+    "loggingStart": {
+        "message": "بدء التسجيل"
+    },
+    "loggingStop": {
+        "message": "إيقاف التسجيل"
+    },
+    "loggingBack": {
+        "message": "ترك التسجيل\/قطع الاتصال"
+    },
+    "loggingErrorNotConnected": {
+        "message": "أنت بحاجة إلى <strong>الاتصال<\/strong> أولاً"
+    },
+    "loggingErrorLogFile": {
+        "message": "يرجى تحديد ملف"
+    },
+    "loggingErrorOneProperty": {
+        "message": "يرجى اختيار خاصية واحدة على الأقل للتسجيل"
+    },
+    "loggingAutomaticallyRetained": {
+        "message": "تم تحميل ملف السجل السابق تلقائيًا: <strong>$1<\/strong>"
+    },
+    "blackboxNotSupported": {
+        "message": "متحكم الطيران الخاص بك لا يدعم تسجيل الصندوق الأسود."
+    },
+    "blackboxMaybeSupported": {
+        "message": "البرنامج الثابت لمتحكم الطيران الخاص بك أقدم من أن يدعم هذه الميزة، أو تم تعطيل الصندوق الأسود في خيارات البرنامج."
+    },
+    "blackboxConfiguration": {
+        "message": "تكوين الصندوق الأسود"
+    },
+    "blackboxButtonSave": {
+        "message": "حفظ وإعادة التشغيل"
+    },
+    "blackboxLoggingNone": {
+        "message": "لا تسجيل"
+    },
+    "blackboxLoggingFlash": {
+        "message": "ذاكرة التخزين المدمجة"
+    },
+    "blackboxLoggingSdCard": {
+        "message": "بطاقة SD"
+    },
+    "blackboxLoggingSerial": {
+        "message": "منفذ تسلسلي"
+    },
+    "blackboxLoggingVirtual": {
+        "message": "إلى ملف"
+    },
+    "serialLoggingSupportedNote": {
+        "message": "يمكنك التسجيل إلى جهاز تسجيل خارجي (مثل OpenLager) باستخدام منفذ تسلسلي. قم بتكوين المنفذ في علامة تبويب المنافذ."
+    },
+    "sdcardNote": {
+        "message": "يمكن تسجيل سجلات الطيران إلى فتحة بطاقة SD المدمجة في متحكم الطيران الخاص بك."
+    },
+    "dataflashUsedSpace": {
+        "message": "المساحة المستخدمة"
+    },
+    "dataflashFreeSpace": {
+        "message": "المساحة الحرة"
+    },
+    "dataflashUnavSpace": {
+        "message": "مساحة غير متوفرة"
+    },
+    "dataflashLogsSpace": {
+        "message": "مساحة حرة للسجلات"
+    },
+    "dataflashNote": {
+        "message": "يمكن تسجيل سجلات الطيران إلى شريحة الذاكرة التخزين المدمجة في متحكم الطيران الخاص بك."
+    },
+    "dataflashNotPresentNote": {
+        "message": "لا يحتوي متحكم الطيران الخاص بك على شريحة ذاكرة تخزين متوافقة متاحة."
+    },
+    "dataflashButtonSaveFile": {
+        "message": "حفظ الذاكرة التخزين إلى ملف..."
+    },
+    "dataflashSavetoFileNote": {
+        "message": "يعد حفظ الذاكرة التخزين مباشرة إلى ملف بطيئًا وعرضة للخطأ \/ تلف الملف بشكل متأصل.<br>في بعض الحالات، سيعمل مع الملفات الصغيرة، ولكن هذا غير مدعوم وسيتم إغلاق طلبات الدعم الخاصة به دون تعليق - استخدم وضع تخزين USB بدلاً من ذلك."
+    },
+    "dataflashSaveFileDepreciationHint": {
+        "message": "هذه الطريقة بطيئة وعرضة للخطأ \/ تلف الملف بشكل متأصل، لأن اتصال MSP نفسه له قيود جوهرية أساسية تجعله غير مناسب لعمليات نقل الملفات. قد يعمل فقط مع ملفات السجلات الصغيرة. لا تقدم طلبات دعم إذا فشلت عمليات نقل الملفات عند حفظها باستخدام هذه الطريقة. الطريقة الموصى بها هي استخدام '<b>$t(onboardLoggingRebootMscText.message)<\/b>' (أدناه) لتفعيل وضع تخزين USB، والوصول إلى متحكم الطيران الخاص بك كجهاز تخزين لتنزيل ملفات السجل."
+    },
+    "dataflashButtonSaveAndErase": {
+        "message": "حفظ ومسح",
+        "description": "Button text to save blackbox logs to file and then erase the flash"
+    },
+    "dataflashButtonErase": {
+        "message": "مسح الذاكرة التخزين "
+    },
+    "dataflashConfirmEraseTitle": {
+        "message": "تأكيد مسح الذاكرة التخزين "
+    },
+    "dataflashConfirmEraseNote": {
+        "message": "سيؤدي هذا إلى محو أي سجلات للصندوق الأسود أو غيرها من البيانات الموجودة في الذاكرة التخزين . وينبغي أن يستغرق حوالي 20 ثانية، هل أنت متأكد؟"
+    },
+    "dataflashSavingTitle": {
+        "message": "جاري حفظ الذاكرة التخزين إلى الملف"
+    },
+    "dataflashSavingNote": {
+        "message": "قد يستغرق الحفظ بضع دقائق. يرجى الانتظار."
+    },
+    "dataflashSavingNoteAfter": {
+        "message": "اكتمل الحفظ! اضغط \"موافق\" للمتابعة."
+    },
+    "dataflashButtonSaveCancel": {
+        "message": "إلغاء"
+    },
+    "dataflashButtonSaveDismiss": {
+        "message": "موافق"
+    },
+    "dataflashButtonEraseConfirm": {
+        "message": "نعم، امسح الذاكرة التخزين "
+    },
+    "dataflashButtonEraseCancel": {
+        "message": "إلغاء"
+    },
+    "dataflashFileWriteFailed": {
+        "message": "فشل الكتابة إلى الملف الذي حددته، هل أذونات هذا المجلد على ما يرام؟"
+    },
+    "sdcardStatusNoCard": {
+        "message": "لم يتم إدخال بطاقة"
+    },
+    "sdcardStatusReboot": {
+        "message": "خطأ فادح<br>أعد التشغيل لإعادة المحاولة"
+    },
+    "sdcardStatusReady": {
+        "message": "البطاقة جاهزة"
+    },
+    "sdcardStatusStarting": {
+        "message": "جاري بدء البطاقة..."
+    },
+    "sdcardStatusFileSystem": {
+        "message": "جاري بدء نظام الملفات..."
+    },
+    "sdcardStatusUnknown": {
+        "message": "حالة غير معروفة$1"
+    },
+    "firmwareFlasherPleaseWait": {
+        "message": "يرجى الانتظار"
+    },
+    "firmwareFlasherBoardSelectionHead": {
+        "message": "اختيار لوحة التحكم"
+    },
+    "firmwareFlasherBranch": {
+        "message": "حدد طلب السحب أو الالتزام"
+    },
+    "firmwareFlasherReleaseSummaryHead": {
+        "message": "معلومات الإصدار والبناء"
+    },
+    "firmwareFlasherReleaseManufacturer": {
+        "message": "معرف الشركة المصنعة:"
+    },
+    "firmwareFlasherReleaseVersion": {
+        "message": "الإصدار:"
+    },
+    "firmwareFlasherReleaseVersionUrl": {
+        "message": "قم بزيارة صفحة الإصدار."
+    },
+    "firmwareFlasherReleaseNotes": {
+        "message": "بيانات الإصدار:"
+    },
+    "firmwareFlasherReleaseDate": {
+        "message": "التاريخ:"
+    },
+    "firmwareFlasherReleaseTarget": {
+        "message": "الهدف:"
+    },
+    "firmwareFlasherTargetWikiUrlInfo": {
+        "message": "احصل على مزيد من المعلومات حول الهدف على ويكي Betaflight",
+        "description": "Link to Betaflight support for target"
+    },
+    "firmwareFlasherReleaseMCU": {
+        "message": "وحدة التحكم الدقيقة:"
+    },
+    "firmwareFlasherCloudBuildDetails": {
+        "message": "تفاصيل بناء السحابة:"
+    },
+    "firmwareFlasherCloudBuildLogUrl": {
+        "message": "إظهار السجل"
+    },
+    "firmwareFlasherCloudBuildStatus": {
+        "message": "حالة البناء:"
+    },
+    "firmwareFlasherFlashStatus": {
+        "message": "حالة التحديث:"
+    },
+    "firmwareFlasherCloudBuildQueued": {
+        "message": "في قائمة الانتظار"
+    },
+    "firmwareFlasherCloudBuildPending": {
+        "message": "قيد الانتظار"
+    },
+    "firmwareFlasherCloudBuildProcessing": {
+        "message": "قيد المعالجة"
+    },
+    "firmwareFlasherCloudBuildSuccessCached": {
+        "message": "ناجح (مخزّن مؤقتًا)\n"
+    },
+    "firmwareFlasherCloudBuildSuccess": {
+        "message": "نجاح"
+    },
+    "firmwareFlasherCloudBuildFailCancel": {
+        "message": "تم الإلغاء"
+    },
+    "firmwareFlasherCloudBuildFailTimeOut": {
+        "message": "انتهى الوقت (يرجى إعادة المحاولة)"
+    },
+    "firmwareFlasherCloudBuildFailRequest": {
+        "message": "خطأ في طلب البناء (يرجى التحقق من إعدادات البناء، مثل التعريفات المخصصة)"
+    },
+    "firmwareFlasherCloudBuildFail": {
+        "message": "فشل (يرجى التحقق من السجل)"
+    },
+    "firmwareFlasherReleaseFileUrl": {
+        "message": "تحميل يدوي."
+    },
+    "firmwareFlasherTargetWarning": {
+        "message": "<span class=\"message-negative\">مهم<\/span>: تأكد من تثبيت ملف مناسب لهدفك. يمكن أن يؤدي تثبيت هدف خاطئ إلى حدوث أشياء <span class=\"message-negative\">سيئة<\/span>."
+    },
+    "firmwareFlasherPath": {
+        "message": "المسار:"
+    },
+    "firmwareFlasherSize": {
+        "message": "الحجم:"
+    },
+    "firmwareFlasherStatus": {
+        "message": "الحالة:"
+    },
+    "firmwareFlasherProgress": {
+        "message": "التقدم:"
+    },
+    "firmwareFlasherLoadFirmwareFile": {
+        "message": "يرجى تحميل ملف البرنامج الثابت"
+    },
+    "firmwareFlasherLoadedConfig": {
+        "message": "تم تحميل الهدف، يرجى تحميل ملف البرنامج الثابت"
+    },
+    "firmwareFlasherNoReboot": {
+        "message": "بدون تسلسل إعادة تشغيل"
+    },
+    "firmwareFlasherOnlineSelectBuildType": {
+        "message": "حدد نوع البناء لرؤية اللوحات المتاحة."
+    },
+    "firmwareFlasherOnlineSelectBoardDescription": {
+        "message": "حدد أو اكتشف لوحتك لرؤية إصدارات البرنامج الثابت المتاحة عبر الإنترنت - حدد البرنامج الثابت الصحيح المناسب للوحتك."
+    },
+    "firmwareFlasherOnlineSelectBoardHint": {
+        "message": "يدعم تطبيق Betaflight تثبيت الأهداف الموحّدة مع الإعدادات الخاصة بكل لوحة في خطوة واحدة.<br><br>يعني مفهوم الأهداف الموحّدة أنه يمكن استخدام ملف البرنامج الثابت نفسه بامتداد .hex لجميع اللوحات التي تستخدم MCU نفسه.<br><br>يقدم Betaflight 4.4 ميزة <strong>البناء السحابي<\/strong><br><br>مع <strong>البناء السحابي<\/strong>، نحتاج إلى تحديد خيارات العتاد الموجودة في تجميعتك.<br><br>لتمكين اللوحات المختلفة من العمل بالبرنامج الثابت نفسه، يتم تثبيت ملف إعدادات خاص إلى جانب البرنامج الثابت عند تفليش هدف موحّد.<br><br>مع البناء المحلي، يمكنك تحميل ملف إعدادات لهدف موحّد أو اختيار لوحة قبل تحميل ملف البرنامج الثابت بامتداد .hex.<br><br>إذا واجهت مشكلات أثناء استخدام البرنامج الثابت، فيرجى التفكير في الانضمام إلى Discord أو فتح <a href=\"https:\/\/github.com\/betaflight\/betaflight\/issues\" target=\"_blank\" rel=\"noopener noreferrer\">بلاغ<\/a>.\n"
+    },
+    "firmwareFlasherOnlineSelectFirmwareVersionDescription": {
+        "message": "حدد إصدار البرنامج الثابت للوحتك."
+    },
+    "firmwareFlasherNoRebootDescription": {
+        "message": "فعّل هذا الخيار إذا كانت FC في bootloader ، أي إذا شغّلت FC أثناء توصيل أطراف bootloader ببعضها أو مع الاستمرار في الضغط على زر BOOT الخاص بها.\n"
+    },
+    "firmwareFlasherFlashOnConnect": {
+        "message": "التثبيت عند الاتصال"
+    },
+    "firmwareFlasherFlashOnConnectDescription": {
+        "message": "محاولة تثبيت اللوحة تلقائيًا (يتم تشغيلها بواسطة منفذ تسلسلي مكتشف حديثًا).<br \/><br \/><span class=\"message-negative\">تحذير<\/span>: تعطل هذه الوظيفة مميزات الكشف والنسخ الاحتياطي."
+    },
+    "firmwareFlasherFullChipErase": {
+        "message": "مسح الشريحة بالكامل"
+    },
+    "firmwareFlasherFullChipEraseDescription": {
+        "message": "يمسح جميع بيانات التكوين المخزنة حاليًا على اللوحة."
+    },
+    "firmwareFlasherFlashDevelopmentFirmware": {
+        "message": "استخدم البرنامج الثابت للتطوير"
+    },
+    "firmwareFlasherFlashDevelopmentFirmwareDescription": {
+        "message": "ثبت أحد برامج التطوير البرنامج الثابت."
+    },
+    "firmwareFlasherManualPort": {
+        "message": "المنفذ"
+    },
+    "firmwareFlasherManualBaud": {
+        "message": "معدل الباود اليدوي"
+    },
+    "firmwareFlasherManualBaudDescription": {
+        "message": "الاختيار اليدوي لمعدل الباود للوحات التي لا تدعم السرعة الافتراضية أو للتثبيت عبر البلوتوث.<br \/><span class=\"message-negative\">ملاحظة:<\/span> لا يتم استخدامه عند التثبيت عبر USB DFU"
+    },
+    "firmwareFlasherBaudRate": {
+        "message": "معدل الباود"
+    },
+    "firmwareFlasherShowDevelopmentReleases": {
+        "message": "عرض الإصدارات المرشحة\n"
+    },
+    "firmwareFlasherShowDevelopmentReleasesDescription": {
+        "message": "إظهار الإصدارات المرشحة بالإضافة إلى الإصدارات المستقرة"
+    },
+    "firmwareFlasherOptionLoading": {
+        "message": "جارٍ التحميل ..."
+    },
+    "firmwareFlasherOptionLabelBuildTypeRelease": {
+        "message": "الإصدار"
+    },
+    "firmwareFlasherOptionLabelBuildTypeReleaseCandidate": {
+        "message": "الإصدار والإصدار المرشح"
+    },
+    "firmwareFlasherOptionLabelBuildTypeDevelopment": {
+        "message": "المطوّر"
+    },
+    "firmwareFlasherOptionLabelBuildTypeAKK3_3": {
+        "message": "رقع AKK & RDQ VTX 3.3"
+    },
+    "firmwareFlasherOptionLabelBuildTypeAKK3_4": {
+        "message": "رقع AKK & RDQ VTX 3.4"
+    },
+    "firmwareFlasherOptionLabelSelectFirmware": {
+        "message": "اختر برنامج ثابت \/ لوحة"
+    },
+    "firmwareFlasherOptionLabelSelectBoard": {
+        "message": "أختر اللوحة الإلكترونية"
+    },
+    "firmwareFlasherOptionLabelSelectFirmwareVersion": {
+        "message": "أختر أصدار البرنامج الثابت"
+    },
+    "firmwareFlasherOptionLabelSelectFirmwareVersionFor": {
+        "message": "أختر أصدار البرنامج الثابت الخاص ب"
+    },
+    "firmwareFlasherButtonLoadLocal": {
+        "message": "حمّل البرنامج الثابت [محلي]"
+    },
+    "firmwareFlasherButtonLoadOnline": {
+        "message": "حمّل البرنامج الثابت [عبر الإنترنت]"
+    },
+    "firmwareFlasherButtonDownloading": {
+        "message": "جارٍ التحميل..."
+    },
+    "firmwareFlasherExitDfu": {
+        "message": "الخروج من وضع DFU"
+    },
+    "firmwareFlasherFindDfuDevice": {
+        "message": "البحث عن جهاز DFU"
+    },
+    "firmwareFlasherFlashFirmware": {
+        "message": "البرنامج الثابت للتحديث"
+    },
+    "firmwareFlasherFlashFirmwareOptions": {
+        "message": "خيارات تثبيت Firmware"
+    },
+    "firmwareFlasherLoadFirmwareOptions": {
+        "message": "خيارات تحميل Firmware"
+    },
+    "firmwareFlasherFlashingProgress": {
+        "message": "تقدّم التثبيت",
+        "description": "Accessible label for the circular progress ring shown during firmware flashing."
+    },
+    "firmwareFlasherGithubInfoHead": {
+        "message": "معلومات البرنامج الثابت من GitHub"
+    },
+    "firmwareFlasherCommiter": {
+        "message": "معلق:"
+    },
+    "firmwareFlasherDate": {
+        "message": "تاريخ:"
+    },
+    "firmwareFlasherHash": {
+        "message": "التجزئة:"
+    },
+    "firmwareFlasherUrl": {
+        "message": "أذهب الى GitHub لأستعراض هذا التعليق..."
+    },
+    "firmwareFlasherMessage": {
+        "message": "رسالة:"
+    },
+    "firmwareFlasherWarningText": {
+        "message": "يرجى <span class=\"message-negative\">عدم<\/span> محاولة تثبيت <strong>غير مخصص لـ Betaflight<\/strong> باستخدام أداة تثبيت البرنامج الثابت هذه.<br \/><span class=\"message-negative\">لا<\/span> <strong>تفصل<\/strong> اللوحة أو <strong>توقف تشغيل<\/strong> الكمبيوتر أثناء التثبيت .<br \/><br \/><strong>ملاحظة:<\/strong><ul><li>محمّل الإقلاع STM32 مخزّن في ذاكرة ROM، لذلك لا يمكن تعطيله نهائيًا.<\/li><li>تكون ميزة <span class=\"message-negative\">الاتصال التلقائي<\/span> معطّلة دائمًا أثناء استخدام أداة تثبيت البرنامج الثابت.<\/li><li>تأكد من وجود نسخة احتياطية؛ فقد تؤدي بعض عمليات الترقية أو الرجوع إلى إصدار أقدم إلى مسح إعداداتك.<\/li><li>إذا واجهت مشكلات في التثبيت، <strong>فجرّب أولًا فصل جميع الكابلات عن FC<\/strong>، ثم حاول إعادة التشغيل وتحديث برامج التشغيل.<\/li><li>عند تثبيت اللوحات المزودة بمنافذ USB متصلة مباشرةً (معظم اللوحات الحديثة)، تأكد من قراءة قسم التثبيت عبر USB في دليل Betaflight، ومن تثبيت البرامج وبرامج التشغيل الصحيحة.<\/li><\/ul>\n"
+    },
+    "firmwareFlasherWarningShort": {
+        "message": "لا تقم بتحديث أجهزة غير مدعومة من Betaflight. لا تفصل الاتصال أثناء عملية التحديث."
+    },
+    "firmwareFlasherRecoveryHead": {
+        "message": "الاستعادة \/ فقدان الاتصال"
+    },
+    "firmwareFlasherRecoveryText": {
+        "message": "إذا فقدت الاتصال بلوحة التحكم، فاتبع الخطوات التالية لاستعادة الاتصال:<ul><li>افصل الطاقة.<\/li><li>فعّل 'No reboot sequence' وفعّل 'Full chip erase'.<\/li><li>قم بتوصيل نقاط BOOT أو اضغط باستمرار على زر BOOT.<\/li><li>شغّل الطاقة (لن يومض مؤشر Activity LED إذا تم ذلك بشكل صحيح).<\/li><li>ثبّت جميع تعريفات STM32 باستخدام Zadig إذا لزم الأمر (راجع قسم <a href=\"https:\/\/betaflight.com\/docs\/wiki\/getting-started\/firmware-installation\" target=\"_blank\" rel=\"noopener noreferrer\">USB Flashing<\/a> في دليل Betaflight).<\/li><li>أغلق التطبيق، ثم أعد تشغيله.<\/li><li>حرّر زر BOOT إذا كانت لوحة FC تحتوي عليه.<\/li><li>قم بتفليش Firmware الصحيح (استخدم معدل Baud يدويًا إذا كان محددًا في دليل الـFC).<\/li><li>افصل الطاقة.<\/li><li>أزل وصلة BOOT.<\/li><li>شغّل الطاقة (يجب أن يومض مؤشر Activity LED).<\/li><li>اتصل بشكل طبيعي.<\/li><\/ul>"
+    },
+    "firmwareFlasherRecoveryShort": {
+        "message": "إذا فقدت الاتصال: افصل الطاقة، وفعّل No Reboot Sequence وFull Chip Erase، ثم قم بتوصيل نقاط BOOT وشغّل الطاقة. ثبّت التعريفات إذا لزم الأمر."
+    },
+    "firmwareFlasherReadMore": {
+        "message": "اقرأ المزيد ←"
+    },
+    "firmwareFlasherSubTabBoardBuild": {
+        "message": "اللوحة والبناء"
+    },
+    "firmwareFlasherAdvancedTitle": {
+        "message": "متقدم"
+    },
+    "firmwareFlasherSubTabFlash": {
+        "message": "تثبيت"
+    },
+    "firmwareFlasherButtonLeave": {
+        "message": "غادر أداة تثبيت البرنامج"
+    },
+    "firmwareFlasherFirmwareNotLoaded": {
+        "message": "لم يتم تحميل البرنامج الثابت"
+    },
+    "firmwareFlasherFirmwareLoaded": {
+        "message": "البرنامج الثابت"
+    },
+    "firmwareFlasherFirmwareSize": {
+        "message": "{{bytes}} بايت"
+    },
+    "firmwareFlasherFirmwareLocalLoaded": {
+        "message": "تم تحميل البرنامج الثابت المحلي: {{filename}} ({{bytes}} بايت)"
+    },
+    "firmwareFlasherFirmwareOnlineLoaded": {
+        "message": "تم تحميل البرنامج الثابت عبر الإنترنت: {{filename}} ({{bytes}} بايت)"
+    },
+    "firmwareFlasherTooltipSaveFirmware": {
+        "message": "حفظ البرنامج الثابت"
+    },
+    "firmwareFlasherInvalidFileFormat": {
+        "message": "تنسيق الملف غير صالح"
+    },
+    "firmwareFlasherUf2Corrupted": {
+        "message": "يبدو أن ملف UF2 تالف"
+    },
+    "firmwareFlasherHexCorrupted": {
+        "message": "يبدو أن ملف HEX تالف"
+    },
+    "firmwareFlasherUF2SaveSuccess": {
+        "message": "Saved (flashed) UF2 successfully"
+    },
+    "firmwareFlasherUF2SaveFailed": {
+        "message": "فشل في حفظ (تثبيت) UF2"
+    },
+    "firmwareFlasherEsp32Connecting": {
+        "message": "جارٍ الاتصال ببرنامج إقلاع ESP32..."
+    },
+    "firmwareFlasherEsp32Detected": {
+        "message": "تم اكتشاف $1"
+    },
+    "firmwareFlasherEsp32Flashing": {
+        "message": "جارٍ تثبيت ESP32..."
+    },
+    "firmwareFlasherEsp32Rebooting": {
+        "message": "اكتمل التثبيت، جارٍ إعادة التشغيل..."
+    },
+    "firmwareFlasherEsp32Complete": {
+        "message": "تم تثبيت ESP32 بنجاح"
+    },
+    "firmwareFlasherEsp32Failed": {
+        "message": "فشل تثبيت  ESP32: $1"
+    },
+    "firmwareFlasherEsp32NotSupported": {
+        "message": "يتطلب تثبيت  ESP32 إصدار المتصفح (Web Serial)"
+    },
+    "firmwareFlasherEsp32NoPort": {
+        "message": "اختر منفذ Serial قبل تثبيت ESP32"
+    },
+    "firmwareFlasherClickToConnectDfu": {
+        "message": "انقر للاتصال بجهاز DFU"
+    },
+    "firmwareFlasherConfigCorrupted": {
+        "message": "يبدو أن ملف الإعدادات تالف، يتم قبول ASCII (الحروف 0-255)",
+        "description": "shown in the progress bar at the bottom, be brief"
+    },
+    "firmwareFlasherConfigCorruptedLogMessage": {
+        "message": "يبدو أن ملف الإعدادات تالف، يتم قبول ASCII (الحروف 0-255)، يُسمح بالأحرف خارج هذا النطاق كتعليقات",
+        "description": "shown in the log, more wordy"
+    },
+    "firmwareFlasherRemoteFirmwareLoaded": {
+        "message": "<span class=\"message-positive\">تم تحميل البرنامج الثابت ، جاهز للتثبيت<\/span>"
+    },
+    "firmwareFlasherFailedToLoadOnlineFirmware": {
+        "message": "فشل تحميل برنامج ثابت خارجي"
+    },
+    "firmwareFlasherFailedToLoadUnifiedConfig": {
+        "message": "فشل تحميل إعداد {{remote_file}} من الخادم\n"
+    },
+    "firmwareFlasherCanceledBackup": {
+        "message": "تم إلغاء النسخ الاحتياطي، تم إحباط التثبيت"
+    },
+    "firmwareFlasherBackupInvalidData": {
+        "message": "فشل النسخ الاحتياطي: تم استلام بيانات غير صالحة من الجهاز (ليس في وضع CLI)، تم إلغاء التثبيت"
+    },
+    "firmwareFlasherLegacyLabel": {
+        "message": "{{target}} (قديم)",
+        "description": "If we have a Unified target and a old style target available, we are labeling the older one"
+    },
+    "firmwareFlasherNoFirmwareSelected": {
+        "message": "<b>لم يتم أختيار برنامج ثابت لتحميلة<\/b>"
+    },
+    "firmwareFlasherNoTargetsLoaded": {
+        "message": "لم يتم تحميل أي أهداف"
+    },
+    "firmwareFlasherNoValidPort": {
+        "message": "<span class=\"message-negative\">يرجى تحديد منفذ تسلسلي صالح<\/span>"
+    },
+    "firmwareFlasherWritePermissions": {
+        "message": "ليس لديك <span class=\"message-negative\">أذونات الكتابة<\/span> لهذا الملف"
+    },
+    "firmwareFlasherFlashTrigger": {
+        "message": "تم الكشف عن: <strong>$1<\/strong> - سيتم تشغيل التثبيت عند الاتصال"
+    },
+    "firmwareFlasherVerifyBoard": {
+        "message": "<h3>عدم تطابق البرنامج الثابت<\/h3><br \/>اللوحة المتصلة هي <strong>{{verified_board}}<\/strong>، بينما اخترت <strong>{{selected_board}}<\/strong>.<br \/><br \/>هل تريد متابعة التثبيت؟\n",
+        "description": "Make a quick connection to read firmware target and never flash a wrong target again"
+    },
+    "firmwareFlasherBoardVerificationSuccess": {
+        "message": "التطبيق <span class=\"message-positive\">نجح<\/span> في الكشف عن اللوحة والتحقق منها: <strong>{{boardName}}<\/strong>",
+        "description": "Board verification has succeeded."
+    },
+    "firmwareFlasherBoardVerficationTargetNotAvailable": {
+        "message": "التطبيق اكتشف اللوحة: <strong>{{boardName}}<\/strong> ولكن لم يتم العثور على هدف Betaflight رسمي",
+        "description": "Board verification has succeeded, but the target is not available as official Betaflight target."
+    },
+    "firmwareFlasherBoardVerificationFail": {
+        "message": "<span class=\"message-negative\">فشل<\/span> التطبيق في التحقق من اللوحة. إذا استمرت المشكلة، فجرّب الانتقال إلى علامة تبويب أخرى ثم أعد المحاولة، أو أعد توصيل كابل USB، أو اتصل باللوحة أولًا إذا كنت قد نسيت تطبيق الإعدادات الافتراضية المخصصة.\n",
+        "description": "Sometimes MSP values cannot be read from firmware correctly"
+    },
+    "firmwareFlasherButtonAbort": {
+        "message": "إلغاء"
+    },
+    "firmwareFlasherButtonContinue": {
+        "message": "متابعة"
+    },
+    "firmwareFlasherDetectBoardButton": {
+        "message": "اكتشاف"
+    },
+    "firmwareFlasherDetectBoardDescriptionHint": {
+        "message": "يعمل الاكتشاف فقط عندما لا تكون في وضع DFU وعندما يعمل اتصال MSP. في بعض الأحيان يجب أن تعيد المحاولة عدة مرات أو حتى إعادة توصيل USB. حاول الاتصال بشكل طبيعي أولاً لأنه قد تكون نسيت تطبيق الإعدادات الافتراضية المخصصة. يرجى إعادة التشغيل بعد التثبيت - أعد توصيل USB الخاص بك."
+    },
+    "firmwareFlasherDetectBoardQuery": {
+        "message": "استعلام معلومات اللوحة للتحديد المسبق للبرنامج الثابت الصحيح"
+    },
+    "unstableFirmwareAcknowledgementDialog": {
+        "message": "أنت على وشك تثبيت <strong>إصدار تطويري من البرنامج الثابت<\/strong>. هذه الإصدارات لا تزال قيد التطوير، وقد تنطبق عليها أي من الحالات التالية:<strong><ul><li>قد لا يعمل البرنامج الثابت إطلاقًا؛<\/li><li>قد يكون البرنامج الثابت غير صالح للطيران؛<\/li><li>قد توجد مشكلات متعلقة بالسلامة في البرنامج الثابت، مثل الطيران غير المنضبط<\/li><li>قد يتسبب البرنامج الثابت في توقف وحدة التحكم بالطيران عن الاستجابة أو تلفها<\/li><\/ul><\/strong>إذا تابعت تثبيت هذا البرنامج الثابت، <strong>فأنت تتحمل كامل المسؤولية عن مخاطر وقوع أي مما سبق<\/strong>. كما أنك تقر بضرورة إجراء <strong>اختبارات شاملة على المنضدة مع إزالة المراوح<\/strong> قبل أي محاولة للطيران باستخدام هذا البرنامج الثابت.\n"
+    },
+    "unstableFirmwareAcknowledgement": {
+        "message": "لقد قرأت ما سبق و<strong>أتحمل المسؤولية الكاملة<\/strong> عن تثبيت Firmware غير مستقر"
+    },
+    "unstableFirmwareAcknowledgementFlash": {
+        "message": "تثبيت"
+    },
+    "firmwareFlasherRemindBackupTitle": {
+        "message": "مسح الإعدادات",
+        "description": "Warning message title before actual flashing takes place"
+    },
+    "firmwareFlasherRemindBackup": {
+        "message": "سيؤدي تثبيت برنامج ثابت جديد إلى مسح جميع الإعدادات. نوصي بشدة بحفظ نسخة احتياطية قبل المتابعة.",
+        "description": "Warning message before actual flashing takes place"
+    },
+    "firmwareFlasherBackup": {
+        "message": "إنشاء نسخة احتياطية",
+        "description": "Create a backup before actual flashing takes place"
+    },
+    "firmwareFlasherBackupIgnore": {
+        "message": "تجاهل المخاطرة",
+        "description": "Ignore creating a backup before actual flashing takes place"
+    },
+    "firmwareBackupEnabled": {
+        "message": "تم تمكين النسخ الاحتياطي"
+    },
+    "firmwareBackupDisabled": {
+        "message": "تم تعطيل النسخ الاحتياطي"
+    },
+    "firmwareBackupAsk": {
+        "message": "اسأل قبل النسخ الاحتياطي"
+    },
+    "ledStripHelp": {
+        "message": "يمكن لوحدة التحكم الطيرانية التحكم في الألوان والتأثيرات لمصابيح LED الفردية على الشريط.<br \/> قم بإعداد مصابيح LED على الشبكة، وقم بإعداد ترتيب التوصيل ثم قم بتثبيت مصابيح LED على طائرتك وفقًا لمواقع الشبكة. لن يتم حفظ مصابيح LED التي لا تحتوي على رقم ترتيب توصيل.<br \/> انقر نقرًا مزدوجًا على اللون لتحرير قيم HSV."
+    },
+    "ledStripButtonSave": {
+        "message": "حفظ"
+    },
+    "ledStripColorSetupTitle": {
+        "message": "ضبط اللون",
+        "description": "Color setup title of the led strip"
+    },
+    "ledStripH": {
+        "message": "H",
+        "description": "Abbreviation of Hue in HSV (Hue, Saturation, Brightness) color model"
+    },
+    "ledStripS": {
+        "message": "S",
+        "description": "Abbreviation of Saturation in HSV  (Hue, Saturation, Brightness) color model"
+    },
+    "ledStripV": {
+        "message": "V",
+        "description": "Abbreviation of Brightness in HSV  (Hue, Saturation, Brightness) color model"
+    },
+    "ledStripRemainingText": {
+        "message": "المتبقى",
+        "description": "In the LED STRIP, text next the counter of leds remaining"
+    },
+    "ledStripClearSelectedButton": {
+        "message": "مسح المحدد",
+        "description": "In the LED STRIP, clear selected leds"
+    },
+    "ledStripClearAllButton": {
+        "message": "مسح الكل",
+        "description": "In the LED STRIP, clear all leds"
+    },
+    "ledStripVtxOverlay": {
+        "message": "VTX (يستخدم تردد VTX لتعيين اللون)"
+    },
+    "ledStripBrightnessSliderTitle": {
+        "message": "السطوع",
+        "description": "Brightness of the LED Strip"
+    },
+    "ledStripBrightnessSliderHelp": {
+        "message": "النسبة المئوية للسطوع الأقصى لمصابيح LED."
+    },
+    "ledStripRainbowDeltaSliderTitle": {
+        "message": "دلتا",
+        "description": "LED Strip rainbow effect delta"
+    },
+    "ledStripRainbowDeltaSliderHelp": {
+        "message": "فرق اللون بين كل مصباح LED.",
+        "description": "Hint on LED Strip tab for rainbow delta"
+    },
+    "ledStripRainbowFreqSliderTitle": {
+        "message": "التردد",
+        "description": "LED Strip rainbow effect frequency"
+    },
+    "ledStripRainbowFreqSliderHelp": {
+        "message": "تردد تغير اللون، بعبارة أخرى سرعة التأثير.",
+        "description": "Hint on LED Strip tab for rainbow frequency"
+    },
+    "ledStripFunctionSection": {
+        "message": "وظائف LED"
+    },
+    "ledStripFunctionTitle": {
+        "message": "وظيفة"
+    },
+    "ledStripFunctionNoneOption": {
+        "message": "لا يوجد",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionColorOption": {
+        "message": "لون",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionModesOption": {
+        "message": "الأوضاع والاتجاه",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionArmOption": {
+        "message": "حالة التشغيل",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionBatteryOption": {
+        "message": "البطارية",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionRSSIOption": {
+        "message": "قوة الإشارة",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionGPSOption": {
+        "message": "نظام تحديد المواقع",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionGPSBarOption": {
+        "message": "شريط GPS",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionBatteryBarOption": {
+        "message": "شريط البطارية",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionAltitudeOption": {
+        "message": "الارتفاع",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionRingOption": {
+        "message": "حلقة",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripColorModifierTitle": {
+        "message": "مصحح اللون"
+    },
+    "ledStripModeColorsTitle": {
+        "message": "ألوان النمط"
+    },
+    "ledStripModeColorsModeOrientation": {
+        "message": "اتجاه",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeHeadfree": {
+        "message": "بلا اتجاه\n",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeHorizon": {
+        "message": "الأفق",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeAngle": {
+        "message": "زاوية",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeMag": {
+        "message": "المغناطيسة",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeBaro": {
+        "message": "الضغط",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripDirN": {
+        "message": "ش",
+        "description": "North direction in Color Mode in Led Strip"
+    },
+    "ledStripDirE": {
+        "message": "شرق",
+        "description": "East direction in Color Mode in Led Strip"
+    },
+    "ledStripDirS": {
+        "message": "جنوب",
+        "description": "South direction in Color Mode in Led Strip"
+    },
+    "ledStripDirW": {
+        "message": "غرب",
+        "description": "West direction in Color Mode in Led Strip"
+    },
+    "ledStripDirU": {
+        "message": "أ",
+        "description": "Up direction in Color Mode in Led Strip"
+    },
+    "ledStripDirD": {
+        "message": "D",
+        "description": "Down direction in Color Mode in Led Strip"
+    },
+    "ledStripModesOrientationTitle": {
+        "message": "اتجاه LED ('الأوضاع والاتجاه') واللون",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModesSpecialColorsTitle": {
+        "message": "ألوان خاصة",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeDisarmed": {
+        "message": "إلغاء التفعيل",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeArmed": {
+        "message": "مفعل",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeAnimation": {
+        "message": "المؤثرات الحركية",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeBlinkBg": {
+        "message": "خلفية الوميض",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeGPSNoSats": {
+        "message": "GPS: لا توجد اقمار",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeGPSNoLock": {
+        "message": "GPS: لا يوجد قفل",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeGPSLocked": {
+        "message": "GPS: تم القفل",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeGpsDefault": {
+        "message": "Default",
+        "description": "One of the modes in GPS Mode in Led Strip"
+    },
+    "ledStripModeGpsBar": {
+        "message": "Bar",
+        "description": "One of the modes in GPS Mode in Led Strip"
+    },
+    "ledStripWiring": {
+        "message": "LED Strip Wiring",
+        "description": "One of the modes in Led Strip"
+    },
+    "ledStripWiringMode": {
+        "message": "Wire Ordering Mode",
+        "description": "One of the wiring modes in Led Strip"
+    },
+    "ledStripWiringClearControl": {
+        "message": "مسح المحدد",
+        "description": "Control button in the wiring modes in Led Strip"
+    },
+    "ledStripWiringClearAllControl": {
+        "message": "مسح كل الأسلاك",
+        "description": "Control button in the wiring modes in Led Strip"
+    },
+    "ledStripWiringMessage": {
+        "message": "لن يتم حفظ مصابيح LED التي لا تحتوي على رقم ترتيب توصيل.",
+        "description": "Message in the wiring modes in Led Strip"
+    },
+    "ledStripLarsonOverlay": {
+        "message": "ماسح Larson",
+        "description": "Larson effect switch label on LED Strip tab"
+    },
+    "ledStripBlinkAlwaysOverlay": {
+        "message": "وميض دائماً"
+    },
+    "ledStripThrottleHue": {
+        "message": "لون Throttle",
+        "description": "Label of throttle hue modifier switch on LED Strip tab"
+    },
+    "ledStripThrottleHueChannel": {
+        "message": "قناة لون Throttle",
+        "description": "Accessible label for the aux-channel select next to the throttle hue switch"
+    },
+    "ledStripRainbowOverlay": {
+        "message": "Rainbow",
+        "description": "Label of rainbow effect switch on LED Strip tab"
+    },
+    "ledStripOverlayTitle": {
+        "message": "تراكب طبقات"
+    },
+    "ledStripWarningsOverlay": {
+        "message": "تحذيرات"
+    },
+    "ledStripIndecatorOverlay": {
+        "message": "مؤشر (يستخدم موقعه على الشبكة)"
+    },
+    "colorBlack": {
+        "message": "الأسود"
+    },
+    "colorWhite": {
+        "message": "الأبيض"
+    },
+    "colorRed": {
+        "message": "احمر"
+    },
+    "colorOrange": {
+        "message": "برتقالي"
+    },
+    "colorYellow": {
+        "message": "الأصفر"
+    },
+    "colorLimeGreen": {
+        "message": "أخضر ليموني"
+    },
+    "colorGreen": {
+        "message": "اخضر"
+    },
+    "colorMintGreen": {
+        "message": "أخضر نعناعي"
+    },
+    "colorCyan": {
+        "message": "سماوي"
+    },
+    "colorLightBlue": {
+        "message": "أزرق فاتح"
+    },
+    "colorBlue": {
+        "message": "الأزرق"
+    },
+    "colorDarkViolet": {
+        "message": "بنفسجي غامق"
+    },
+    "colorMagenta": {
+        "message": "أرجواني"
+    },
+    "colorDeepPink": {
+        "message": "وردي غامق"
+    },
+    "controlAxisRoll": {
+        "message": "اللف [A]"
+    },
+    "controlAxisPitch": {
+        "message": "PITCH [E]"
+    },
+    "controlAxisYaw": {
+        "message": "YAW [R]"
+    },
+    "controlAxisThrottle": {
+        "message": "لون Throttle]"
+    },
+    "controlAxisAux1": {
+        "message": "إضافي 1"
+    },
+    "controlAxisAux2": {
+        "message": "إضافي 2"
+    },
+    "controlAxisAux3": {
+        "message": "إضافي 3"
+    },
+    "controlAxisAux4": {
+        "message": "إضافي 4"
+    },
+    "controlAxisAux5": {
+        "message": "إضافي 5"
+    },
+    "controlAxisAux6": {
+        "message": "إضافي 6"
+    },
+    "controlAxisAux7": {
+        "message": "إضافي 7"
+    },
+    "controlAxisAux8": {
+        "message": "إضافي 8"
+    },
+    "controlAxisAux9": {
+        "message": "إضافي 9"
+    },
+    "controlAxisAux10": {
+        "message": "إضافي 10"
+    },
+    "controlAxisAux11": {
+        "message": "إضافي 11"
+    },
+    "controlAxisAux12": {
+        "message": "إضافي 12"
+    },
+    "controlAxisAux13": {
+        "message": "أضافي 13"
+    },
+    "controlAxisAux14": {
+        "message": "أضافي 14"
+    },
+    "controlAxisAux15": {
+        "message": "أضافي 15"
+    },
+    "controlAxisAux16": {
+        "message": "أضافي 16"
+    },
+    "pidTuningBasic": {
+        "message": "أساسي\/أكرو"
+    },
+    "pidTuningYawJumpPrevention": {
+        "message": "منع القفزة المفاجئة لمحور Yaw\n"
+    },
+    "pidTuningYawJumpPreventionHelp": {
+        "message": "يمنع الطائرة من القفز في نهاية حركات YAW . الرقم الأعلى يعطي تثبيطًا أكثر في نهاية حركات YAW (يعمل مثل D القديم للـ YAW، والذي لم يكن D حقيقيًا كما في المحاور الأخرى)"
+    },
+    "pidTuningRcExpoPower": {
+        "message": "قوة RC Expo"
+    },
+    "pidTuningRcExpoPowerHelp": {
+        "message": "الأُس المستخدم عند حساب RC Expo. في إصدارات Betaflight السابقة للإصدار 3.0، كانت القيمة ثابتة عند 3."
+    },
+    "pidTuningLevel": {
+        "message": "زاوية\/أفق"
+    },
+    "pidTuningAltitude": {
+        "message": "مقياس الضغط والسونار\/الارتفاع"
+    },
+    "pidTuningMag": {
+        "message": "المغناطيس\/الاتجاه"
+    },
+    "pidTuningGps": {
+        "message": "ملاحة GPS"
+    },
+    "pidTuningStrength": {
+        "message": "قوة"
+    },
+    "pidTuningTransition": {
+        "message": "انتقال"
+    },
+    "pidTuningHorizon": {
+        "message": "الأفق"
+    },
+    "pidTuningAngle": {
+        "message": "زاوية"
+    },
+    "pidTuningLevelAngleLimit": {
+        "message": "حد الزاوية"
+    },
+    "pidTuningLevelSensitivity": {
+        "message": "حساسية"
+    },
+    "pidTuningLevelHelp": {
+        "message": "تغير القيم أدناه سلوك أوضاع الطيران ANGLE و HORIZON. تتعامل وحدات تحكم PID المختلفة مع القيم بشكل مختلف. يرجى مراجعة الوثائق."
+    },
+    "pidTuningMotorOutputLimit": {
+        "message": "حد خرج المحرك"
+    },
+    "pidTuningMotorLimit": {
+        "message": "عامل القياس [%]"
+    },
+    "pidTuningMotorLimitHelp": {
+        "message": "النسبة المئوية للتقليل في إشارة دفع المحرك الفردي.<br><br>يقلل التيار في ESC وحرارة المحرك عند استخدام بطاريات بعدد خلايا أعلى على محركات ذات KV عالي.<br><br>عند استخدام بطارية 6S على طائرة بمحركات ومراوح وضبط لـ 4S، جرب 66%؛ عند استخدام بطارية 4S على طائرة مخصصة لـ 3S، جرب 75%.<br><br>تأكد من أن جميع مكوناتك تدعم جهد البطارية التي تستخدمها."
+    },
+    "pidTuningCellCount": {
+        "message": "عدد الخلايا - للتبديل التلقائي بين الملفات الشخصية"
+    },
+    "pidTuningCellCountHelp": {
+        "message": "يقوم بتنشيط أول ملف شخصي يتطابق عدد خلاياه مع عدد خلايا البطارية المتصلة تلقائيًا.<br><br><ul><li><b>تبديل<\/b>: قم دائمًا بالتبديل إلى ملف شخصي يتطابق عدد خلاياه إذا وجد واحد.<\/li><li><b>تعطيل<\/b>: تعطيل التبديل التلقائي بين الملفات الشخصية<\/li><li><b>1S-8S<\/b>: حدد عدد خلايا الملف الشخصي الذي سيتم استخدامه لهذا الملف الشخصي<\/li><\/ul>"
+    },
+    "pidTuningCellCountChange": {
+        "message": "تبديل",
+        "description": "Switch profile if there are no profiles matching cell count"
+    },
+    "pidTuningCellCountStay": {
+        "message": "تعطيل",
+        "description": "Disable cell count for this profile"
+    },
+    "pidTuningCellCount1S": {
+        "message": "1S"
+    },
+    "pidTuningCellCount2S": {
+        "message": "2S"
+    },
+    "pidTuningCellCount3S": {
+        "message": "3S"
+    },
+    "pidTuningCellCount4S": {
+        "message": "4S"
+    },
+    "pidTuningCellCount5S": {
+        "message": "5S"
+    },
+    "pidTuningCellCount6S": {
+        "message": "6S"
+    },
+    "pidTuningCellCount7S": {
+        "message": "7S"
+    },
+    "pidTuningCellCount8S": {
+        "message": "8S"
+    },
+    "pidTuningNonProfileFilterSettings": {
+        "message": "إعدادات الفلتر المستقلة عن الملف الشخصي"
+    },
+    "pidTuningFilterSlidersHelp": {
+        "message": "تضبط هذه المنزلقات فلاتر الجيروسكوب و D-term.<br \/><br \/>لمزيد من التصفية:<br \/> - انقل المنزلقات لليسار<br> - خفض ترددات القطع.<br \/><br \/> التصفية الأقوى تبقي المحركات أكثر برودة عن طريق إزالة المزيد من الضوضاء، لكنها تؤخر إشارة الجيروسكوب أكثر وقد تزيد من prop-wash أو تسبب تذبذبات رنينية. الطائرات الأقل استجابة مثل X-Class تعمل بشكل أفضل مع تصفية أقوى. <br><br>لتقليل التصفية:<br \/> - انقل المنزلقات لليمين<br \/> - ترددات قطع أعلى <br><br>تقليل التصفية يقلل من تأخير إشارة الجيروسكوب، وغالبًا ما يحسن prop-wash. تحريك فلتر التمرير المنخفض للجيروسكوب لليمين عادةً ما يكون مقبولاً، لكن تحريك فللتر D لليمين عادةً لا يكون مطلوبًا، ويمكن بسهولة أن يؤدي إلى محركات ساخنة جدًا.",
+        "description": "Overall helpicon message for filter tuning sliders"
+    },
+    "pidTuningSliderLowFiltering": {
+        "message": "تصفية أقل",
+        "description": "Filter tuning slider low header"
+    },
+    "pidTuningSliderDefaultFiltering": {
+        "message": "التصفية الافتراضية",
+        "description": "Filter tuning slider default header"
+    },
+    "pidTuningSliderHighFiltering": {
+        "message": "تصفية أكثر",
+        "description": "Filter tuning slider high header"
+    },
+    "pidTuningGyroFilterSlider": {
+        "message": "مضاعف فلتر Gyro",
+        "description": "Gyro filter tuning slider label"
+    },
+    "pidTuningGyroFilterSliderHelp": {
+        "message": "يغير ترددات قطع فلتر التمرير المنخفض للجيروسكوب.<br \/><br \/>تحريك المنزلق لليسار يعطي تصفية أقوى للجيروسكوب (تردد قطع أقل).<br \/><br \/>تحريك المنزلق لليمين يعطي تصفية أقل للجيروسكوب (تردد قطع أعلى).<br \/><br \/>عند تحريك المنزلق لليمين لتحسين التعامل مع propwash ، كن حذرًا جدًا في عدم المبالغة. سوف تسمح بدخول المزيد من الضوضاء إلى كل من P وD وقد تحصل على طيران بعيد عن السيطرة أو محركات محترقة.<br \/><br \/>قد تحتاج إلى تحريك المنزلق لليسار إذا كانت لديك مشاكل رنين في الهيكل، محامل سيئة، مراوح متضررة، محركات ساخنة، إلخ.<br \/><br \/>يتم تطبيق تصفية الجيروسكوب قبل تصفية D، وبالإضافة إليها.",
+        "description": "Gyro filter tuning slider helpicon message"
+    },
+    "pidTuningDTermFilterSlider": {
+        "message": "مضاعف فلتر D-Term",
+        "description": "D Term filter tuning slider label"
+    },
+    "pidTuningDTermFilterSliderHelp": {
+        "message": "يغير ترددات قطع فلتر التمرير المنخفض لـ D-term.<br \/><br \/>تحريك المنزلق لليسار يعطي تصفية أقوى لـ D (تردد قطع أقل).<br \/><br \/>تحريك المنزلق لليمين يعطي تصفية أقل (تردد قطع أعلى).<br \/><br \/>D-term هو عنصر PID الأكثر حساسية للضوضاء والرنين. يمكنه تضخيم الضوضاء عالية التردد من 10x إلى 100x. لهذا السبب تكون ترددات قطع فلتر D أقل بكثير من فلاتر الجيروسكوب.<br \/><br \/>يتم تطبيق تصفية D-term بعد تصفية الجيروسكوب، وبالإضافة إليها. التصفية الافتراضية لـ D هي الأمثل لمعظم الطائرات ونادرًا ما تحتاج إلى تغيير.<br \/><br \/>تحريك هذا المنزلق لليسار يقلل من حرارة المحرك في الطائرات الصاخبة ومع ضبط D عالي في PID، ولكن قد نرى المزيد من propwash  ورنانات D ذات التردد المنخفض.<br \/><br \/>تحريك المنزلق لليمين غير موصى به، ولكن قد يحسن propwash  في التصميمات النظيفة. قد يسبب طحن المحرك عند التشغيل، ورنانات مفاجئة أثناء الطيران، وارتفاع خطير في حرارة المحرك.",
+        "description": "D Term filter tuning slider helpicon message"
+    },
+    "pidTuningPidSlidersHelp": {
+        "message": "أشرطة لضبط خصائص طيران الطائرة (قيم PID).<br \/><br \/>Damping (كسب D): يقاوم الحركة السريعة ويقلل تذبذب P.<br \/><br \/>Tracking (كسب P وI): يزيد استجابة الطائرة؛ وإذا ارتفع كثيرًا قد يسبب اهتزازًا.<br \/><br \/>Stick Response (Feedforward): يزيد استجابة الطائرة لحركات العصا السريعة.<br \/><br \/>Drift - Wobble (كسب I، خبير): ضبط دقيق لقيمة I.<br \/><br \/>Dynamic D (D Max، خبير): يحدد أقصى زيادة لقيمة D أثناء الحركات السريعة.<br \/><br \/>Pitch Damping (نسبة Pitch:Roll D، خبير): يزيد التخميد على Pitch مقارنةً بـRoll.<br \/><br \/>Pitch Tracking (نسبة Pitch:Roll P وI وF، خبير): يزيد قوة التثبيت على Pitch مقارنةً بـRoll.<br \/><br \/>Master Multiplier (جميع قيم الكسب، خبير): يرفع أو يخفض جميع قيم PID مع الحفاظ على نسبها.",
+        "description": "Overall helpicon message for PID tuning sliders"
+    },
+    "pidTuningSliderWarning": {
+        "message": "<span class=\"message-negative\">تحذير<\/span>: المواضع الحالية للمنزلقات قد تسبب طيرانًا بعيدًا عن السيطرة، تلف المحرك أو سلوك طائرة غير آمن. يرجى المتابعة بحذر.",
+        "description": "Warning shown when tuning slider are above safe limits"
+    },
+    "pidTuningSlidersDisabled": {
+        "message": "<strong>ملاحظة:<\/strong> المنزلقات معطلة لأن القيم تم تغييرها يدويًا. النقر على زر '$t(pidTuningSliderEnableButton.message)' سيعيد تفعيلها. هذا سيعيد تعيين القيم وأي تغييرات غير محفوظة سيتم فقدها.",
+        "description": "Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningGyroSliderDisabled": {
+        "message": "<strong>ملاحظة:<\/strong> منزلق الجيروسكوب معطل لأن القيم تم تغييرها يدويًا. النقر على زر '$t(pidTuningGyroSliderEnableButton.message)' سيعيد تفعيله. هذا سيعيد تعيين القيم وأي تغييرات غير محفوظة سيتم فقدها.",
+        "description": "Gyro Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningDTermSliderDisabled": {
+        "message": "<strong>ملاحظة:<\/strong> منزلق DTerm معطل لأن القيم تم تغييرها يدويًا. النقر على زر '$t(pidTuningDTermSliderEnableButton.message)' سيعيد تفعيله. هذا سيعيد تعيين القيم وأي تغييرات غير محفوظة سيتم فقدها.",
+        "description": "DTerm Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningPidSlidersDisabled": {
+        "message": "<strong>ملاحظة:<\/strong> المنزلقات معطلة. النقر على زر '$t(pidTuningSliderEnableButton.message)' سيغير قيم PID لتطابق موضع المنزلق المحفوظ مسبقًا.",
+        "description": "Tuning sliders disabled note"
+    },
+    "pidTuningSliderEnableButton": {
+        "message": "تمكين المنزلقات",
+        "description": "Button label for enabling sliders"
+    },
+    "pidTuningSlidersNonExpertMode": {
+        "message": "<strong>ملاحظة:<\/strong> نطاق المنزلقات مقيد لأنك لست في وضع الخبير. هذا النطاق يجب أن يكون مناسبًا لمعظم التصميمات والمبتدئين.",
+        "description": "Sliders restricted message"
+    },
+    "pidTuningPidSlidersNonExpertMode": {
+        "message": "<strong>ملاحظة:<\/strong> الوصول إلى المنزلقات ونطاقها مقيد لأنك لست في وضع الخبير. الوضع الأساسي يجب أن يكون مناسبًا لمعظم التصميمات والمبتدئين.",
+        "description": "Firmware Pid sliders restricted message"
+    },
+    "pidTuningFilterSlidersNonExpertMode": {
+        "message": "<strong>ملاحظة:<\/strong> نطاق المنزلقات مقيد لأنك لست في وضع الخبير. هذا النطاق يجب أن يكون مناسبًا لمعظم التصميمات والمبتدئين.",
+        "description": "Firmware filter sliders restricted message"
+    },
+    "pidTuningSlidersExpertSettingsDetectedNote": {
+        "message": "<strong>ملاحظة:<\/strong> المنزلق(ات) معطلة لأن القيم الحالية خارج نطاق الضبط للوضع الأساسي. انتقل إلى وضع الخبير لإجراء التغييرات",
+        "description": "Slider expert settings detected while in non-expert mode"
+    },
+    "pidTuningSliderLow": {
+        "message": "منخفض",
+        "description": "Tuning Slider Low header"
+    },
+    "pidTuningSliderDefault": {
+        "message": "افتراضي",
+        "description": "Tuning Slider Default header"
+    },
+    "pidTuningSliderHigh": {
+        "message": "مرتفع",
+        "description": "Tuning Slider High header"
+    },
+    "pidTuningMasterSlider": {
+        "message": "المضاعف الرئيسي:",
+        "description": "Master tuning slider label"
+    },
+    "pidTuningMasterSliderHelp": {
+        "message": "يزيد جميع معاملات PID بالتساوي. لا تغير هذا المنزلق إلا إذا نفد منك التعديل في المنزلقات الأخرى. عادة ما يكون هذا مطلوبًا فقط للطائرات منخفضة السلطة أو ذات عزم القصور الذاتي العالي مثل X-Class أو تصاميم cinelifter. الكثير من الكسب الرئيسي قد يسبب تذبذبات رنينية أو محركات ساخنة.",
+        "description": "Master Gain tuning slider helpicon message"
+    },
+    "pidTuningDGainSlider": {
+        "message": "التثبيط:<br \/><i><small>مكاسب D<\/small><\/i>",
+        "description": "D Gain (Damping) tuning slider label"
+    },
+    "pidTuningDGainSliderHelp": {
+        "message": "كسب D مرتفع نسبيًا سيخمد استجابة المقبض وقد يجعل المحركات ساخنة، ولكن يجب أن يساعد في التحكم في التذبذبات السريعة وسيحسن propwash .<br \/><br \/>كسب D منخفض نسبيًا يعطي استجابة مقبض أسرع، لكنه يضعف أداء propwash  والاستجابة للقوى الخارجية (الرياح).",
+        "description": "D gain balance tuning slider helpicon message"
+    },
+    "pidTuningPIGainSlider": {
+        "message": "التتبع:<br \/><i><small>مكاسب P & I<\/small><\/i>",
+        "description": "P and I Gain (Stability) tuning slider label"
+    },
+    "pidTuningPIGainSliderHelp": {
+        "message": "ارفع شريط Tracking لزيادة دقة استجابة الطائرة لأوامرك وللتأثيرات الخارجية، والمساعدة على منع مقدمة الطائرة من الانحراف عن المسار.<br \/><br \/>القيم المنخفضة من Tracking قد تسبب تمايلًا وانحرافًا أثناء حركات العصا وفي Propwash. القيم المرتفعة قد تسبب اهتزازًا وBounceback سريعًا قد يصعب رؤيته لكن يمكن سماعه. الزيادة المفرطة قد تسبب اهتزازات وارتفاع حرارة المحركات.",
+        "description": "P and I gain tuning slider helpicon message"
+    },
+    "pidTuningResponseSlider": {
+        "message": "استجابة المقبض:<br \/><i><small>مكاسب FF<\/small><\/i>",
+        "description": "Response tuning slider label"
+    },
+    "pidTuningResponseSliderHelp": {
+        "message": "استجابة المقبض المنخفضة ستزيد من زمن استجابة حركات الطائرة للأوامر وقد تؤدي إلى ارتداد بطيء في نهاية الشقلبة أو اللفة.<br><br>استجابة المقبض الأعلى ستعطي استجابة أسرع للطائرة لحركات المقبض الحادة. الكثير من استجابة المقبض يمكن أن يسبب تجاوزًا في نهاية الشقلبة أو اللفة.<br \/><br \/><strong>ملاحظة:<\/strong><br \/> \"استرخاء I-term\" يمكن أن يقلل الارتداد للطائرات منخفضة السلطة أو إذا تم استخدام مكاسب استجابة مقبض منخفضة.",
+        "description": "Stick response gain tuning slider helpicon message"
+    },
+    "pidTuningIGainSlider": {
+        "message": "الانحراف - التمايل:<br \/><i><small>مكاسب I<\/small><\/i>",
+        "description": "I-term slider label"
+    },
+    "pidTuningIGainSliderHelp": {
+        "message": "يزيد أو يقلل I. قد يحسن I الأعلى التتبع في المنعطفات الحلزونية، المدارات، أو أوامر دفع المحرك 0%. الكثير من I، خاصة مع عدم كفاية P، قد يسبب تمايلًا أو ارتدادًا بعد الشقلبات\/اللفات أو عند خفض دفع المحرك إلى 0%.<br \/><br \/>بشكل عام، تريد أن يكون منزلق 'الانحراف – التمايل' مرتفعًا بقدر ما يمكن للحفاظ على تتبع الطائرة في المنعطفات الحلزونية، المدارات، إلخ... ولكن ليس مرتفعًا جدًا لدرجة أنك تبدأ في رؤية تمايل عند خفض دفع المحرك إلى 0%.<br \/><br \/><strong>ملاحظة:<\/strong><br \/>إذا واجهت ارتدادًا في أي وقت يسهل رؤيته، تأكد من تمكين \"استرخاء I-term\"، وحاول خفض قيمة iterm_relax_cutoff.",
+        "description": "I-gain Gain tuning slider helpicon message"
+    },
+    "pidTuningDMaxGainSlider": {
+        "message": "التثبيط الديناميكي:<br \/><i><small>D Max<\/small><\/i>",
+        "description": "D Max slider label"
+    },
+    "pidTuningDMaxGainSliderHelp": {
+        "message": "يزيد D max، الحد الأقصى للمقدار الذي يمكن أن يزيد إليه D أثناء الحركات الأسرع.<br \/><br \/>لطائرات السباق، حيث تم ضبط منزلق التثبيط الرئيسي على منخفض لتقليل حرارة المحرك، تحريك هذا المنزلق لليمين سيحسن التحكم في التجاوز للتغيرات السريعة في الاتجاه.<br \/><br \/>لطائرات HD أو السينمائية، يتم التعامل مع عدم الاستقرار في الطيران الأمامي بشكل أفضل عن طريق تحريك منزلق التثبيط (وليس منزلق التثبيط الديناميكي) لليمين. تحقق من حرارة المحرك واستمع للأصوات الغريبة أثناء المدخلات السريعة عند تحريك هذا المنزلق لليمين.<br \/><br \/>لطائرات الاستعراض الجوي، خاصة التصميمات الأثقل، تحريك هذا المنزلق لليمين قد يساعد في التحكم في التجاوز في الشقلبات واللفات.<br \/><br \/><strong>ملاحظة:<\/strong><br \/>بشكل عام، التجاوز في الشقلبات واللفات يكون بسبب عدم كفاية 'استرخاء i-Term'، أو فقدان تزامن المحرك، أو عدم كفاية السلطة (المعروفة أيضًا باسم تشبع المحرك). إذا وجدت أن تحريك منزلق تعزيز التثبيط لليمين لا يحسن تجاوز الشقلبة أو اللفة، فارجعه إلى الموضع الطبيعي، وابحث عن سبب التجاوز أو التمايل.",
+        "description": "D Max slider helpicon message"
+    },
+    "pidTuningRollPitchRatioSlider": {
+        "message": "تثبيط pitch :<br \/><i><small>Pitch:Roll D<\/small><\/i>",
+        "description": "Pitch-Roll Ratio slider label"
+    },
+    "pidTuningRollPitchRatioSliderHelp": {
+        "message": "يزيد التخميد (D) على محور Pitch فقط، أي يزيد تخميد Pitch مقارنةً بمحور Roll. يساعد ذلك في التحكم بالتجاوز أو الارتداد الخاص بمحور Pitch.<br \/><br \/>تحتاج الطائرات ذات عزم القصور الذاتي 'الأكبر' حول محور Pitch عمومًا إلى قدرة تخميد أعلى (لأن محور Pitch يمتلك قصورًا ذاتيًا أكبر ويكتسب زخمًا أكثر).<br \/><br \/>اضبط أولًا منزلقَي 'التخميد' و\/أو 'التتبّع' الرئيسيين حتى تحصل على سلوك جيد لمحور Roll. بعد ذلك استخدم منزلقات Pitch (بالزيادة أو النقصان) لإجراء ضبط دقيق لمحور Pitch دون التأثير في محور Roll.\n",
+        "description": "Pitch-Roll Ratio tuning slider helpicon message"
+    },
+    "pidTuningPitchPIGainSlider": {
+        "message": "تتبع pitch:<br><i><small>Pitch:Roll P, I & FF<\/small><\/i>",
+        "description": "Pitch P & I slider label"
+    },
+    "pidTuningPitchPIGainSliderHelp": {
+        "message": "يزيد قوة التتبع على محور pitch فقط، عن طريق تغيير قيم P و I للـ pitch بالنسبة إلى roll . يسمح بسلطة تتبع أقوى على محور pitch بالنسبة إلى roll  .<br \/><br \/>زد لتحقيق الاستقرار لاهتزاز الأنف (pitch ) مع مدخلات pitch حادة أو تخفيضات throttle . فكر أيضًا في رفع مكاسب  Anti-Gravity مضاد الجاذبية.<br \/><br \/>اضبط منزلقات 'التثبيط' الرئيسية و\/أو 'التتبع' أولاً، حتى تحصل على سلوك جيد لمحور roll . ثم استخدم منزلقات pitch (زيادة أو نقصان) لضبط محور pitch بدقة دون التأثير على roll .",
+        "description": "Pitch P & I Gain tuning slider helpicon message"
+    },
+    "pidTuningGyroLowpassFiltersGroup": {
+        "message": "فلاتر التمرير المنخفضة للجيروسكوب"
+    },
+    "pidTuningGyroLowpassType": {
+        "message": "نوع فلتر التمرير المنخفض 1 للجيروسكوب"
+    },
+    "pidTuningGyroLowpass": {
+        "message": "التمرير المنخفض للجيروسكوب 1"
+    },
+    "pidTuningGyroLowpassHelp": {
+        "message": "أول فلاتر من فلاتر التمرير المنخفض للجيروسكوب.<br \/><br \/>كان استخدام التمرير المنخفض للجيروسكوب 1 في الوضع الديناميكي مهمًا مع كود الشق الديناميكي السابق. يمكن عادةً تعطيل التمرير المنخفض للجيروسكوب 1 تمامًا في البرنامج الثابت 4.3 عند استخدام تصفية RPM، ما لم يكن الجيروسكوب لا يحتوي على تصفية عتادية داخلية.<br \/><br \/>في الوضع الديناميكي، ستكون التصفية أقوى عند throttle المنخفض، مع تصفية أقل وتأخير أقل مع زيادة throttle . سيحدث الانتقال من قطع منخفض إلى قطع مرتفع في وقت أبكر، مع زيادة throttle ، مع قيم Gyro lowpass expo أعلى.<br \/><br \/>في الوضع الثابت، تردد القطع ثابت.<br \/><br \/>نوع الفلتر افتراضيًا هو PT1. نادرًا ما تكون التصفية ذات الرتبة الأعلى مطلوبة.",
+        "description": "Help icon for the Gyro Lowpass 1 Filter"
+    },
+    "pidTuningGyroLowpassMode": {
+        "message": "الوضع"
+    },
+    "pidTuningLowpassStatic": {
+        "message": "ثابت"
+    },
+    "pidTuningLowpassDynamic": {
+        "message": "ديناميكي"
+    },
+    "pidTuningLowpassFilterType": {
+        "message": "نوع الفلتر"
+    },
+    "pidTuningMinCutoffFrequency": {
+        "message": "الحد الأدنى لتردد القطع [هرتز]"
+    },
+    "pidTuningMaxCutoffFrequency": {
+        "message": "الحد الأقصى لتردد القطع [هرتز]"
+    },
+    "pidTuningGyroLowpass2": {
+        "message": "التمرير المنخفض للجيروسكوب 2"
+    },
+    "pidTuningGyroLowpass2Help": {
+        "message": "ثاني فلاتر من فلاتر التمرير المنخفض للجيروسكوب.<br \/><br \/>يعمل هذا فلتر في حلقة الجيروسكوب، مصفيًا الإشارة قبل دخولها حلقة PID. يكون دائمًا في وضع ثابت (قطع ثابت).<br \/><br \/>إذا كان تردد حلقة PID أقل من تردد حلقة الجيروسكوب، على سبيل المثال حلقة PID 4k مع حلقة جيروسكوب 8k، فيجب الاحتفاظ بهذا الفلتر لمنع مشاكل الازدواجية بسبب التخفيض من 8k->4k.<br \/><br \/>تكوين واحد للتمرير المنخفض للجيروسكوب 2، مضبوط في مكان ما بين 500 و 1000 هرتز، يعمل جيدًا مع Betaflight 4.3 أو أعلى، للتصميمات النظيفة مع تفعيل تصفية RPM وعلى الأقل تصفية D افتراضية.",
+        "description": "Gyro lowpass filter helpicon message"
+    },
+    "pidTuningGyroLowpassFilterHelp": {
+        "message": "تقوم فلاتر التمرير المنخفض للجيروسكوب بتخفيف الضوضاء عالية التردد لإبعادها عن حلقة PID. هناك فلترين جيروسكوبيان قابلان للتكوين بشكل مستقل؛ بشكل افتراضي كلاهما نشطان.<br \/><br \/>مع تصفية RPM، يمكن غالبًا تحريك منزلق فلتر الجيروسكوب بعض الشيء إلى اليمين، أو بدلاً من ذلك قد يكون فلتر تمرير منخفض ثابت واحد للجيروسكوب عند 500 هرتز كافيًا.<br \/><br \/>ستكون للطائرة propwash  أقل مع أقل تأخير لفلتر الجيروسكوب.<br \/><br \/>تحقق دائمًا من حرارة المحرك عند تحريك المنزلقات لليمين. مع الحد الأدنى من تصفية الجيروسكوب، من الضروري أن يكون لديك تصفية D كافية! كن حذرًا!",
+        "description": "Gyro lowpass filter helpicon message"
+    },
+    "pidTuningDTermLowpassFilterHelp": {
+        "message": "تقوم فلاتر التمرير المنخفض لـ D-term بتخفيف الضوضاء عالية التردد والرنانات التي قد يتم تضخيمها بواسطة كسب D.<br \/><br \/>هناك فلتران D، وتأثيراتهما متراكبة. كلاهما مطلوب في aircraft ، على الرغم من أنه يمكن استخدام PT2 واحد بدلاً من PT1 مزدوج.<br \/><br \/>بشكل عام، ستحلق الطائرة بشكل أفضل ولديها أقل propwash  عند تكوينها ليكون لها أقل تأخير فلتر(منزلقات لليمين، قيم قطع أعلى). ومع ذلك، خاصة مع فلاتر D، يمكن أن تزيد المنزلقات إلى اليمين بشكل كبير من فرص الحصول على محركات ساخنة.<br \/><br \/>من السهل جدًا حرق المحركات إذا لم يكن لديك تصفية D كافية - كن حذرًا!",
+        "description": "D-term lowpass filter helpicon message"
+    },
+    "pidTuningGyroNotchFiltersGroup": {
+        "message": "فلتر  الشق للجيروسكوب"
+    },
+    "pidTuningGyroNotchFilter": {
+        "message": "فلتر الشق للجيروسكوب 1"
+    },
+    "pidTuningGyroNotchFilterHelp": {
+        "message": "يطبق فلتر شق ثابت (تردد ثابت) على الجيروسكوب، عند تردد المركز المحدد. <br \/><br \/>قد يكون مفيدًا للرنانات المعزولة وثابتة التردد التي تؤثر على كل من P و D. <br \/><br \/>لكي يكون مفيدًا، يجب أن يكون تردد الرنين ثابتًا عبر نطاق throttle .<br \/><br \/>يتم تعيين عرض الشق بواسطة تردد القطع. يجب أن يتم ضبط القطع عادة بين 10% و 40% أقل من تردد المركز. استخدم أضيق نطاق فلتر يتحكم في الرنين. تجنب تعيين فلاتر الشق أقل من 100 هرتز إلا في ظروف خاصة.<br \/><br \/>نادرًا ما تكون فلاتر الشق الثابتة مطلوبة في 4.3."
+    },
+    "pidTuningGyroNotchFilter2": {
+        "message": "فلتر الشق للجيروسكوب 2"
+    },
+    "pidTuningGyroNotchFilter2Help": {
+        "message": "يطبق فلتر  شق ثابت ثانٍ (تردد ثابت) على الجيروسكوب.<br \/><br \/>هذا نادرًا ما يكون مطلوبًا، ويجب استخدامه فقط كملاذ أخير لمكافحة خط رنين ثابت تردد ثانٍ لا يمكن التحكم فيه بوسائل أخرى."
+    },
+    "pidTuningCenterFrequency": {
+        "message": "تردد المركز [هرتز]"
+    },
+    "pidTuningCutoffFrequency": {
+        "message": "تردد القطع [هرتز]"
+    },
+    "pidTuningNotchFilterHelp": {
+        "message": "فلتر Notch هو فلتر متماثل وضيّق ذو توهين مرتفع، وله قيمتا Center وCutoff.<br \/><br \/>قيمة Center هي التردد المركزي للفلتر، وقيمة Cutoff هي تردد القطع السفلي عند ‎-3 dB.<br \/><br \/>مثال: ضبط Notch Cutoff على 160 وNotch Center على 260 ينتج Notch واسعًا بنطاق ‎-3 dB من 160 إلى 360 Hz، ويكون أقوى توهين حول 260 Hz.",
+        "description": "Notch filter helpicon message"
+    },
+    "pidTuningDynamicNotchFilterGroup": {
+        "message": "فلتر الشق الديناميكي"
+    },
+    "pidTuningDynamicNotchFilterHelp": {
+        "message": "يتتبع فلتر الشق الديناميكي ترددات ذروة ضوضاء المحرك ويضع فلاتر شق عند تلك الترددات، بشكل مستقل لكل محور."
+    },
+    "pidTuningMultiDynamicNotchFilterHelp": {
+        "message": "يتتبع فلتر الشق الديناميكي ترددات ضوضاء الجيروسكوب الذروية ويضع من واحد إلى خمسة فلاتر شق بمركزها عند هذه الترددات على كل محور."
+    },
+    "pidTuningDynamicNotchFilterDisabledWarning": {
+        "message": "<strong>ملاحظة:<\/strong> فلتر الشق الديناميكي معطل. من أجل تكوينه واستخدامه، يرجى تمكين ميزة 'DYNAMIC_FILTER' في قسم '$t(configurationFeatures.message)' في '$t(tabConfiguration.message)'. وتأكد أيضًا من أن معدل حلقة PID هو 2kHz على الأقل."
+    },
+    "pidTuningDynamicNotchFilterNyquistWarning": {
+        "message": "فلتر الشق الديناميكي معطل. من أجل استخدامه، يرجى التأكد من ضبط تردد حلقة PID على 2 كيلو هرتز على الأقل في العلامة '$t(tabConfiguration.message)'."
+    },
+    "pidTuningDynamicNotchRange": {
+        "message": "نطاق فلتر الشق الديناميكي"
+    },
+    "pidTuningDynamicNotchQ": {
+        "message": "معامل Q (×100)"
+    },
+    "pidTuningDynamicNotchMinHz": {
+        "message": "الحد الأدنى للتردد [هرتز]"
+    },
+    "pidTuningDynamicNotchMaxHz": {
+        "message": "الحد الأقصى للتردد [هرتز]"
+    },
+    "pidTuningDynamicNotchCount": {
+        "message": "عدد الشقوق"
+    },
+    "pidTuningDynamicNotchRangeHelp": {
+        "message": "يحتوي الشق الديناميكي على ثلاثة نطاقات تردد يمكن أن يعمل فيها: LOW (80-330 هرتز) للطائرات منخفضة الدوران مثل 6+ بوصات، MEDIUM (140-550 هرتز) لطائرة 5 بوصة عادية، HIGH (230-800 هرتز) لطائرات 2.5-3 بوصة عالية الدوران جدًا. يحدد خيار AUTO النطاق اعتمادًا على قيمة تردد القطع الأقصى لفلتر التمرير المنخفض الديناميكي 1 للجيروسكوب."
+    },
+    "pidTuningDynamicNotchQHelp": {
+        "message": "يضبط معامل Q مدى ضيق أو اتساع فلاتر Dynamic Notch. القيمة المخزنة هي معامل Q × 100 (مثال: 300 = Q 3.0). القيمة الأعلى تجعل الفلتر أضيق وأكثر دقة، والقيمة الأقل تجعله أوسع. القيم المنخفضة جدًا تزيد تأخير الفلتر بشكل كبير."
+    },
+    "pidTuningDynamicNotchMinHzHelp": {
+        "message": "اضبط هذا على أدنى تردد ضوضاء وارد يحتاج إلى التحكم فيه بواسطة الشق الديناميكي."
+    },
+    "pidTuningDynamicNotchMaxHzHelp": {
+        "message": "اضبط هذا على أعلى تردد ضوضاء وارد يحتاج إلى التحكم فيه بواسطة الشق الديناميكي."
+    },
+    "pidTuningDynamicNotchCountHelp": {
+        "message": "يحدد عدد الشقوق الديناميكية لكل محور. مع تمكين فلتر RPM، يوصى بقيمة 1 أو 2. بدون فلتر RPM، يوصى بقيمة 4 أو 5. الأرقام الأقل ستقلل من تأخير الفلتر، ومع ذلك قد تزيد من حرارة المحرك."
+    },
+    "pidTuningRpmFilterGroup": {
+        "message": "فلتر جيروسكوب RPM",
+        "description": "Header text for the RPM Filter group"
+    },
+    "pidTuningRpmFilterHelp": {
+        "message": "تصفية RPM هي مجموعة من فلاتر الشق على الجيروسكوب تستخدم بيانات تليمترية RPM لإزالة ضوضاء المحرك بدقة جراحية.<br \/><br \/><b><span class=\"message-positive\">مهم<\/span>: يجب أن يدعم ESC بروتوكول DShot ثنائي الاتجاه ويجب أن تكون قيمة $t(configurationMotorPoles.message) في $t(tabMotorTesting.message) صحيحة حتى يعمل هذا الفلتر .<\/b>",
+        "description": "Header text for the RPM Filter group"
+    },
+    "pidTuningRpmHarmonics": {
+        "message": "التوافقيات",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmHarmonicsHelp": {
+        "message": "عدد التوافقيات لكل محرك. قيمة 3 (موصى بها لمعظم الطائرات) ستولد 3 فلاتر شق، لكل محرك لكل محور، بإجمالي 36 شق. واحد عند تردد المحرك الأساسي وتوافقيتين عند مضاعفات ذلك التردد الأساسي.",
+        "description": "Help text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmMinHz": {
+        "message": "أدنى تردد [Hz]",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmMinHzHelp": {
+        "message": "أدنى تردد سيتم استخدامه بواسطة فلتر RPM.",
+        "description": "Help text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmFadeRangeHz": {
+        "message": "نطاق التلاشي [Hz]",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmQ": {
+        "message": "معامل Q (×100)",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmQHelp": {
+        "message": "يضبط معامل Q مدى ضيق أو اتساع فلاتر RPM Notch. القيمة المخزنة هي معامل Q × 100، والنطاق المسموح 250–3000 (من Q 2.5 إلى Q 30.0)، والافتراضي 500 (Q 5.0). القيم الأعلى تجعل كل Notch أضيق وأكثر دقة، والقيم الأقل تجعله أوسع. القيم المنخفضة جدًا تزيد تأخير الفلتر بشكل ملحوظ."
+    },
+    "pidTuningRpmWeight": {
+        "message": "الوزن {{index}}",
+        "description": "Text for the per-harmonic weight parameter of the RPM Filter"
+    },
+    "pidTuningFilterSettings": {
+        "message": "إعدادات الفلاتر المعتمدة على الملف الشخصي"
+    },
+    "pidTuningDTermLowpass": {
+        "message": "التمرير المنخفض لـ D Term 1"
+    },
+    "pidTuningDTermLowpassHelp": {
+        "message": "أول فلترين من فلاتر التمرير المنخفض لـ D-term.<br \/><br \/>في الوضع الديناميكي، ستكون التصفية أقوى عند throttle  المنخفض، مع تصفية أقل وتأخير أقل مع زيادة throttle . هذا يساعد في التحكم في صرير المحرك أو الطيران بعيد غير متوقع عند التشغيل، مع تقليل التأخير وpropwash  بعد الإقلاع. سيحدث الانتقال من قطع منخفض إلى قطع مرتفع في وقت أبكر، مع زيادة throttle  مع قيم D-term lowpass expo أعلى.<br \/><br \/>في الوضع الثابت، تردد القطع ثابت. هذا غير موصى به لتصفية D.<br \/><br \/>نوع الفلتر افتراضيًا هو PT1، على الرغم من أن بعض المستخدمين استخدموا فلتر Biquad ديناميكي واحد فقط هنا، بدون PT1 ثانٍ.<br \/><br \/>التغييرات التي تؤدي إلى تقليل تصفية D قد تسبب ارتفاع خطير في حرارة المحرك أو طيران بعيد عن السيطرة عند التشغيل.",
+        "description": "Help icon for the DTerm Lowpass 1 Filter"
+    },
+    "pidTuningDTermLowpassMode": {
+        "message": "الوضع"
+    },
+    "pidTuningDTermLowpass2": {
+        "message": "التمرير المنخفض لـ D Term 2"
+    },
+    "pidTuningDTermLowpass2Help": {
+        "message": "ثاني فلترين من فلاتر التمرير المنخفض لـ D-term. <br \/><br \/>هذا الفلتردائمًا في وضع ثابت (قطع ثابت). هناك حاجة إلى فلترين PT1 منخفضي التمرير على الأقل، أو فلتر واحد من الرتبة الثانية، لتصفية D.<br \/><br \/>عادة ما يتم ضبط هذا القطع على القيمة الأعلى لنطاق التمرير المنخفض الديناميكي 1. وهذا يوفر تحكمًا في الضوضاء من الرتبة الثانية فوق ذلك التردد. <br \/><br \/>التغييرات التي تؤدي إلى تقليل تصفية D قد تسبب ارتفاع خطير في حرارة المحرك أو طيران بعيد عن السيطرة عند التشغيل.",
+        "description": "Help icon for the DTerm Lowpass 2 Filter"
+    },
+    "pidTuningDTermLowpassFiltersGroup": {
+        "message": "فلاتر التمرير المنخفض لـ D Term"
+    },
+    "pidTuningDTermLowpassType": {
+        "message": "نوع الفلتر"
+    },
+    "pidTuningStaticCutoffFrequency": {
+        "message": "تردد القطع الثابت [هرتز]"
+    },
+    "pidTuningDTermLowpass2Type": {
+        "message": "نوع الفلتر"
+    },
+    "pidTuningDTermLowpassDynExpo": {
+        "message": "أس المنحنى الديناميكي"
+    },
+    "pidTuningDTermNotchFiltersGroup": {
+        "message": "فلتر الشق لـ D Term"
+    },
+    "pidTuningDTermNotchFiltersGroupHelp": {
+        "message": "يطبق فلتر شق ثابت (تردد ثابت) على بيانات D-Term، عند تردد المركز المحدد.<br \/><br \/>يتم تعيين عرض الشق بواسطة تردد القطع. <br \/><br \/>قد يكون مفيدًا للرنانات المعزولة وثابتة التردد التي يتم تضخيمها بواسطة D.<br \/><br \/>حافظ على القطع أقرب ما يكون إلى المركز. تجنب تعيين مرشحات الشق أقل من 100 هرتز إلا على تصاميم RPM المنخفضة."
+    },
+    "pidTuningYawLowpassFiltersGroup": {
+        "message": "فلتر التمرير المنخفض للـyaw\n"
+    },
+    "pidTuningYawLowpassFiltersGroupHelp": {
+        "message": "يطبق فلتر PT1 عند تردد القطع المحدد على بيانات الجيروسكوب على محور yaw\n."
+    },
+    "pidTuningVbatPidCompensation": {
+        "message": "تعويض PID حسب جهد البطارية\n"
+    },
+    "pidTuningVbatPidCompensationHelp": {
+        "message": "يزيد قيم PID للتعويض عندما ينخفض جهد البطارية. هذا سيعطي خصائص طيران أكثر ثباتًا طوال الرحلة. يتم حساب مقدار التعويض المطبق من $t(powerBatteryMaximum.message) المضبوط في صفحة $t(tabPower.message)، لذا تأكد من ضبط ذلك على قيمة مناسبة."
+    },
+    "pidTuningVbatSagCompensation": {
+        "message": "تعويض هبوط جهد البطارية %"
+    },
+    "pidTuningVbatSagCompensationHelp": {
+        "message": "يحافظ على أداء ثابت للـThrottle وPID ضمن نطاق جهد البطارية القابل للاستخدام، وذلك بزيادة خرج المحركات مع انخفاض جهد البطارية.<br \/><br \/>يمكن ضبط مقدار التعويض بين 0 و100%. يوصى بالتعويض الكامل (100%).<br \/><br \/>راجع <a href=\"https:\/\/betaflight.com\/docs\/wiki\/tuning\/4-2-Tuning-Notes#dynamic-battery-sag-compensation\" target=\"_blank\" rel=\"noopener noreferrer\">صفحة Wiki هذه<\/a> لمزيد من المعلومات."
+    },
+    "pidTuningVbatSagValue": {
+        "message": "%"
+    },
+    "pidTuningThrustLinearization": {
+        "message": "خطية الدفع %"
+    },
+    "pidTuningThrustLinearizationHelp": {
+        "message": "يحسن سلطة throttle  المنخفض والاستجابة. <br><br> مفيد بشكل خاص للطائرات الصغيرة ومتحكمات السرعة الإلكترونية 48k. ليس له تأثير عند throttle  الأعلى.<br><br>يمكن أن يختلف مقدار التعويض بين 0 و 150%. عادةً ما يكون 30-40% كافيًا."
+    },
+    "pidTuningThrustLinearValue": {
+        "message": "%"
+    },
+    "pidTuningItermRotation": {
+        "message": "تدوير I Term"
+    },
+    "pidTuningItermRotationHelp": {
+        "message": "يدير متجه I Term الحالي بشكل صحيح إلى المحاور الأخرى مع دوران الطائرة عند yaw باستمرار أثناء roll وعند أداء الحفر والحيل الأخرى. يقدره بشدة طياري أكرو LOS."
+    },
+    "pidTuningItermRelax": {
+        "message": "تخفيف I Term"
+    },
+    "pidTuningItermRelaxHelp": {
+        "message": "يحدّ من تراكم I Term  أثناء الحركات السريعة، مما يقلل الارتداد في نهاية حركات Roll وFlip وغيرها من المدخلات السريعة.<br><br>يستجيب وضع Setpoint لمدخلات عصا التحكم المنعّمة، ويعمل بشكل أفضل مع الطائرات سريعة الاستجابة.<br><br>قد يكون وضع Gyro مفيدًا للطائرات بطيئة الاستجابة جدًا.<br><br>عادةً، ينبغي عدم تطبيق تخفيف مركّبة I على محور Yaw.\n"
+    },
+    "pidTuningItermRelaxAxes": {
+        "message": "المحاور",
+        "description": "Iterm Relax Axes selection"
+    },
+    "pidTuningOptionRP": {
+        "message": "RP"
+    },
+    "pidTuningOptionRPY": {
+        "message": "RPY"
+    },
+    "pidTuningItermRelaxAxesOptionRPInc": {
+        "message": "RP (زيادة فقط)"
+    },
+    "pidTuningItermRelaxAxesOptionRPYInc": {
+        "message": "RPY (زيادة فقط)"
+    },
+    "pidTuningItermRelaxType": {
+        "message": "النوع",
+        "description": "Iterm Relax Type selection"
+    },
+    "pidTuningItermRelaxTypeOptionSetpoint": {
+        "message": "نقطة الضبط"
+    },
+    "pidTuningItermRelaxCutoff": {
+        "message": "القطع",
+        "description": "Cutoff value of the I Term Relax"
+    },
+    "pidTuningItermRelaxCutoffHelp": {
+        "message": "تعني القيم المنخفضة تثبيطًا أقوى للارتداد بعد حركات Flip في الطائرات ذات قدرة التحكم المنخفضة. وتزيد القيم الأعلى دقة الانعطاف بمعدلات دوران عالية في السباقات.<br><br>اضبط القيمة على 30-40 للسباقات، و15 لطائرات Freestyle سريعة الاستجابة، و10 لطائرات Freestyle الأثقل، و3-5 لطائرات X-class.\n"
+    },
+    "pidTuningAbsoluteControlGain": {
+        "message": "التحكم المطلق"
+    },
+    "pidTuningAbsoluteControlGainHelp": {
+        "message": "هذه الميزة تحل بعض المشاكل الأساسية لـ $t(pidTuningItermRotation.message) وقد تحل محلها في وقت ما. تتراكم خطأ الجيروسكوب المطلق في إحداثيات الطائرة وتخلط تصحيحًا تناسبيًا في Setpoint.<br><br>يجب تمكين AirMode و $t(pidTuningItermRelax.message) (لـ $t(pidTuningOptionRP.message)). عند الجمع مع $t(pidTuningIntegratedYaw.message)، يمكنك تعيين $t(pidTuningItermRelax.message) ممكّن لـ $t(pidTuningOptionRPY.message)."
+    },
+    "pidTuningThrottleBoost": {
+        "message": "تعزيز Throttle "
+    },
+    "pidTuningThrottleBoostHelp": {
+        "message": "يعزز Throttle  بشكل عابر مع مدخلات Throttle  أسرع، مما يوفر استجابة Throttle  فورية أكثر"
+    },
+    "pidTuningIdleMinRpm": {
+        "message": "قيمة الخمول الديناميكي [* 100 دورة في الدقيقة]"
+    },
+    "pidTuningIdleMinRpmHelp": {
+        "message": "يحسّن الخمول الديناميكي التحكم عند سرعات الدوران المنخفضة، ويقلل خطر فقدان تزامن المحركات. <br \/><br \/> كما يحسّن قدرة تحكم PID، والثبات عند صفر خنق، ومدة البقاء في الوضع المقلوب، وكبح المحركات.<br \/><br \/>يجب ضبط الحد الأدنى لسرعة دوران الخمول الديناميكي على نحو 3000 - 3500 دورة في الدقيقة. <br \/><br \/>تفضل بزيارة <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Dynamic-Idle\" target=\"_blank\" rel=\"noopener noreferrer\">صفحة الويكي هذه<\/a> لمزيد من المعلومات.\n"
+    },
+    "pidTuningIdleMinRpmDisabled": {
+        "message": "الخمول الديناميكي معطل لأن تليمترية Dshot غير مفعلة"
+    },
+    "pidTuningAcroTrainerAngleLimit": {
+        "message": "حد زاوية وضع تدريب الأكرو\n"
+    },
+    "pidTuningAcroTrainerAngleLimitHelp": {
+        "message": "يساعد الطيارين على تعلم الطيران في وضع الأكرو عن طريق الحد من الزاوية التي يمكن أن تصل إليها الطائرة. الحدود الصالحة هي 10-80 درجة. يجب تنشيط الوضع بمفتاح في $t(tabAuxiliary.message)."
+    },
+    "pidTuningIntegratedYaw": {
+        "message": "yaw المتكامل"
+    },
+    "pidTuningIntegratedYawCaution": {
+        "message": "<span class=\"message-negative\">تحذير<\/span>: إذا قمت بتمكين هذه الميزة، يجب عليك ضبط PID للـ yaw وفقًا لذلك. المزيد من المعلومات <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Integrated-Yaw\" target=\"_blank\" rel=\"noopener noreferrer\">هنا<\/a>"
+    },
+    "pidTuningIntegratedYawHelp": {
+        "message": "يدمج yaw المتكامل قيم P و I و D للـ yaw، مما يسمح بضبط P و I و D للـ yaw قليلاً كما تضبط PITCH وROLL .<br><br>يحتاج إلى القليل جدًا من I، لأن P المتكامل يعمل مثل I، و D المتكامل يعمل مثل P.<br><br>ملاحظة: يتطلب YAW المتكامل استخدام التحكم المطلق، حيث لا حاجة لـ I مع YAW المتكامل."
+    },
+    "failsafeFeaturesHelpOld": {
+        "message": "تكوين الفشل الآمن تغير بشكل كبير. استخدم Betaflight <strong>v1.12.0+<\/strong> لتمكين لوحة التكوين المحسنة."
+    },
+    "failsafePaneTitleOld": {
+        "message": "فشل آمن للمستقبل"
+    },
+    "failsafeFeaturesHelpNew": {
+        "message": "يتكون نظام Failsafe من مرحلتين. يتم الدخول إلى <strong>المرحلة 1<\/strong> عندما يكون طول نبضة إحدى قنوات التحكم غير صالح، أو يبلّغ جهاز الاستقبال عن حالة Failsafe، أو تنقطع إشارة جهاز الاستقبال تمامًا. عندها تُطبّق إعدادات القيم الاحتياطية للقنوات على <span class=\"message-negative\">جميع القنوات<\/span>، وتُمنح مهلة قصيرة لاستعادة الاتصال. يتم الدخول إلى <strong>المرحلة 2<\/strong> عندما تستمر حالة الخطأ مدة أطول من مهلة الحماية المحددة بينما تكون الطائرة <span class=\"message-negative\">مسلّحة<\/span>. وتبقى جميع القنوات عند القيم الاحتياطية المطبّقة، ما لم يغيّرها الإجراء المختار. <br \/><strong>ملاحظة:<\/strong> قبل الدخول إلى المرحلة 1، تُطبّق إعدادات القيم الاحتياطية أيضًا على قنوات AUX الفردية التي تحتوي على نبضات غير صالحة.\n"
+    },
+    "failsafePulsrangeTitle": {
+        "message": "إعدادات نطاق النبضة الصالح"
+    },
+    "failsafePulsrangeHelp": {
+        "message": "النبضات الأقصر من الحد الأدنى أو الأطول من الحد الأقصى غير صالحة وسوف تؤدي إلى تطبيق إعدادات الرجوع للقناة الفردية لقنوات AUX أو الدخول في المرحلة 1 لقنوات الطيران"
+    },
+    "failsafeRxMinUsecItem": {
+        "message": "الحد الادنى للطول"
+    },
+    "failsafeRxMaxUsecItem": {
+        "message": "الحد الأقصى للطول"
+    },
+    "failsafeChannelFallbackSettingsTitle": {
+        "message": "المرحلة 1 - إعدادات الرجوع للقناة"
+    },
+    "failsafeChannelFallbackSettingsHelp": {
+        "message": "يتم تطبيق هذه الإعدادات على قنوات AUX الفردية غير الصالحة أو على جميع القنوات عند الدخول في المرحلة 1. <strong>ملاحظة:<\/strong> يتم حفظ القيم بخطوات 25 ميكروثانية، لذا تختفي التغييرات الصغيرة"
+    },
+    "failsafeChannelFallbackSettingsAuto": {
+        "message": "<strong>تلقائي<\/strong> يعني Roll, Pitch و Yaw إلى المركز ودفع Throttle  منخفض. <strong>تثبيت<\/strong> يعني الحفاظ على آخر قيمة جيدة تم استلامها"
+    },
+    "failsafeChannelFallbackSettingsHold": {
+        "message": "<strong>تثبيت<\/strong> يعني الحفاظ على آخر قيمة جيدة تم استلامها. <strong>تعيين<\/strong> يعني أنه سيتم استخدام القيمة المعطاة هنا"
+    },
+    "failsafeChannelFallbackSettingsValueAuto": {
+        "message": "تلقائي",
+        "description": "Text for Auto option"
+    },
+    "failsafeChannelFallbackSettingsValueHold": {
+        "message": "تثبيت",
+        "description": "Text for Hold option"
+    },
+    "failsafeChannelFallbackSettingsValueSet": {
+        "message": "تعيين",
+        "description": "Text for Set option"
+    },
+    "failsafeStageTwoSettingsTitle": {
+        "message": "المرحلة 2 - الإعدادات"
+    },
+    "failsafeDelayItem": {
+        "message": "فترة الزمن في الفشل الآمن للمرحلة 1 بعد فقدان الإشارة [ثواني]"
+    },
+    "failsafeDelayHelp": {
+        "message": "اضبط الفترة الزمنية في الفشل الآمن للمرحلة 1 بعد فقدان الإشارة. إذا انتهى وقت التأخير دون عودة الإشارة، سيبدأ الفشل الآمن للمرحلة 2"
+    },
+    "failsafeThrottleLowItem": {
+        "message": "تأخير الفشل الآمن لدواسة الوقود المنخفضة [ثواني]"
+    },
+    "failsafeThrottleLowHelp": {
+        "message": "فقط قم بإلغاء تشغيل الطائرة بدلاً من تنفيذ إجراء الفشل الآمن المحدد عندما كانت دواسة الوقود منخفضة لهذه الفترة الزمنية"
+    },
+    "failsafeThrottleItem": {
+        "message": "قيمة دفع throttle  المستخدمة أثناء الهبوط"
+    },
+    "failsafeOffDelayItem": {
+        "message": "التأخير لإيقاف تشغيل المحركات أثناء الفشل الآمن [ثواني]"
+    },
+    "failsafeOffDelayHelp": {
+        "message": "الوقت للبقاء في وضع الهبوط حتى يتم إيقاف تشغيل المحركات وإلغاء تشغيل الطائرة"
+    },
+    "failsafeSubTitle1": {
+        "message": "المرحلة 2 - إجراء الفشل الآمن"
+    },
+    "failsafeProcedureItemSelect1": {
+        "message": "هبوط"
+    },
+    "failsafeProcedureItemSelect2": {
+        "message": "إسقاط"
+    },
+    "failsafeProcedureItemSelect4": {
+        "message": "إنقاذ GPS"
+    },
+    "failsafeGpsRescueItemAltitudeMode": {
+        "message": "وضع الارتفاع"
+    },
+    "failsafeGpsRescueItemAltitudeModeMaxAlt": {
+        "message": "الحد الأقصى للارتفاع"
+    },
+    "failsafeGpsRescueItemAltitudeModeFixedAlt": {
+        "message": "ارتفاع ثابت"
+    },
+    "failsafeGpsRescueItemAltitudeModeCurrentAlt": {
+        "message": "الارتفاع الحالي"
+    },
+    "failsafeGpsRescueInitialClimb": {
+        "message": "الصعود الأولي (أمتار)"
+    },
+    "failsafeGpsRescueInitialClimbHelp": {
+        "message": "المسافة التي ستتسلقها الطائرة، فوق الارتفاع الحالي، عندما يتم بدء الإنقاذ ووضع الارتفاع مضبوط على الارتفاع الحالي؛ يُضاف أيضًا في وضع الحد الأقصى للارتفاع."
+    },
+    "failsafeGpsRescueItemReturnAltitude": {
+        "message": "ارتفاع العودة (أمتار)"
+    },
+    "failsafeGpsRescueItemAscendRate": {
+        "message": "معدل الصعود (أمتار\/ثانية)"
+    },
+    "failsafeGpsRescueItemGroundSpeed": {
+        "message": "سرعة الأرض للعودة (أمتار\/ثانية)"
+    },
+    "failsafeGpsRescueItemAngle": {
+        "message": "أقصى زاوية ميلان"
+    },
+    "failsafeGpsRescueAngleHelp": {
+        "message": "الزوايا القصوى الأعلى تؤدي إلى عودة أكثر عدوانية وسرعات أمامية أعلى. قد تكون مفيدة للطائرات الأثقل، عالية السحب أو منخفضة السلطة، أو للاستخدام في رياح أقوى. تحذير: عادةً ما يحتاج زيادة throttle  إذا تم زيادة أقصى زاوية! وإلا قد تفقد الطائرة الارتفاع وتتحطم!"
+    },
+    "failsafeGpsRescueItemDescentDistance": {
+        "message": "مسافة النزول (أمتار)"
+    },
+    "failsafeGpsRescueItemDescendRate": {
+        "message": "معدل النزول (أمتار\/ثانية)"
+    },
+    "failsafeGpsRescueDescendRateHelp": {
+        "message": "يتم ضبط معدل النزول الأولي على 3 أضعاف هذه القيمة، متناقصًا إلى القيمة المضبوطة عند ارتفاع الهبوط."
+    },
+    "failsafeGpsRescueItemMinStartDistHelp": {
+        "message": "إذا بدأ الإنقاذ قريبًا جدًا من المنزل (ضمن هذه المسافة الدنيا)، ستطير الطائرة بعيدًا، في اتجاهها الحالي، حتى تكون على الأقل هذه المسافة من المنزل، ثم تبدأ سلوك الإنقاذ الطبيعي",
+        "description": "Updated help text for the minimum start distance needed for GPS rescue to activate"
+    },
+    "failsafeGpsRescueItemThrottleMin": {
+        "message": "الحد الأدنى للـ Throttle "
+    },
+    "failsafeGpsRescueItemThrottleMax": {
+        "message": "الحد الأقصى للـ Throttle "
+    },
+    "failsafeGpsRescueThrottleMaxHelp": {
+        "message": "يجب زيادته للطائرات الأثقل، عالية السحب أو منخفضة السلطة، إذا كان من المحتمل العودة ضد رياح قوية، أو إذا تم زيادة أقصى زاوية PITCH."
+    },
+    "failsafeGpsRescueItemThrottleHover": {
+        "message": "Throttle hover  - <span class=\"message-negative\">مهم: اضبط هذه القيمة بدقة<\/span>"
+    },
+    "failsafeGpsRescueThrottleHoverHelp": {
+        "message": "للعثور على القيمة الصحيحة، اضبط إجراء مفتاح الفشل الآمن على المرحلة 2، اضبط إجراء الفشل الآمن للمرحلة 2 على الهبوط، وضبط قيمة دفع المحرك المستخدمة أثناء الهبوط حتى تحوم الطائرة أو تنزل ببطء. ثم اضبط دفع Throttle Hover  لإنقاذ GPS، وقيمة الرجوع لدفع Throttle في المرحلة 1 على هذه القيمة."
+    },
+    "failsafeGpsRescueItemMinDth": {
+        "message": "أقل مسافة إلى المنزل (أمتار)"
+    },
+    "failsafeGpsRescueItemMinDthHelp": {
+        "message": "أقل مسافة إلى المنزل مطلوبة لتفعيل إنقاذ GPS"
+    },
+    "failsafeGpsRescueItemMinSats": {
+        "message": "الحد الأدنى للأقمار الصناعية"
+    },
+    "failsafeGpsRescueItemAllowArmingWithoutFix": {
+        "message": "السماح بالتشغيل بدون تثبيت - <span class=\"message-negative\">تحذير: لا تثبيت = إلغاء التشغيل عند الفشل الآمن!<\/span>"
+    },
+    "failsafeGpsRescueArmWithoutFixHelp": {
+        "message": "غير موصى به. يسمح بالتشغيل دون تعيين نقطة المنزل، لكن الطائرة سوف تلغي التشغيل وتتحطم مع فشل آمن حقيقي لفقدان Rx. إذا تم اختباره بمفتاح، هناك فترة قصيرة لا تفعل شيئًا قبل إلغاء التشغيل ."
+    },
+    "failsafeGpsRescueItemSanityChecks": {
+        "message": "فحوصات التعقل"
+    },
+    "failsafeGpsRescueItemSanityChecksOff": {
+        "message": "إيقاف"
+    },
+    "failsafeGpsRescueItemSanityChecksOn": {
+        "message": "تشغيل"
+    },
+    "failsafeGpsRescueItemSanityChecksFSOnly": {
+        "message": "فشل آمن فقط"
+    },
+    "failsafeKillSwitchItem": {
+        "message": "مفتاح أغلاق الفشل الآمن (أضبط الفشل الآمن في علامة Modes )"
+    },
+    "failsafeKillSwitchHelp": {
+        "message": "اضبط هذا الخيار لجعل مفتاح الفشل الآمن (لسان الأنماط) يعمل كمفتاح إيقاف مباشر، متجاوزًا إجراء الفشل الآمن المحدد. <strong>ملاحظة:<\/strong> يتم حظر التسليح عندما يكون مفتاح إيقاف الفشل الآمن في وضع التشغيل"
+    },
+    "failsafeSwitchTitle": {
+        "message": "مفتاح الفشل الآمن"
+    },
+    "failsafeSwitchModeItem": {
+        "message": "تأثير مفتاح الفشل الآمن"
+    },
+    "failsafeSwitchModeHelp": {
+        "message": "يحدد هذا الخيار ما يحدث عند تنشيط الفشل الآمن عبر مفتاح AUX:<br\/><strong>المرحلة 1<\/strong> ينشط الفشل الآمن للمرحلة 1. هذا مفيد إذا كنت تريد محاكاة سلوك الفشل الآمن الدقيق لفقدان الإشارة.<br\/><strong>المرحلة 2<\/strong> يتخطى المرحلة 1 وينشط إجراء المرحلة 2 فورًا<br\/><strong>إيقاف<\/strong> يلغي التسليح على الفور (ستتحطم طائرتك)"
+    },
+    "failsafeSwitchOptionStage1": {
+        "message": "المرحلة 1"
+    },
+    "failsafeSwitchOptionStage2": {
+        "message": "المرحلة 2"
+    },
+    "failsafeSwitchOptionKill": {
+        "message": "وقف"
+    },
+    "powerButtonSave": {
+        "message": "حفظ"
+    },
+    "powerFirmwareUpgradeRequired": {
+        "message": "ترقية البرنامج الثابت <span class=\"message-negative\">مطلوبة<\/span>. تكوينات البطارية\/التيار\/الجهد باستخدام API &lt; 1.33.0 (إصدار Betaflight &lt;= 3.17) غير مدعوم."
+    },
+    "powerBatteryVoltageMeterSource": {
+        "message": "مصدر مقياس الجهد للبطارية"
+    },
+    "powerBatteryVoltageMeterTypeNone": {
+        "message": "لا يوجد"
+    },
+    "powerBatteryVoltageMeterTypeAdc": {
+        "message": "ADC المضمن"
+    },
+    "powerBatteryVoltageMeterTypeEsc": {
+        "message": "مستشعر متحكم السرعة الألكتروني"
+    },
+    "powerBatteryCurrentMeterSource": {
+        "message": "مصدر مقياس التيار للبطارية"
+    },
+    "powerBatteryCurrentMeterTypeNone": {
+        "message": "لا يوجد"
+    },
+    "powerBatteryCurrentMeterTypeAdc": {
+        "message": "وحدة ADC المدمجة في اللوحة\n"
+    },
+    "powerBatteryCurrentMeterTypeVirtual": {
+        "message": "افتراضي"
+    },
+    "powerBatteryCurrentMeterTypeEsc": {
+        "message": "مستشعر متحكم السرعة الألكتروني"
+    },
+    "powerBatteryCurrentMeterTypeMsp": {
+        "message": "مستشعر MSP\/OSD Slave"
+    },
+    "powerBatteryMinimum": {
+        "message": "الحد الأدنى لجهد الخلية"
+    },
+    "powerBatteryMaximum": {
+        "message": "الحد الأقصى لجهد الخلية"
+    },
+    "powerBatteryWarning": {
+        "message": "جهد الخلية التحذيري"
+    },
+    "powerBatteryMinimumHelp": {
+        "message": "الجهد الذي يعتبر منخفضًا بشكل خطير، وسيؤدي إلى تشغيل التحذيرات المقابلة. تحذير 'اهبط الآن' في OSD وصفير مسموع إذا كان هناك صافرة ملحومة. يساعد أيضًا في حساب عدد الخلايا."
+    },
+    "powerBatteryMaximumHelp": {
+        "message": "جهد الخلية المشحونة بالكامل. يساعد في حساب عدد الخلايا."
+    },
+    "powerBatteryWarningHelp": {
+        "message": "الجهد الذي يعتبر منخفضًا، وسيؤدي إلى تشغيل التحذيرات المقابلة. تحذير 'بطارية منخفضة' في OSD."
+    },
+    "powerCalibrationManagerButton": {
+        "message": "معايرة"
+    },
+    "powerCalibrationManagerTitle": {
+        "message": "ادارة المعايرة"
+    },
+    "powerCalibrationManagerHelp": {
+        "message": "للمعايرة، استخدم مقياس متعدد لقياس الجهد الفعلي \/ استهلاك التيار على طائرتك (مع توصيل البطارية)، وأدخل القيم أدناه. ثم، مع نفس البطارية لا تزال موصولة، انقر على [معايرة]."
+    },
+    "powerCalibrationManagerNote": {
+        "message": "<strong>ملاحظة:<\/strong> قبل معايرة المقياس تأكد من ضبط المقسم والمضاعف للجهد والإزاحة للتيار بشكل صحيح.<br>ترك القيم عند 0 لن يطبق المعايرة.<\/br><strong>تذكر إزالة المراوح قبل توصيل البطارية!<\/strong>"
+    },
+    "powerCalibrationManagerWarning": {
+        "message": "<span class=\"message-negative\">تحذير:<\/span> البطارية <span class=\"message-negative\">غير موصولة<\/span> أو مصادر مقياس الجهد والتيار <span class=\"message-negative\">غير مضبوطة بشكل صحيح.<\/span> تأكد من أن الجهد و\/أو التيار يقرأان قيمة أعلى من 0. وإلا لن تتمكن من المعايرة باستخدام هذه الأداة."
+    },
+    "powerCalibrationManagerSourceNote": {
+        "message": "<span class=\"message-negative\">تحذير:<\/span> مصادر مقياس الجهد و\/أو التيار <strong>تم تغييرها ولكن لم يتم حفظها.<\/strong> يرجى تعيين مصادر المقاييس الصحيحة وحفظها قبل محاولة المعايرة."
+    },
+    "powerCalibrationManagerConfirmationTitle": {
+        "message": "تأكيد ادارة المعايرة"
+    },
+    "powerCalibrationSave": {
+        "message": "معايرة"
+    },
+    "powerCalibrationApply": {
+        "message": "تطبيق المعايرة"
+    },
+    "powerCalibrationDiscard": {
+        "message": "تجاهل المعايرة"
+    },
+    "powerCalibrationConfirmHelp": {
+        "message": "المقاييس المعايرة الجديدة معروضة هنا. <br>تطبيقها سيضبط المقاييس ولكن <strong>لن يحفظها.<\/strong><\/br> <br>بعد الحفظ تأكد من أن الجهد والتيار الجديدين صحيحان.<\/br>"
+    },
+    "powerVoltageHead": {
+        "message": "مقياس الفولت"
+    },
+    "powerVoltageWarning": {
+        "message": "<span class=\"message-negative\">تحذير:<\/span> القيم محدودة بـ 25.5 فولت."
+    },
+    "powerVoltageValue": {
+        "message": "$1 فولت"
+    },
+    "powerVoltageCalibration": {
+        "message": "الجهد المقاس"
+    },
+    "powerVoltageCalibratedScale": {
+        "message": "مقياس الجهد المعاير:"
+    },
+    "powerVoltageId10": {
+        "message": "البطارية"
+    },
+    "powerVoltageId20": {
+        "message": "5 فولت"
+    },
+    "powerVoltageId30": {
+        "message": "9 فولت"
+    },
+    "powerVoltageId40": {
+        "message": "12 فولت"
+    },
+    "powerVoltageId50": {
+        "message": "قراءات ESC المجمّعة\n"
+    },
+    "powerVoltageId60": {
+        "message": "متحكم سرعة المحرك 1"
+    },
+    "powerVoltageId61": {
+        "message": "متحكم سرعة المحرك 2"
+    },
+    "powerVoltageId62": {
+        "message": "متحكم سرعة المحرك 3"
+    },
+    "powerVoltageId63": {
+        "message": "متحكم سرعة المحرك 4"
+    },
+    "powerVoltageId64": {
+        "message": "متحكم سرعة المحرك 5"
+    },
+    "powerVoltageId65": {
+        "message": "متحكم سرعة المحرك 6"
+    },
+    "powerVoltageId66": {
+        "message": "متحكم سرعة المحرك 7"
+    },
+    "powerVoltageId67": {
+        "message": "متحكم سرعة المحرك 8"
+    },
+    "powerVoltageId68": {
+        "message": "متحكم سرعة المحرك 9"
+    },
+    "powerVoltageId69": {
+        "message": "متحكم سرعة المحرك 10"
+    },
+    "powerVoltageId70": {
+        "message": "متحكم سرعة المحرك 11"
+    },
+    "powerVoltageId71": {
+        "message": "متحكم سرعة المحرك 12"
+    },
+    "powerVoltageId80": {
+        "message": "خلية 1"
+    },
+    "powerVoltageId81": {
+        "message": "خلية 2"
+    },
+    "powerVoltageId82": {
+        "message": "خلية 3"
+    },
+    "powerVoltageId83": {
+        "message": "خلية 4"
+    },
+    "powerVoltageId84": {
+        "message": "خلية 5"
+    },
+    "powerVoltageId85": {
+        "message": "خلية 6"
+    },
+    "powerVoltageScale": {
+        "message": "مقياس"
+    },
+    "powerVoltageDivider": {
+        "message": "قيمة مُقسِّم الجهد\n"
+    },
+    "powerVoltageMultiplier": {
+        "message": "القيمة المضاعف"
+    },
+    "powerAmperageHead": {
+        "message": "مقياس الأمبيرية"
+    },
+    "powerAmperageWarning": {
+        "message": "<span class=\"message-negative\">تحذير:<\/span> القيم محدودة بـ 63.5 أمبير."
+    },
+    "powerAmperageValue": {
+        "message": "$1 أمبير"
+    },
+    "powerAmperageId10": {
+        "message": "البطارية"
+    },
+    "powerAmperageId50": {
+        "message": "قراءات ESC المجمّعة\n"
+    },
+    "powerAmperageId60": {
+        "message": "متحكم سرعة المحرك 1"
+    },
+    "powerAmperageId61": {
+        "message": "متحكم سرعة المحرك 2"
+    },
+    "powerAmperageId62": {
+        "message": "متحكم سرعة المحرك 3"
+    },
+    "powerAmperageId63": {
+        "message": "متحكم سرعة المحرك 4"
+    },
+    "powerAmperageId64": {
+        "message": "متحكم سرعة المحرك 5"
+    },
+    "powerAmperageId65": {
+        "message": "متحكم سرعة المحرك 6"
+    },
+    "powerAmperageId66": {
+        "message": "متحكم سرعة المحرك 7"
+    },
+    "powerAmperageId67": {
+        "message": "متحكم سرعة المحرك 8"
+    },
+    "powerAmperageId68": {
+        "message": "متحكم سرعة المحرك 9"
+    },
+    "powerAmperageId69": {
+        "message": "متحكم سرعة المحرك 10"
+    },
+    "powerAmperageId70": {
+        "message": "متحكم سرعة المحرك 11"
+    },
+    "powerAmperageId71": {
+        "message": "متحكم سرعة المحرك 12"
+    },
+    "powerAmperageId80": {
+        "message": "افتراضي"
+    },
+    "powerAmperageId90": {
+        "message": "MSP"
+    },
+    "powerMahValue": {
+        "message": "$1 ملي أمبير"
+    },
+    "powerAmperageScale": {
+        "message": "المقياس [1\/10 ملي فولت\/أمبير]"
+    },
+    "powerAmperageOffset": {
+        "message": "الإزاحة [مللي أمبير]"
+    },
+    "powerAmperageCalibration": {
+        "message": "التيار المقاس"
+    },
+    "powerAmperageCalibratedScale": {
+        "message": "مقياس التيار المعاير:"
+    },
+    "powerBatteryProfile": {
+        "message": "ملف تعريف البطارية"
+    },
+    "powerBatteryProfileOption": {
+        "message": "ملف تعريف البطارية $1"
+    },
+    "powerReceivedBatteryProfile": {
+        "message": "تم تعيين ملف تعريف البطارية في متحكم الطيران: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "powerBatteryProfileNamePlaceholder": {
+        "message": "مثل LiPo وLi-Ion"
+    },
+    "powerBatteryProfileNameLabel": {
+        "message": "اسم الملف التعريفي"
+    },
+    "powerBatteryHead": {
+        "message": "البطارية"
+    },
+    "powerStateHead": {
+        "message": "وضع الطاقة"
+    },
+    "powerBatteryConnected": {
+        "message": "متصل"
+    },
+    "powerBatteryConnectedValueYes": {
+        "message": "نعم (الخلايا: $1)"
+    },
+    "powerBatteryConnectedValueNo": {
+        "message": "لا"
+    },
+    "powerBatteryVoltage": {
+        "message": "الفولت"
+    },
+    "powerBatteryCurrentDrawn": {
+        "message": "ملي أمبير مستخدم"
+    },
+    "powerBatteryAmperage": {
+        "message": "التيار"
+    },
+    "powerBatteryPowerDraw": {
+        "message": "استهلاك الطاقة"
+    },
+    "powerWattValue": {
+        "message": "قيمة الطاقة بالواط"
+    },
+    "powerBatteryVoltageDrop": {
+        "message": "هبوط الجهد"
+    },
+    "powerBatteryCapacity": {
+        "message": "سعة (ملي أمبير)"
+    },
+    "osdSetupTitle": {
+        "message": "عارض المعلومات على الشاشه"
+    },
+    "osdToggleElementVisibility": {
+        "message": "تبديل إظهار {{element}} لملف التعريف {{profile}}"
+    },
+    "osdSetupNoOsdChipDetectWarning": {
+        "message": "<span class=\"message-negative\"><b>تحذير:<\/b><\/span> لم يتم اكتشاف شريحة OSD. بعض وحدات التحكم الطيران لن تزود شريحة OSD بالطاقة بشكل صحيح إلا إذا كانت متصلة بطاقة البطارية. يرجى توصيل البطارية قبل توصيل USB (تم إزالة المراوح!)."
+    },
+    "osdSetupPreviewHelp": {
+        "message": "<strong>ملاحظة:<\/strong> قد لا يظهر معاين OSD الخط الفعلي المثبت على وحدة التحكم الطيران. قد يبدو تخطيط العناصر الفردية مختلفًا عند استخدام إصدارات أقدم من البرنامج الثابت - يرجى التحقق من المظهر من خلال نظارتك قبل الطيران."
+    },
+    "osdSetupUnsupportedNote1": {
+        "message": "وحدة التحكم الطيران الخاصة بك لا تستجيب لأوامر OSD. هذا يعني على الأرجح أنها لا تحتوي على OSD Betaflight مدمج."
+    },
+    "osdSetupUnsupportedNote2": {
+        "message": "لاحظ أن بعض وحدات التحكم الطيران تحتوي على <a href=\"https:\/\/www.youtube.com\/watch?v=ikKH_6SQ-Tk\" target=\"_blank\" rel=\"noopener noreferrer\">MinimOSD<\/a> مدمج يمكن تثبيته وتكوينه باستخدام <a href=\"https:\/\/github.com\/ShikOfTheRa\/scarab-osd\/releases\/latest\" target='_blank'>scarab-osd<\/a>، ومع ذلك لا يمكن تكوين MinimOSD من خلال هذه الواجهة."
+    },
+    "osdSetupProfilesTitle": {
+        "message": "رقم ملف OSD الشخصي",
+        "description": "Description of the header of the OSD elements column associated to each profile"
+    },
+    "osdSetupElementsTitle": {
+        "message": "العناصر"
+    },
+    "osdSetupPreviewTitle": {
+        "message": "اسحب العناصر لتغيير الموضع",
+        "description": "Indicates in the preview window of the OSD that the user can drag the elements to reorder them"
+    },
+    "osdSetupPreviewSelectProfileTitle": {
+        "message": "المعاينة ل",
+        "description": "Label of the selector for the OSD Profile in the preview. KEEP IT SHORT!!!"
+    },
+    "osdSetupPreviewForTitle": {
+        "message": "التغيير هنا للملف الشخصي أو الخط لن يغير الملف الشخصي أو الخط في وحدة التحكم الطيران، يؤثر فقط على نافذة المعاينة. إذا كنت تريد تغييره، يجب عليك استخدام خيار '$t(osdSetupSelectedProfileTitle.message)' أو زر '$t(osdSetupFontManager.message)' على التوالي.",
+        "description": "Help content for the OSD profile and font PREVIEW"
+    },
+    "osdSetupSelectedProfileTitle": {
+        "message": "ملف OSD الشخصي النشط",
+        "description": "Title of the box to select the current active OSD profile"
+    },
+    "osdSetupSelectedProfileLabel": {
+        "message": "الحالي:",
+        "description": "Label for the selection of the curren active OSD profile"
+    },
+    "osdSetupPreviewSelectProfileElement": {
+        "message": "ملف OSD الشخصي {{profileNumber}}",
+        "description": "Content of the selector for the OSD Profile in the preview"
+    },
+    "osdSetupPreviewSelectFont": {
+        "message": "الخط",
+        "description": "Content of the selector for the OSD Font in the preview"
+    },
+    "osdSetupFontManagerTitle": {
+        "message": "مدير خط OSD",
+        "description": "Dialog title"
+    },
+    "osdSetupFontTypeDefault": {
+        "message": "افتراضي",
+        "description": "Font Default"
+    },
+    "osdSetupFontTypeBold": {
+        "message": "عريض",
+        "description": "Font Bold"
+    },
+    "osdSetupFontTypeLarge": {
+        "message": "كبير",
+        "description": "Font Large"
+    },
+    "osdSetupFontTypeLargeExtra": {
+        "message": "كبير جدًا",
+        "description": "Font Large Extra"
+    },
+    "osdSetupFontTypeBetaflight": {
+        "message": "Betaflight",
+        "description": "Font Betaflight"
+    },
+    "osdSetupFontTypeDigital": {
+        "message": "Digital",
+        "description": "Font Digital"
+    },
+    "osdSetupFontTypeClarity": {
+        "message": "Clarity",
+        "description": "Font Clarity"
+    },
+    "osdSetupFontTypeVision": {
+        "message": "الرؤية",
+        "description": "Font Vision"
+    },
+    "osdSetupFontTypeImpact": {
+        "message": "تأثير",
+        "description": "Font Impact"
+    },
+    "osdSetupFontTypeImpactMini": {
+        "message": "تأثير مصغر",
+        "description": "Font Impact Mini"
+    },
+    "osdSetupPreviewCheckZoom": {
+        "message": "تكبير",
+        "description": "Check to select a bigger display of the OSD preview in small screens"
+    },
+    "osdSetupVideoFormatTitle": {
+        "message": "صيغة الفيديو"
+    },
+    "osdSetupVideoFormatOptionAuto": {
+        "message": "تلقائي",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSetupVideoFormatOptionPal": {
+        "message": "PAL",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSetupVideoFormatOptionNtsc": {
+        "message": "NTSC",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSetupVideoFormatOptionHd": {
+        "message": "HD",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdProtocol": {
+        "message": "بروتوكول OSD"
+    },
+    "osdProtocolHelp": {
+        "message": "البروتوكول المستخدم لعرض OSD. يقوم MAX7456 وFrSky OSD بتشغيل شريحة أو وحدة تناظرية، بينما يرسل MSP بيانات OSD عبر منفذ UART المحدد أدناه، كما تتطلب نظارات DJI وHDZero وWalksnail.\n"
+    },
+    "osdSerialPort": {
+        "message": "منفذ OSD المسلسل"
+    },
+    "osdSerialPortHelp": {
+        "message": "منفذ UART الموصول به نظام OSD تسلسلي. ابتداءً من API 1.49، يُضبط المنفذ من جهاز OSD نفسه؛ أما علامة المنافذ فتعرضه فقط.\n"
+    },
+    "osdCustomTextSerialPort": {
+        "message": "المنفذ التسلسلي للنص المخصص\n"
+    },
+    "osdCustomTextSerialPortHelp": {
+        "message": "تم استلام نص OSD مخصص UART."
+    },
+    "osdCustomTextSerialBaud": {
+        "message": "سرعة اتصال النص المخصص\n"
+    },
+    "osdCustomTextSerialBaudHelp": {
+        "message": "سرعة الاتصال لمنفذ نص OSD المخصص.\n"
+    },
+    "osdSetupUnitsTitle": {
+        "message": "وحدات"
+    },
+    "osdSetupUnitsOptionImperial": {
+        "message": "إمبراطوري",
+        "description": "Option for the units system used in the OSD"
+    },
+    "osdSetupUnitsOptionMetric": {
+        "message": "متري",
+        "description": "Option for the units system used in the OSD"
+    },
+    "osdSetupUnitsOptionBritish": {
+        "message": "بريطاني",
+        "description": "Option for the units system used in the OSD"
+    },
+    "osdSetupTimersTitle": {
+        "message": "المؤقتات"
+    },
+    "osdSetupAlarmsTitle": {
+        "message": "أنذارات"
+    },
+    "osdSetupStatsTitle": {
+        "message": "إحصائيات ما بعد الطيران"
+    },
+    "osdSetupVtxTitle": {
+        "message": "إعدادات VTX"
+    },
+    "osdSetupCraftNameTitle": {
+        "message": "اسم الطائرة"
+    },
+    "osdSetupWarningsTitle": {
+        "message": "تحذيرات"
+    },
+    "osdSetupFontPresets": {
+        "message": "الضبط المسبق للخط:"
+    },
+    "osdSetupFontPresetsSelector": {
+        "message": "أختر الضبط المسبق للخط:"
+    },
+    "osdSetupFontPresetsSelectorCustomOption": {
+        "message": "خط مقدم من المستخدم",
+        "description": "Option to show as selected when the user selects a custom local font"
+    },
+    "osdSetupFontPresetsSelectorOr": {
+        "message": "أو"
+    },
+    "osdSetupOpenFont": {
+        "message": "أفتح ملف الخط"
+    },
+    "osdSetupCustomLogoTitle": {
+        "message": "شعار التمهيد:"
+    },
+    "osdSetupCustomLogoOpenImageButton": {
+        "message": "حدد صورة مخصصة&hellip;"
+    },
+    "osdSetupCustomLogoInfoTitle": {
+        "message": "صورة مخصصة:"
+    },
+    "osdSetupCustomLogoInfoImageSize": {
+        "message": "يجب أن يكون الحجم {{logoWidthPx}}×{{logoHeightPx}} بكسل"
+    },
+    "osdSetupCustomLogoInfoColorMap": {
+        "message": "يجب أن يحتوي بكسلات أخضر, أسود وأبيض"
+    },
+    "osdSetupCustomLogoInfoUploadHint": {
+        "message": "انقر <b>$t(osdSetupUploadFont.message)<\/b> لجعل الشعار المخصص دائمًا"
+    },
+    "osdSetupCustomLogoImageSizeError": {
+        "message": "حجم الصورة غير صالح: {{width}}×{{height}} (المتوقع {{logoWidthPx}}×{{logoHeightPx}})"
+    },
+    "osdSetupCustomLogoColorMapError": {
+        "message": "تحتوي الصورة على بكسل غير صالح: rgb({{valueR}}, {{valueG}}, {{valueB}}) عند الإحداثيات {{posX}}×{{posY}}"
+    },
+    "osdSetupUploadFont": {
+        "message": "رفع الخط"
+    },
+    "osdSetupUploadingFont": {
+        "message": "جاري الرفع..."
+    },
+    "osdSetupUploadingFontEnd": {
+        "message": "تم رفع جميع {{length}} حرفًا إلى OSD"
+    },
+    "osdSetupUploadingFontFailed": {
+        "message": "فشل الرفع"
+    },
+    "osdSetupSaveReboot": {
+        "message": "حفظ وإعادة التشغيل"
+    },
+    "osdSetupSave": {
+        "message": "حفظ"
+    },
+    "osdSetupRefresh": {
+        "message": "تحديث"
+    },
+    "osdSetupFontManager": {
+        "message": "مدير الخط"
+    },
+    "osdSetupUncheckAll": {
+        "message": "إلغاء اختيار الكل"
+    },
+    "osdSetupHead": {
+        "message": "معلومات"
+    },
+    "osdSetupVideoMode": {
+        "message": "وضع الفيديو"
+    },
+    "osdSetupCameraConnected": {
+        "message": "الكاميرا متصلة"
+    },
+    "osdSetupResetText": {
+        "message": "إعادة تعيين OSD إلى الوضع الافتراضي"
+    },
+    "osdSetupButtonReset": {
+        "message": "إعادة تعيين الإعدادات"
+    },
+    "osdTextElementMainBattVoltage": {
+        "message": "جهد البطارية الرئيسية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMainBattVoltage": {
+        "message": "جهد البطارية الرئيسية اللحظي (يومض عندما يكون أقل من عتبة الإنذار)"
+    },
+    "osdTextElementRssiValue": {
+        "message": "RSSI value",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRssiValue": {
+        "message": "قيمة RSSI اللحظية (تومض عند انخفاضها عن حد الإنذار). مع البروتوكولات الحديثة، استخدم RSSI dBm بدلًا منها."
+    },
+    "osdTextElementRssiDbmValue": {
+        "message": "قيمة RSSI بوحدة dBm",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRssiDbmValue": {
+        "message": "مؤشر قوة الإشارة المستقبلة؛ توضح هذه القيمة قوة الاستقبال بوحدة dBm."
+    },
+    "osdTextElementTimer": {
+        "message": "المؤقت",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementTimer": {
+        "message": "مؤقت الطيران"
+    },
+    "osdTextElementThrottlePosition": {
+        "message": "موضع دواسة الوقود",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementThrottlePosition": {
+        "message": "قيمة قناة دواسة الوقود الحالية"
+    },
+    "osdTextElementCpuLoad": {
+        "message": "تحميل المعالج",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCpuLoad": {
+        "message": "تحميل المعالج الحالي"
+    },
+    "osdTextElementVtxChannel": {
+        "message": "قناة VTX",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementVtxChannel": {
+        "message": "قناة وقوة VTX الحالية"
+    },
+    "osdTextElementVTXchannelVariantPower": {
+        "message": "قوة VTX",
+        "description": "One of the variants of the VTX channel element of the OSD"
+    },
+    "osdTextElementVTXchannelVariantFull": {
+        "message": "النطاق:القناة:القوة:الحفرة",
+        "description": "One of the variants of the VTX channel element of the OSD"
+    },
+    "osdTextElementVoltageWarning": {
+        "message": "تحذير جهد البطارية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementVoltageWarning": {
+        "message": "يعرض تحذيرًا عندما يكون الجهد أقل من قيمة الإنذار"
+    },
+    "osdTextElementArmed": {
+        "message": "مشغل",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementArmed": {
+        "message": "رسالة نصية للتشغيل"
+    },
+    "osdTextElementDisarmed": {
+        "message": "غير مشغل",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDisarmed": {
+        "message": "رسالة نصية لإلغاء التشغيل"
+    },
+    "osdTextElementCrosshairs": {
+        "message": "علامات التقاطع",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCrosshairs": {
+        "message": "علامة التقاطع في مركز الشاشة"
+    },
+    "osdTextElementArtificialHorizon": {
+        "message": "الأفق الاصطناعي",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementArtificialHorizon": {
+        "message": "مؤشر الأفق الاصطناعي الرسومي"
+    },
+    "osdTextElementHorizonSidebars": {
+        "message": "الشريط الجانبي للأفق الاصطناعي",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementHorizonSidebars": {
+        "message": "أشرطة جانبية حول مؤشر الأفق الاصطناعي"
+    },
+    "osdTextElementCurrentDraw": {
+        "message": "استهلاك تيار البطارية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCurrentDraw": {
+        "message": "استهلاك تيار البطارية اللحظي"
+    },
+    "osdTextElementMahDrawn": {
+        "message": "استهلاك ملي أمبير للبطارية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMahDrawn": {
+        "message": "السعة الإجمالية للبطارية المستخدمة"
+    },
+    "osdTextElementWhDrawn": {
+        "message": "استهلاك واط ساعة للبطارية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWhDrawn": {
+        "message": "إجمالي سعة البطارية المستخدمة بوحدة واط ساعة"
+    },
+    "osdDescElementAuxValue": {
+        "message": "قيمة إضافي",
+        "description": "Displays a receiver AUX channel see PR 10789"
+    },
+    "osdTextElementAuxValue": {
+        "message": "قيمة إضافي",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementSysGoggleVoltage": {
+        "message": "جهد النظارة",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysGoggleVoltage": {
+        "message": "جهد النظارة المعروض من خلال النظارة"
+    },
+    "osdTextElementSysVtxVoltage": {
+        "message": "جهد جهاز الإرسال الفيديوي (VTX)",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysVtxVoltage": {
+        "message": "جهد جهاز الإرسال الفيديوي (VTX) المعروض من خلال النظارة"
+    },
+    "osdTextElementSysBitrate": {
+        "message": "معدل البت لجهاز الإرسال الفيديو (VTX)",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysBitrate": {
+        "message": "معدل بت الفيديو المعروض من خلال النظارة"
+    },
+    "osdTextElementSysDelay": {
+        "message": "تأخر جهاز الإرسال الفيديو (VTX)",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysDelay": {
+        "message": "تأخر الفيديو المعروض من خلال النظارة"
+    },
+    "osdTextElementSysDistance": {
+        "message": "مسافة جهاز الإرسال الفيديو (VTX)",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysDistance": {
+        "message": "مسافة نقل الفيديو المعروضة من خلال النظارة"
+    },
+    "osdTextElementSysLQ": {
+        "message": "جودة رابط النظارة",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysLQ": {
+        "message": "جودة رابط الفيديو المعروضة من خلال النظارة"
+    },
+    "osdTextElementSysGoggleDVR": {
+        "message": "حالة مسجل الفيديو في النظارة (DVR)",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysGoggleDVR": {
+        "message": "حالة مسجل الفيديو في النظارة (DVR) المعروضة من خلال النظارة"
+    },
+    "osdTextElementSysVtxDVR": {
+        "message": "حالة مسجل الفيديو في جهاز الإرسال الفيديو (VTX DVR)",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysVtxDVR": {
+        "message": "حالة مسجل الفيديو في جهاز الإرسال الفيديو (VTX DVR) المعروضة من خلال النظارة"
+    },
+    "osdTextElementSysWarnings": {
+        "message": "تحذيرات نظام النظارة",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysWarnings": {
+        "message": "تحذيرات نظام الفيديو المعروضة من خلال النظارة"
+    },
+    "osdTextElementSysVtxTemp": {
+        "message": "درجة حرارة جهاز الإرسال الفيديو (VTX)",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysVtxTemp": {
+        "message": "درجة حرارة جهاز الإرسال الفيديو  (VTX) المعروضة من خلال النظارة"
+    },
+    "osdTextElementSysFanSpeed": {
+        "message": "سرعة مروحة النظارة",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysFanSpeed": {
+        "message": "سرعة مروحة النظارة المعروضة من خلال النظارة"
+    },
+    "osdTextElementLapTimeCurrent": {
+        "message": "زمن الدورة الحالي عبر GPS",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLapTimeCurrent": {
+        "message": "زمن الدورة الحالي عبر نظام تحديد المواقع العالمي (GPS)"
+    },
+    "osdTextElementLapTimePrevious": {
+        "message": "زمن الدورة السابق عبر GPS",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLapTimePrevious": {
+        "message": "زمن الدورة السابق عبر نظام تحديد المواقع العالمي (GPS)"
+    },
+    "osdTextElementLapTimeBest3": {
+        "message": "أفضل 3 أزمنة دورة عبر GPS",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLapTimeBest3": {
+        "message": "أفضل 3 أزمنة دورة عبر نظام تحديد المواقع العالمي (GPS)"
+    },
+    "osdTextElementCraftName": {
+        "message": "اسم الطائرة",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCraftName": {
+        "message": "اسم الطائرة كما تم تعيينه في علامة التبويب \"التكوين\".<\/br>يمكن أيضًا تعيينه عبر متغير سطر الأوامر (CLI) \"craft_name\"."
+    },
+    "osdTextElementAltitude": {
+        "message": "الارتفاع",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementAltitude": {
+        "message": "الارتفاع الحالي (يومض عند تجاوز حد التنبيه)"
+    },
+    "osdTextElementAltitudeVariant1DecimalAGL": {
+        "message": "الارتفاع فوق سطح الأرض بدقة منزلة واحدة",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementAltitudeVariantNoDecimalAGL": {
+        "message": "الارتفاع فوق سطح الأرض بدون منازل عشرية",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementAltitudeVariant1DecimalASL": {
+        "message": "الارتفاع فوق مستوى البحر بدقة منزلة واحدة",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementAltitudeVariantNoDecimalASL": {
+        "message": "الارتفاع فوق مستوى البحر بدون منازل عشرية",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementCustomMsg0": {
+        "message": "رسالة مخصصة 1",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementCustomMsg1": {
+        "message": "رسالة مخصصة 2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementCustomMsg2": {
+        "message": "رسالة مخصصة 3",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementCustomMsg3": {
+        "message": "رسالة مخصصة 4",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCustomMsg0": {
+        "message": "الرسالة المخصصة 1 من جهاز خارجي",
+        "description": "Description of the custom message 1 element of the OSD"
+    },
+    "osdDescElementCustomMsg1": {
+        "message": "الرسالة المخصصة 2 من جهاز خارجي",
+        "description": "Description of the custom message 2 element of the OSD"
+    },
+    "osdDescElementCustomMsg2": {
+        "message": "الرسالة المخصصة 3 من جهاز خارجي",
+        "description": "Description of the custom message 3 element of the OSD"
+    },
+    "osdDescElementCustomMsg3": {
+        "message": "الرسالة المخصصة 4 من جهاز خارجي",
+        "description": "Description of the custom message 4 element of the OSD"
+    },
+    "osdTextElementOnTime": {
+        "message": "زمن التشغيل",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementOnTime": {
+        "message": "إجمالي الوقت الذي كانت فيه الطائرة قيد التشغيل"
+    },
+    "osdTextElementFlyTime": {
+        "message": "زمن الطيران",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlyTime": {
+        "message": "إجمالي الوقت الذي كانت فيه الطائرة في وضع التشغيل في دورة الطاقة الحالية (يومض عند تجاوز حد التنبيه)"
+    },
+    "osdTextElementFlyMode": {
+        "message": "نمط الطيران",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlyMode": {
+        "message": "نمط الطيران الحالي"
+    },
+    "osdTextElementGPSSpeed": {
+        "message": "السرعة عبر GPS",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSSpeed": {
+        "message": "السرعة المجهزة من نظام تحديد المواقع العالمي (GPS)"
+    },
+    "osdTextElementGPSSats": {
+        "message": "أقمار GPS",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSSats": {
+        "message": "عدد الأقمار الصناعية التي توفر تثبيت GPS"
+    },
+    "osdTextElementGPSLon": {
+        "message": "خط طول GPS",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSLon": {
+        "message": "إحداثي خط الطول لنظام تحديد المواقع العالمي (GPS)"
+    },
+    "osdTextElementGPSLat": {
+        "message": "خط عرض GPS",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSLat": {
+        "message": "إحداثي خط العرض لنظام تحديد المواقع العالمي (GPS)"
+    },
+    "osdTextElementGPSVariant7Decimals": {
+        "message": "بدقة 7 منازل عشرية",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementGPSVariant4Decimals": {
+        "message": "بدقة 4 منازل عشرية",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementGPSVariantDegMinSec": {
+        "message": "باستخدام الدرجات والدقائق والثواني",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementGPSVariantOpenLocation": {
+        "message": "باستخدام رمز المفتوح للموقع (Open Location Code)",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementDebug": {
+        "message": "تصحيح",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDebug": {
+        "message": "متغيرات التصحيح"
+    },
+    "osdTextElementDebug2": {
+        "message": "تصحيح 2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDebug2": {
+        "message": "متغيرات التصحيح للتصحيح 4-7"
+    },
+    "osdTextElementPIDRoll": {
+        "message": "PID لمحور Roll\n",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDRoll": {
+        "message": "مكاسب PID لمحور ROLL"
+    },
+    "osdTextElementPIDPitch": {
+        "message": "PID لمحور OITCH\n",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDPitch": {
+        "message": "مكاسب PID لمحور PITCH"
+    },
+    "osdTextElementPIDYaw": {
+        "message": "PID لمحور YAW\n",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDYaw": {
+        "message": "مكاسب PID لمحور الانعراج"
+    },
+    "osdTextElementPower": {
+        "message": "الطاقة",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPower": {
+        "message": "استهلاك الطاقة الكهربائية اللحظي"
+    },
+    "osdTextElementPIDRateProfile": {
+        "message": "الملف: PID ومعدل الدوران",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDRateProfile": {
+        "message": "عرض رقمي لملفات PID ومعدل الدوران النشط"
+    },
+    "osdTextElementBatteryWarning": {
+        "message": "تحذير البطارية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementBatteryWarning": {
+        "message": "نص تحذير يظهر عندما ينخفض جهد البطارية below عتبة التنبيه"
+    },
+    "osdTextElementAvgCellVoltage": {
+        "message": "متوسط جهد خلية البطارية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementAvgCellVoltage": {
+        "message": "متوسط جهد الخلية (جهد البطارية الرئيسي \/ عدد الخلايا)"
+    },
+    "osdTextElementPitchAngle": {
+        "message": "الزاوية: PITCH",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPitchAngle": {
+        "message": "زاوية PITCH الرقمية بالدرجات"
+    },
+    "osdTextElementRollAngle": {
+        "message": "الزاوية: ROLL",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRollAngle": {
+        "message": "زاوية ROLL الرقمية بالدرجات"
+    },
+    "osdTextElementMainBattUsage": {
+        "message": "استخدام البطارية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMainBattUsage": {
+        "message": "تمثيل بياني لاستخدام سعة البطارية"
+    },
+    "osdTextElementMainBattUsageVariantGraphrRemain": {
+        "message": "المتبقي بيانيًا",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementMainBattUsageVariantGraphUsage": {
+        "message": "المستخدم بيانيًا",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementMainBattUsageVariantValueRemain": {
+        "message": "النسبة المئوية المتبقية",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementMainBattUsageVariantValueUsage": {
+        "message": "النسبة المئوية المستخدمة",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementArmedTime": {
+        "message": "المؤقت: زمن التشغيل",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementArmedTime": {
+        "message": "الوقت منذ آخر مرة تم فيها تشغيل الطائرة"
+    },
+    "osdTextElementHomeDirection": {
+        "message": "اتجاه نقطة الأصل (Home)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementHomeDirection": {
+        "message": "سهم يظهر الاتجاه towards نقطة الأصل"
+    },
+    "osdTextElementHomeDistance": {
+        "message": "المسافة إلى نقطة الأصل (Home)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementHomeDistance": {
+        "message": "المسافة إلى نقطة الأصل (Home) (بالقدم أو بالمتر اعتمادًا على إعدادات وحدات القياس)"
+    },
+    "osdTextElementNumericalHeading": {
+        "message": "الاتجاه الرقمي",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNumericalHeading": {
+        "message": "قراءة رقمية للاتجاه الحالي بالدرجات"
+    },
+    "osdTextElementNumericalVario": {
+        "message": "مقياس الارتفاع الرقمي",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNumericalVario": {
+        "message": "قراءة رقمية للسرعة العمودية (بإما القدم أو المتر بناءً على إعداد نظام الوحدات)"
+    },
+    "osdTextElementCompassBar": {
+        "message": "شريط البوصلة",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCompassBar": {
+        "message": "شريط البوصلة الرسومي الذي يظهر الاتجاه الحالي"
+    },
+    "osdTextElementWarnings": {
+        "message": "تحذيرات",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWarnings": {
+        "message": "تنبيهات (مثل انخفاض البطارية)، وتحذيرات (مثل أسباب عدم التسليح، انخفاض البطارية الشديد) والجرس المرئي (4 asterisks تومض)."
+    },
+    "osdTextElementEscTemperature": {
+        "message": "درجة حرارة متحكم السرعة الإلكتروني (ESC)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEscTemperature": {
+        "message": "درجة الحرارة المبلغ عنها من خلال بيانات متحكم السرعة الإلكتروني (ESC)، إما عبر الاتصال التسلسلي أحادي السلك (one wire telemetry)، أو عبر بروتوكول DShot ثنائي الاتجاه مع EDT، إذا كان مدعومًا من خلال برنامج متحكم السرعة الإلكتروني (ESC) الخاص بك."
+    },
+    "osdTextElementEscRpm": {
+        "message": "دورات متحكم السرعة الإلكتروني (ESC) في الدقيقة (RPM)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEscRpm": {
+        "message": "دورات في الدقيقة (RPM) المبلغ عنها من خلال بيانات متحكم السرعة الإلكتروني (ESC)"
+    },
+    "osdTextElementRemainingTimeEstimate": {
+        "message": "المؤقت: التقدير الزمني المتبقي",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRemainingTimeEstimate": {
+        "message": "تقدير الوقت المتبقي للرحلة"
+    },
+    "osdTextElementRtcDateTime": {
+        "message": "تاريخ ووقت الساعة الزمنية الحقيقية (RTC)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementRtcDateTimeVariantFullDate": {
+        "message": "Full date",
+        "description": "One of the variants of the RTC date and time element of the OSD"
+    },
+    "osdTextElementRtcDateTimeVariantShortDate": {
+        "message": "التاريخ المختصر",
+        "description": "One of the variants of the RTC date and time element of the OSD"
+    },
+    "osdTextElementRtcDateTimeVariantTimeOnly": {
+        "message": "الوقت فقط",
+        "description": "One of the variants of the RTC date and time element of the OSD"
+    },
+    "osdDescElementRtcDateTime": {
+        "message": "ساعة الوقت الحقيقي (RTC) تاريخ \/ وقت"
+    },
+    "osdTextElementAdjustmentRange": {
+        "message": "نطاق الضبط",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementAdjustmentRange": {
+        "message": "إعداد وقيمة نطاق الضبط النشط حاليًا"
+    },
+    "osdTextElementTimer1": {
+        "message": "المؤقت 1",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementTimer1": {
+        "message": "يعرض قيمة المؤقت 1"
+    },
+    "osdTextElementTimer2": {
+        "message": "المؤقت 2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementTimer2": {
+        "message": "يعرض قيمة المؤقت 2"
+    },
+    "osdTextElementCoreTemperature": {
+        "message": "درجة حرارة المعالج\n",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCoreTemperature": {
+        "message": "درجة حرارة معالج STM32 الدقيق (MCU)"
+    },
+    "osdTextAntiGravity": {
+        "message": "Anti gravity",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescAntiGravity": {
+        "message": "مؤشر التنشيط عندما يكون مضاد الجاذبية مفعلًا"
+    },
+    "osdTextGForce": {
+        "message": "قوة الجاذبية (G-Force)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescGForce": {
+        "message": "يظهر مقدار قوة الجاذبية (G-Force) التي تتعرض لها الطائرة"
+    },
+    "osdTextElementMotorDiag": {
+        "message": "تشخيص المحركات",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMotorDiag": {
+        "message": "يعرض رسمًا بيانيًا لمخرجات كل محرك"
+    },
+    "osdTextElementLogStatus": {
+        "message": "حالة سجل الصندوق الأسود (Blackbox)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLogStatus": {
+        "message": "أرقام وتحذيرات الصندوق الأسود"
+    },
+    "osdTextElementFlipArrow": {
+        "message": "سهم الانقلاب بعد التحطم",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlipArrow": {
+        "message": "سهم يظهر أي جانب من المحركات يكون لأعلى في وضع السلحفاة (يجب تفعيل مقياس التسارع)"
+    },
+    "osdTextElementLinkQuality": {
+        "message": "جودة الرابط",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLinkQuality": {
+        "message": "مؤشر جودة الرابط بناءً على نسبة حزم البيانات السليمة التي تم استقبالها بنجاح."
+    },
+    "osdTextElementLinkQualityVariantRfMode": {
+        "message": "وضع RF : جودة الرابط",
+        "description": "One of the variants of the Link Quality element of the OSD"
+    },
+    "osdTextElementLinkQualityVariantQualityOnly": {
+        "message": "جودة الرابط فقط",
+        "description": "One of the variants of the Link Quality element of the OSD"
+    },
+    "osdTextElementFlightDist": {
+        "message": "مسافة الطيران",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlightDist": {
+        "message": "المسافة المقطوعة خلال رحلة الطيران هذه."
+    },
+    "osdTextElementStickOverlayLeft": {
+        "message": "تراكب عصا التحكم اليسرى",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementStickOverlayLeft": {
+        "message": "تراكب يظهر موضع عصا المرسل اليسرى."
+    },
+    "osdTextElementStickOverlayRight": {
+        "message": "تراكب عصا التحكم اليمنى",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementStickOverlayRight": {
+        "message": "تراكب يظهر موضع عصا المرسل اليمنى."
+    },
+    "osdTextElementDisplayName": {
+        "message": "اسم العرض",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDisplayName": {
+        "message": "يمكن أيضًا تعيينه عبر متغير سطر الأوامر (CLI) \"display_name\"."
+    },
+    "osdTextElementPilotName": {
+        "message": "اسم الطيار",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPilotName": {
+        "message": "اسم الطيار كما تم تعيينه في علامة التبويب \"التكوين\".<\/br>يمكن أيضًا تعيينه عبر متغير سطر الأوامر (CLI) \"pilot_name\"."
+    },
+    "osdTextElementEscRpmFreq": {
+        "message": "تردد دورات متحكم السرعة الإلكتروني (ESC) في الدقيقة (RPM)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEscRpmFreq": {
+        "message": "تردد الدورات في الدقيقة (RPM) المبلغ عنه من خلال بيانات متحكم السرعة الإلكتروني (ESC)"
+    },
+    "osdTextElementRateProfileName": {
+        "message": "الملف: اسم ملف تعريف معدل الدوران",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRateProfileName": {
+        "message": "يعرض اسم ملف تعريف معدل الدوران الحالي"
+    },
+    "osdTextElementPidProfileName": {
+        "message": "الملف: اسم ملف تعريف PID",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPidProfileName": {
+        "message": "يعرض اسم ملف تعريف PID الحالي"
+    },
+    "osdTextElementOsdProfileName": {
+        "message": "الملف: اسم ملف تعريف OSD",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementOsdProfileName": {
+        "message": "اسم ملف تعريف OSD كما تم تعيينه في متغيرات سطر الأوامر (CLI) \"osd_profile_1_name\" و \"osd_profile_2_name\" و \"osd_profile_3_name\""
+    },
+    "osdTextElementRcChannels": {
+        "message": "قنوات التحكم اللاسلكي (RC)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRcChannels": {
+        "message": "عرض 4 قيم قنوات كحد أقصى. يجب تحديد القنوات باستخدام متغير سطر الأوامر (CLI) 'osd_rcchannels'"
+    },
+    "osdTextElementCameraFrame": {
+        "message": "إطار الكاميرا",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCameraFrame": {
+        "message": "يضيف عنصر مخطط تفصيلي قابل للتعديل مصمم لتمثيل مجال رؤية كاميرا الطيار عالية الدقة (HD) للتأطير المرئي.<br \/><br \/>يمكنك ضبط العرض والارتفاع في سطر الأوامر (CLI) باستخدام 'osd_camera_frame_width' و 'osd_camera_frame_height'"
+    },
+    "osdTextElementEfficiency": {
+        "message": "كفاءة البطارية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEfficiency": {
+        "message": "استهلاك البطارية اللحظي بوحدة ملي أمبير في الساعة لكل مسافة (mAh\/distance). (يتطلب تثبيت GPS صالح)"
+    },
+    "osdTextTotalFlights": {
+        "message": "إجمالي رحلات الطيران",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescTotalFlights": {
+        "message": "العدد التقريبي الإجمالي لرحلات الطيران"
+    },
+    "osdTextElementUpDownReference": {
+        "message": "مرجع الأعلى (انحدار 90 درجة)\/الأسفل (انحدار -90 درجة)",
+        "description": "OSD Symbol to show when pitch is approaching vertical (90 deg, U) and D for nose down (-90 deg, D)"
+    },
+    "osdDescUpDownReference": {
+        "message": "رمز OSD يظهر عندما يقترب الانحدار من الوضع العمودي (90 درجة، U) و D للأنف لأسفل (-90 درجة، D)"
+    },
+    "osdTextElementTxUplinkPower": {
+        "message": "قوة الارسال الصاعد (Tx uplink power)",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescTxUplinkPower": {
+        "message": "يعرض قيمة لقوة الإرسال (بوحدة ملي واط أو واط). مفيد عندما يكون <i>الطاقة الديناميكية (Dynamic Power)<\/i> مفعلًا لأجهزة الراديو المدعومة"
+    },
+    "osdTextElementReadyMode": {
+        "message": "نمط الاستعداد (Ready Mode)",
+        "description": "When active READY will be displayed until flying"
+    },
+    "osdDescElementReadyMode": {
+        "message": "عند التفعيل، سيتم عرض \"جاهز\" (READY) حتى بدء الطيران"
+    },
+    "osdTextElementRSNRValue": {
+        "message": "قيمة RSNR",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRSNRValue": {
+        "message": "قيمة RSNR"
+    },
+    "osdTextElementUnknown": {
+        "message": "غير معروف $1",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementUnknown": {
+        "message": "عنصر غير معروف (سيتم إضافة التفاصيل في الإصدارات المستقبلية)"
+    },
+    "osdTextStatMaxSpeed": {
+        "message": "السرعة القصوى",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxSpeed": {
+        "message": "أقصى سرعة مسجلة"
+    },
+    "osdTextStatMinBattery": {
+        "message": "أقل جهد للبطارية",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinBattery": {
+        "message": "أقل فولت بطارية مسجلة"
+    },
+    "osdTextStatMinRssi": {
+        "message": "أقل قيمة لـ RSSI",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinRssi": {
+        "message": "أقل تبيان لقوة الإشارة المستلمة (RSSI) مسجلة"
+    },
+    "osdTextStatMaxCurrent": {
+        "message": "أقصى سحب تيار للبطارية",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxCurrent": {
+        "message": "أقصى سحب تيار مسجل"
+    },
+    "osdTextStatUsedMah": {
+        "message": "سعة البطارية المستخدمة (بوحدة ملي أمبير في الساعة)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUsedMah": {
+        "message": "سعة بطارية المستخدمة"
+    },
+    "osdTextStatUsedWh": {
+        "message": "سعة البطارية المستخدمة (بوحدة واط في الساعة)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUsedWh": {
+        "message": "سعة البطارية المستخدمة بوحدة واط في الساعة (Wh)"
+    },
+    "osdTextStatMaxAltitude": {
+        "message": "الارتفاع الأقصى",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxAltitude": {
+        "message": "أقصى ارتفاع مسجل"
+    },
+    "osdTextStatBlackbox": {
+        "message": "استخدام الصندوق الأسود (Blackbox)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBlackbox": {
+        "message": "النسبة الكلية المستخدمة من الصندوق الأسود"
+    },
+    "osdTextStatEndBattery": {
+        "message": "جهد البطارية عند الانتهاء",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatEndBattery": {
+        "message": "فولت البطارية عند فصل التشغيل"
+    },
+    "osdTextStatFlyTime": {
+        "message": "إجمالي زمن الطيران",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFlyTime": {
+        "message": "إجمالي الوقت الذي كانت فيه الطائرة في وضع التشغيل في دورة الطاقة الحالية"
+    },
+    "osdTextStatArmedTime": {
+        "message": "زمن الطيران عند آخر تشغيل",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatArmedTime": {
+        "message": "الوقت منذ آخر مرة تم فيها تشغيل الطائرة"
+    },
+    "osdTextStatMaxDistance": {
+        "message": "أقصى مسافة عن نقطة الأصل (Home)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxDistance": {
+        "message": "أقى مسافة من موقع المنزل"
+    },
+    "osdTextStatBlackboxLogNumber": {
+        "message": "رقم الصندوق الأسود (Blackbox)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBlackboxLogNumber": {
+        "message": "رقم السجل لسجل الطيران من الصندوق الأسود"
+    },
+    "osdTextStatTimer1": {
+        "message": "المؤقت 1",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTimer1": {
+        "message": "قيمة المؤقت 1 عند وقت فصل التشغيل"
+    },
+    "osdTextStatTimer2": {
+        "message": "المؤقت 2",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTimer2": {
+        "message": "قيمة المؤقت 2 عند وقت فصل التشغيل"
+    },
+    "osdTextStatRtcDateTime": {
+        "message": "تاريخ ووقت الساعة الزمنية الحقيقية (RTC)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatRtcDateTime": {
+        "message": "التاريخ والوقت من ساعة الوقت الحقيقي"
+    },
+    "osdTextStatBattery": {
+        "message": "جهد البطارية",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBattery": {
+        "message": "فولت البطارية في الوقت الحقيقي"
+    },
+    "osdTextStatGForce": {
+        "message": "أقصى قوة جاذبية (G-Force)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatGForce": {
+        "message": "أقصى قوة جاذبية (G-Force) تعرضت لها الطائرة"
+    },
+    "osdTextStatEscTemperature": {
+        "message": "أقصى درجة حرارة لمتحكم السرعة الإلكتروني (ESC)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatEscTemperature": {
+        "message": "أقصى درجة حرارة لمتحكم السرعة الإلكتروني (ESC)"
+    },
+    "osdTextStatEscRpm": {
+        "message": "أقصى دورات لمتحكم السرعة الإلكتروني (ESC) في الدقيقة (RPM)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatEscRpm": {
+        "message": "أقصى دورات في الدقيقة (RPM) لمتحكم السرعة الإلكتروني (ESC)"
+    },
+    "osdTextStatMinLinkQuality": {
+        "message": "أقل جودة للرابط",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinLinkQuality": {
+        "message": "الحد الأدنى للمؤشر البديل لـ 'جودة الرابط' بناءً على فقد الإطارات"
+    },
+    "osdTextStatFlightDistance": {
+        "message": "مسافة الطيران",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFlightDistance": {
+        "message": "إجمالي المسافة المقطوعة خلال رحلة الطيران"
+    },
+    "osdTextStatMaxFFT": {
+        "message": "أقصى قيمة لتحويل فورييه السريع (FFT)",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxFFT": {
+        "message": "ذروة تردد تحويل فورييه السريع (FFT)"
+    },
+    "osdTextStatTotalFlights": {
+        "message": "إجمالي عدد رحلات الطيران",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalFlights": {
+        "message": "العدد الإجمالي لرحلات الطيران"
+    },
+    "osdTextStatTotalFlightTime": {
+        "message": "إجمالي زمن الطيران",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalFlightTime": {
+        "message": "إجمالي الوقت الذي تم قضاؤه في الطيران"
+    },
+    "osdTextStatTotalFlightDistance": {
+        "message": "إجمالي مسافة الطيران",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalFlightDistance": {
+        "message": "إجمالي المسافة المقطوعة"
+    },
+    "osdTextStatMinRssiDbm": {
+        "message": "أقل قيمة لـ RSSI بوحدة dBm",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinRssiDbm": {
+        "message": "أقل قيمة لـ RSSI بوحدة dBm"
+    },
+    "osdTextStatMinRSNR": {
+        "message": "أقل قيمة لـ RSNR",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinRSNR": {
+        "message": "أقل قيمة لـ RSNR"
+    },
+    "osdTextStatBest3ConsecLaps": {
+        "message": "أفضل 3 دورات متتالية",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBest3ConsecLaps": {
+        "message": "أفضل 3 دورات متتالية"
+    },
+    "osdTextStatBestLap": {
+        "message": "أفضل دورة",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBestLap": {
+        "message": "أفضل دورة"
+    },
+    "osdTextStatFullThrottleTime": {
+        "message": "مؤقت دواسة الوقود الكامل",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFullThrottleTime": {
+        "message": "مؤقت دواسة الوقود الكامل"
+    },
+    "osdTextStatFullThrottleCounter": {
+        "message": "عداد دواسة الوقود الكامل",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFullThrottleCounter": {
+        "message": "عداد دواسة الوقود الكامل"
+    },
+    "osdTextStatAvgThrottle": {
+        "message": "متوسط دواسة الوقود",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatAvgThrottle": {
+        "message": "متوسط دواسة الوقود"
+    },
+    "osdTextStatUnknown": {
+        "message": "غير معروف $1",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUnknown": {
+        "message": "إحصائية غير معروفة (سيتم إضافة التفاصيل في إصدار مستقبلي)"
+    },
+    "osdDescribeFontVersion1": {
+        "message": "إصدار الخط: 1 (Betaflight 4.0 أو أقدم)"
+    },
+    "osdDescribeFontVersion2": {
+        "message": "إصدار الخط: 2 (Betaflight 4.1 أو أحدث)"
+    },
+    "osdDescribeFontVersionCUSTOM": {
+        "message": "إصدار الخط: مقدم من المستخدم"
+    },
+    "osdTimerSource": {
+        "message": "المصدر:"
+    },
+    "osdTimerSourceTooltip": {
+        "message": "اختر مصدر المؤقت، وهذا يتحكم في المدة\/الحدث الذي يقيسه المؤقت"
+    },
+    "osdTimerSourceOptionOnTime": {
+        "message": "زمن التشغيل",
+        "description": "One of the options for the source timer. This options shows the amount of time has passed since the battery was plugged"
+    },
+    "osdTimerSourceOptionTotalArmedTime": {
+        "message": "إجمالي زمن التشغيل",
+        "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed since the battery was plugged"
+    },
+    "osdTimerSourceOptionLastArmedTime": {
+        "message": "آخر زمن تشغيل",
+        "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed the latest time"
+    },
+    "osdTimerSourceOptionOnArmTime": {
+        "message": "مدة التشغيل",
+        "description": "One of the options for the source timer. This option shows On time when aircraft is disarmed, and Armed time when armed"
+    },
+    "osdTimerPrecision": {
+        "message": "الدقة:"
+    },
+    "osdTimerPrecisionTooltip": {
+        "message": "حدد دقة المؤقت، هذا يتحكم بدقة الوقت المسجل"
+    },
+    "osdTimerPrecisionOptionSecond": {
+        "message": "الثانية",
+        "description": "Selectable option for the precision of the timer in the OSD"
+    },
+    "osdTimerPrecisionOptionHundredth": {
+        "message": "جزء من مئة",
+        "description": "Selectable option for the precision of the timer in the OSD"
+    },
+    "osdTimerPrecisionOptionTenth": {
+        "message": "جزء من عشرة",
+        "description": "Selectable option for the precision of the timer in the OSD"
+    },
+    "osdTimerAlarm": {
+        "message": "تنبيه:"
+    },
+    "osdTimerAlarmTooltip": {
+        "message": "حدد بداية تنبيه المؤقت بالدقائق، عند تجاوز الوقت هذه القيمة عنصر OSD سوف يومض، ووضع هذا إلى 0 سيعطل جهاز الإنذار"
+    },
+    "osdTimerAlarmOptionRssi": {
+        "message": "قوة الإشارة",
+        "description": "Text of the RSSI alarm"
+    },
+    "osdTimerAlarmOptionCapacity": {
+        "message": "السعة",
+        "description": "Text of the capacity alarm"
+    },
+    "osdTimerAlarmOptionAltitude": {
+        "message": "الارتفاع",
+        "description": "Text of the altitude alarm"
+    },
+    "osdTimerAlarmOptionLinkQuality": {
+        "message": "جودة الرابط",
+        "description": "Text of the link quality alarm"
+    },
+    "osdTimerAlarmOptionRssiDbm": {
+        "message": "RSSI بوحدة dBm",
+        "description": "Text of the RSSI dBm alarm"
+    },
+    "osdWarningTextArmingDisabled": {
+        "message": "التشغيل معطل",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningArmingDisabled": {
+        "message": "أخبر عن الأسباب الأكثر حدة لعدم التشغيل "
+    },
+    "osdWarningTextBatteryNotFull": {
+        "message": "البطارية غير ممتلئة",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningBatteryNotFull": {
+        "message": "تحذير عندما تكون البطارية الموصولة غير مشحونة بالكامل"
+    },
+    "osdWarningTextBatteryWarning": {
+        "message": "تحذير البطارية",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningBatteryWarning": {
+        "message": "تنبيه عند هبوط فولتية البطارية دون عتبة التنبيه"
+    },
+    "osdWarningTextBatteryCritical": {
+        "message": "البطارية حرجة",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningBatteryCritical": {
+        "message": "تنبيه عند هبوط فولتية البطارية below أقل معدل الفولتية لكل خلية"
+    },
+    "osdWarningTextVisualBeeper": {
+        "message": "الجرس المرئي",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningVisualBeeper": {
+        "message": "يعرض تجسيدًا للجرس (يظهر كـ 4 asterisks)"
+    },
+    "osdWarningTextCrashFlipMode": {
+        "message": "نمط الانقلاب بعد التحطم",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningCrashFlipMode": {
+        "message": "يحذر عند تفعيل نمط الانقلاب بعد التحطم"
+    },
+    "osdWarningTextEscFail": {
+        "message": "فشل متحكم السرعة الإلكتروني (ESC)",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningEscFail": {
+        "message": "يعدد قائمة بمتحكمات السرعة الإلكترونية\/المحركات التي تفشل (دورات في الدقيقة أو درجة الحرارة خارج النطاق الم configured)"
+    },
+    "osdWarningTextCoreTemperature": {
+        "message": "درجة حرارة المعالج\n",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningCoreTemperature": {
+        "message": "يعرض تحذيرًا عندما تتجاوز درجة حرارة معالج MCU الحد المحدد.\n"
+    },
+    "osdWarningTextRcSmoothingFailure": {
+        "message": "فشل تنعيم التحكم اللاسلكي (RC)",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRcSmoothingFailure": {
+        "message": "يحذر عندما يفشل تهيئة تنعيم التحكم اللاسلكي (RC)"
+    },
+    "osdWarningTextFailsafe": {
+        "message": "وضع الأمان (Failsafe)",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningFailsafe": {
+        "message": "يحذر عند حدوث وضع الأمان (Failsafe)"
+    },
+    "osdWarningTextLaunchControl": {
+        "message": "تحكم الإطلاق",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLaunchControl": {
+        "message": "يحذر عند تفعيل نمط تحكم الإطلاق"
+    },
+    "osdWarningTextGpsRescueUnavailable": {
+        "message": "إنقاذ GPS غير متاح",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningGpsRescueUnavailable": {
+        "message": "يحذر عندما لا يكون وضع الانقاذ \"GPS\" متاحًا ولا يمكن تفعيله"
+    },
+    "osdWarningTextGpsRescueDisabled": {
+        "message": "وضع الإنقاذ GPS معطل",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningGpsRescueDisabled": {
+        "message": "يحذر عندما يكون وضع الإنقاذ GPS معطلًا"
+    },
+    "osdWarningTextRSSI": {
+        "message": "قوة الإشارة",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRSSI": {
+        "message": "يعرض تحذيرًا عندما تنخفض قيمة RSNR عن حد التنبيه المحدد.\n"
+    },
+    "osdWarningTextLinkQuality": {
+        "message": "جودة الرابط",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLinkQuality": {
+        "message": "يحذر عندما تكون جودة الرابط below إعداد التنبيه"
+    },
+    "osdWarningTextRssiDbm": {
+        "message": "RSSI بوحدة dBm",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRssiDbm": {
+        "message": "يحذر عندما تكون قيمة RSSI بوحدة dBm below إعداد التنبيه"
+    },
+    "osdWarningTextOverCap": {
+        "message": "تجاوز سعة البطارية",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningOverCap": {
+        "message": "يعرض تحذيرًا عندما تتجاوز السعة المستهلكة بوحدة mAh حد السعة المحدد.\n"
+    },
+    "osdWarningTextRSNR": {
+        "message": "نسبة الإشارة إلى الضوضاء عند المستقبِل.",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRSNR": {
+        "message": "يعرض تحذيرًا عندما تنخفض قيمة RSNR عن حد التنبيه المحدد.\n"
+    },
+    "osdWarningTextLoad": {
+        "message": "الحمل (LOAD)",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLoad": {
+        "message": "يحذر إذا كان حمل المعالج (CPU LOAD) لوحدة تحكم الطيران مرتفعًا جدًا",
+        "description": "Description of one of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdTextElementPosHoldFailed": {
+        "message": "فشل تثبيت الموقع",
+        "description": "One of the elements of the OSD that can be enabled to show a warning when position hold fails (e.g. in GPS mode)"
+    },
+    "osdDescElementPosHoldFailed": {
+        "message": "يعرض تحذيرًا عند فشل تثبيت الموقع (مثلًا في وضع GPS)"
+    },
+    "osdWarningTextPosHoldFailed": {
+        "message": "فشل تثبيت الموقع",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningPosHoldFailed": {
+        "message": "فشل تثبيت الموقع",
+        "description": "Warns when the position hold fails (e.g. in GPS mode)"
+    },
+    "osdWarningTextAutopilotAbort": {
+        "message": "تم إلغاء مهمة الطيار الآلي",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningAutopilotAbort": {
+        "message": "تم إلغاء مهمة الطيار الآلي",
+        "description": "Warns when a waypoint mission aborts (GPS lost, stalled or flyaway)"
+    },
+    "osdWarningTextUnknown": {
+        "message": "غير معروف $1"
+    },
+    "osdWarningUnknown": {
+        "message": "تحذير غير معروف (سيتم إضافة التفاصيل في إصدار مستقبلي)"
+    },
+    "osdSectionHelpElements": {
+        "message": "تفعيل أو تعطيل العناصر المعروضة على الشاشة."
+    },
+    "osdSectionHelpVideoMode": {
+        "message": "تعيين نمط الفيديو المتوقع للكاميرا (عادة يمكن ترك هذا على الوضع التلقائي، إذا واجهت صعوبات فقم بتعيينه ليتطابق مع إخراج الكاميرا)."
+    },
+    "osdSectionHelpUnits": {
+        "message": "يضبط نظام الوحدات المستخدم للقراءات الرقمية."
+    },
+    "osdSectionHelpTimers": {
+        "message": "اضبط مؤقتات الطيران."
+    },
+    "osdSectionHelpAlarms": {
+        "message": "تعيين العتبات المستخدمة لعناصر OSD ذات حالات التنبيه."
+    },
+    "osdSectionHelpStats": {
+        "message": "حدد القيم المعروضة في شاشة إحصاءات ما بعد الطيران."
+    },
+    "osdSectionHelpWarnings": {
+        "message": "تمكين أو تعطيل التحذيرات التي تظهر على عنصر \"التحذيرات\"."
+    },
+    "osdSettingsSaved": {
+        "message": "تم حفظ إعدادات العرض على الشاشة"
+    },
+    "osdWritePermissions": {
+        "message": "ليس لديك <span class=\"message-negative\">أذونات الكتابة<\/span> لهذا الملف"
+    },
+    "osdButtonSaved": {
+        "message": "تم الحفظ"
+    },
+    "vtxHelp": {
+        "message": "يمكنك هنا ضبط قيم جهاز إرسال الفيديو (VTX). ويمكنك عرض قيم الإرسال وتغييرها، بما في ذلك جداول VTX، إذا كانت وحدة التحكم بالطيران وجهاز VTX يدعمان ذلك.<br>لإعداد جهاز VTX، اتبع الخطوات التالية:<br>1. انتقل إلى <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/VTX#vtx-tables\">هذه<\/a> الصفحة؛<br>2. ابحث عن ملف إعداد VTX المناسب لبلدك وطراز جهاز VTX لديك، ثم نزّله؛<br>3. اضغط على '$t(vtxButtonLoadFile.message)' أدناه، ثم اختر ملف إعداد VTX وحمّله؛<br>4. تحقق من صحة الإعدادات؛<br>5. اضغط على '$t(vtxButtonSave.message)' لحفظ إعدادات VTX في وحدة التحكم بالطيران.<br>6. يمكنك اختياريًا الضغط على '$t(vtxButtonSaveLua.message)' لحفظ ملف إعداد Lua يمكنك استخدامه مع برامج Betaflight النصية بلغة Lua (اطّلع على المزيد من <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https:\/\/github.com\/betaflight\/betaflight-tx-lua-scripts\/\">هنا<\/a>.)\n",
+        "description": "Introduction message in the VTX tab"
+    },
+    "vtxMessageNotSupported": {
+        "message": "<span class=\"message-negative\">تنبيه:<\/span> لم يستجب جهاز VTX بعد. اختر أدناه البروتوكول الذي يستخدمه جهاز VTX ومنفذ UART الموصل به، ثم احفظ الإعدادات؛ ستظهر بقية الإعدادات بمجرد استجابة الجهاز.\n",
+        "description": "Message to show when the VTX is not supported in the VTX tab"
+    },
+    "vtxMessageTableNotConfigured": {
+        "message": "<span class=\"message-negative\">انتباه:<\/span> تحتاج إلى تكوين وحفظ جدول VTX أولاً في الأسفل قبل أن تتمكن من استخدام حقول $t(vtxSelectedMode.message).",
+        "description": "Message to show when the VTX is not supported in the VTX tab"
+    },
+    "vtxMessageFactoryBandsNotSupported": {
+        "message": "<span class=\"message-negative\">انتباه:<\/span> نوع VTX المحدد لا يدعم إعداد 'المصنع' للنطاقات، ولكن بعض نطاقاتك لديها هذا الإعداد. انقر على '$t(vtxButtonSave.message)' لإصلاح هذا.",
+        "description": "Message to show when the configured VTX type does not support factory bands, but one or more of the configured bands are of this type"
+    },
+    "vtxMessageVerifyTable": {
+        "message": "<span class=\"message-negative\">انتباه:<\/span> تم تحميل قيم جدول VTX، ولكن لم يتم تخزينها بعد على وحدة تحكم الطيران. يجب عليك التحقق من القيم وتعديلها لتتأكد من أنها صالحة وقانونية في بلدك ثم اضغط على زر $t(vtxButtonSave.message) لتخزينها على وحدة تحكم الطيران.",
+        "description": "Message to show when the VTX Table has been loaded from a external source"
+    },
+    "vtxFrequencyChannel": {
+        "message": "أدخل التردد مباشرة",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxFrequencyChannelHelp": {
+        "message": "إذا قمت بتمكين هذا، سيتيح لك التطبيق اختيار تردد بدلاً من النطاق\/القناة المعتاد. لكي يعمل هذا، يجب أن يدعم VTX الخاص بك هذه الميزة.",
+        "description": "Help text for the frequency or channel select field of the VTX tab"
+    },
+    "vtxSelectedMode": {
+        "message": "النمط المحدد",
+        "description": "Title for the actual mode header of the VTX"
+    },
+    "vtxActualState": {
+        "message": "القيم الحالية",
+        "description": "Title for the actual values header of the VTX"
+    },
+    "vtxType": {
+        "message": "نوع VTX",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxType_0": {
+        "message": "غير مدعوم",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_1": {
+        "message": "RTC6705",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_3": {
+        "message": "SmartAudio",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_4": {
+        "message": "Tramp",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_5": {
+        "message": "MSP",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_255": {
+        "message": "غير معروف",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxBand": {
+        "message": "النطاق",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxBandHelp": {
+        "message": "يمكنك اختيار النطاق لـ VTX الخاص بك هنا",
+        "description": "Help text for the band field of the VTX tab"
+    },
+    "vtxBand_0": {
+        "message": "لا شيء",
+        "description": "Text of one of the options for the band field of the VTX tab"
+    },
+    "vtxBand_X": {
+        "message": "النطاق {{bandName}}",
+        "description": "Text of one of the options for the band field of the VTX tab"
+    },
+    "vtxChannel_0": {
+        "message": "لا شيء",
+        "description": "Text of one of the options for the channel field of the VTX tab"
+    },
+    "vtxChannel_X": {
+        "message": "القناة {{channelName}}",
+        "description": "Text of one of the options for the channel field of the VTX tab"
+    },
+    "vtxPower_0": {
+        "message": "لا شيء",
+        "description": "Text of one of the options for the power field of the VTX tab"
+    },
+    "vtxPower_X": {
+        "message": "المستوى {{powerLevel}}",
+        "description": "Text of one of the options for the power field of the VTX tab"
+    },
+    "vtxChannel": {
+        "message": "القناة",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxChannelHelp": {
+        "message": "يمكنك اختيار القناة لـ VTX الخاص بك هنا",
+        "description": "Help text for the channel field of the VTX tab"
+    },
+    "vtxFrequency": {
+        "message": "التردد",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxFrequencyHelp": {
+        "message": "يمكنك اختيار التردد لـ VTX الخاص بك هنا إذا كان مدعومًا",
+        "description": "Help text for the frequency field of the VTX tab"
+    },
+    "vtxReadyTrue": {
+        "message": "صحيح",
+        "description": "vtx device are ready"
+    },
+    "vtxReadyFalse": {
+        "message": "خطأ",
+        "description": "vtx device are not ready"
+    },
+    "vtxDeviceReady": {
+        "message": "الجهاز جاهز",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPower": {
+        "message": "الطاقة",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPowerHelp": {
+        "message": "هذه هي الطاقة المحددة لـ VTX. يمكن تعديلها إذا كان $t(vtxPitMode.message) أو $t(vtxLowPowerDisarm.message) مفعلًا",
+        "description": "Help text for the power field of the VTX tab"
+    },
+    "vtxPitMode": {
+        "message": "وضع الحفرة (Pit Mode)",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPitModeHelp": {
+        "message": "عند التمكين، يدخل VTX في وضع طاقة منخفض جدًا للسماح للطائرة بالعمل على المنضدة دون إزعاج الطيارين الآخرين. عادةً ما يكون مدى هذا الوضع أقل من 5 أمتار.<br \/><br \/>ملاحظة: بعض البروتوكولات، مثل SmartAudio، لا يمكنها تمكين وضع الحفرة (Pit Mode) عبر البرنامج بعد التشغيل.",
+        "description": "Help text for the pit mode field of the VTX tab"
+    },
+    "vtxPitModeFrequency": {
+        "message": "تردد وضع الحفرة (Pit Mode)",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPitModeFrequencyHelp": {
+        "message": "التردد الذي تتغير إليه وضع الحفرة (Pit Mode) عند التمكين.",
+        "description": "Help text for the pit mode field of the VTX tab"
+    },
+    "vtxDeviceSetup": {
+        "message": "جهاز VTX"
+    },
+    "vtxProtocol": {
+        "message": "بروتوكول"
+    },
+    "vtxProtocolHelp": {
+        "message": "بروتوكول التحكم في VTX. يتم تشغيل SmartAudio وTramp على UART أدناه؛ مشاركة MSP مع MSP, كما تفعل DJI وHDZero وWalksnail."
+    },
+    "vtxSerialPort": {
+        "message": "منفذ تسلسلي"
+    },
+    "vtxSerialPortHelp": {
+        "message": "منفذ UART الموصول به نظام OSD تسلسلي. ابتداءً من API 1.49، يُضبط المنفذ من جهاز OSD نفسه؛ أما علامة المنافذ فتعرضه فقط.\n"
+    },
+    "vtxSerialPortMspHelp": {
+        "message": "يستجيب جهاز MSP VTX عبر وصلة MSP نفسها المستخدمة لعرض OSD على النظارات؛ لذلك يتبع منفذ OSD التسلسلي المحدد في علامة تبويب OSD، ولا يمكن ضبطه من هنا.\n"
+    },
+    "vtxLowPowerDisarm": {
+        "message": "طاقة منخفضة عند إلغاء التشغيل",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxLowPowerDisarmHelp": {
+        "message": "عند التمكين، يستخدم VTX أقل طاقة متاحة عند إلغاء التشغيل (إلا إذا حدث فشل أمان).",
+        "description": "Help text for the low power disarm field of the VTX tab"
+    },
+    "vtxLowPowerDisarmOption_0": {
+        "message": "إيقاف",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxLowPowerDisarmOption_1": {
+        "message": "تشغيل",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxLowPowerDisarmOption_2": {
+        "message": "مفعّل حتى أول تشغيل\n",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxTable": {
+        "message": "جدول VTX",
+        "description": "Text of the header of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevels": {
+        "message": "عدد مستويات الطاقة",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsHelp": {
+        "message": "يحدد هذا عدد مستويات الطاقة المدعومة من قبل VTX الخاص بك",
+        "description": "Help for the number of power levels field of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsTableHelp": {
+        "message": "يمثل هذا الجدول قيم الطاقة المختلفة التي يمكن استخدامها لـ VTX. وهي مقسمة إلى قسمين: <br><b>- $t(vtxTablePowerLevelsValue.message):<\/b> يتطلب كل مستوى طاقة قيمة محددة من قبل الشركة المصنعة للأجهزة. اسأل الشركة المصنعة الخاصة بك عن القيمة الصحيحة أو استشر ويكي Betaflight لجداول VTX لالتقاط بعض العينات. <br><b>- $t(vtxTablePowerLevelsLabel.message):<\/b> يمكنك وضع التسمية التي تريدها لكل قيمة مستوى طاقة هنا. يمكن أن تكون أرقامًا (25, 200, 600, 1.2)، أو حروفًا (OFF, MIN, MAX) أو مزيجًا منها. <br \/><br \/>يجب عليك تكوين <b>فقط<\/b> مستويات الطاقة المسموح بها في بلدك.",
+        "description": "Help for the table of power levels (value-label) that appears in the VTX tab"
+    },
+    "vtxTablePowerLevelsValue": {
+        "message": "القيمة",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsLabel": {
+        "message": "التسمية",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBands": {
+        "message": "عدد النطاقات",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsHelp": {
+        "message": "يحدد هذا عدد النطاقات المطلوبة لـ VTX",
+        "description": "Help for the number of bands field of the VTX Table element in the VTX tab"
+    },
+    "vtxTableChannels": {
+        "message": "عدد القنوات لكل نطاق",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsChannelsHelp": {
+        "message": "يحدد هذا عدد النطاقات وعدد القنوات لكل نطاق التي تريدها لـ VTX الخاص بك.",
+        "description": "Help for the number of bands and channels field of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleName": {
+        "message": "الاسم",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleLetter": {
+        "message": "الحرف",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleFactory": {
+        "message": "المصنع",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsChannelsTableHelp": {
+        "message": "يمثل هذا الجدول جميع الترددات التي يمكن استخدامها لـ VTX الخاص بك. يمكن أن يكون لديك عدة نطاقات ولكل نطاق يجب عليك تكوين:<br><b>- $t(vtxTableBandTitleName.message):<\/b> الاسم الذي تريد تعيينه لهذا النطاق، مثل BOSCAM_A أو FATSHARK أو RACEBAND.<br><b>- $t(vtxTableBandTitleLetter.message):<\/b> حرف قصير يشير إلى النطاق.<br><b>- $t(vtxTableBandTitleFactory.message):<\/b> يشير هذا إلى ما إذا كان نطاق مصنع. إذا تم تمكينه، يرسل Betaflight إلى VTX رقم نطاق وقناة. بعد ذلك سوف يستخدم VTX جدول الترددات المدمج الخاص به والترددات الم configured هنا فقط لإظهار القيمة في OSD وأماكن أخرى. إذا لم يتم تمكينه، فسيرسل Betaflight إلى VTX التردد الحقيقي الم configured هنا.<br><b>- الترددات:<\/b> الترددات لهذا النطاق.<br \/><br \/>تذكر أنه ليس جميع الترددات قانونية في بلدك. يجب عليك وضع قيمة <b>صفر<\/b> لكل فهرس تردد غير مسموح لك باستخدامه لتعطيله.",
+        "description": "Help for the table of bands-channels that appears in the VTX tab"
+    },
+    "vtxSavedFileOk": {
+        "message": "تم <span class=\"message-positive\">حفظ<\/span> ملف تكوين VTX",
+        "description": "Message in the GUI log when the VTX Config file is saved"
+    },
+    "vtxSavedFileKo": {
+        "message": "<span class=\"message-negative\">خطأ<\/span> أثناء حفظ ملف تكوين VTX",
+        "description": "Message in the GUI log when the VTX Config file is saved"
+    },
+    "vtxSavedLuaFileOk": {
+        "message": "تم <span class=\"message-positive\">حفظ<\/span> ملف تكوين VTX بلغة Lua",
+        "description": "Message in the GUI log when the lua VTX Config file is saved"
+    },
+    "vtxSavedLuaFileKo": {
+        "message": "<span class=\"message-negative\">خطأ<\/span> أثناء حفظ ملف تكوين VTX بلغة Lua",
+        "description": "Message in the GUI log when the lua VTX Config file saving has failed"
+    },
+    "vtxLoadFileOk": {
+        "message": "تم <span class=\"message-positive\">تحميل<\/span> ملف تكوين VTX",
+        "description": "Message in the GUI log when the VTX Config file is loaded"
+    },
+    "vtxLoadFileKo": {
+        "message": "<span class=\"message-negative\">خطأ<\/span> أثناء تحميل ملف تكوين VTX",
+        "description": "Message in the GUI log when the VTX Config file is loaded"
+    },
+    "vtxLoadClipboardOk": {
+        "message": "تم <span class=\"message-positive\">تحميل<\/span> معلومات تكوين VTX من الحافظة",
+        "description": "Message in the GUI log when the VTX Config file is pasted from clipboard"
+    },
+    "vtxLoadClipboardKo": {
+        "message": "<span class=\"message-negative\">خطأ<\/span> أثناء تحميل معلومات تكوين VTX من الحافظة. ربما المحتويات غير صحيحة",
+        "description": "Message in the GUI log when the VTX Config file is pasted from clipboard"
+    },
+    "vtxButtonSaveFile": {
+        "message": "حفظ إلى ملف",
+        "description": "Save to file button in the VTX tab"
+    },
+    "vtxButtonSaveLua": {
+        "message": "حفظ نص Lua",
+        "description": "Save Lua script button in the VTX tab"
+    },
+    "vtxLuaFileHelp": {
+        "message": "سيسمح لك زر '$t(vtxButtonSaveLua.message)' بحفظ ملف <i>mcuid<\/i>.lua يحتوي على تكوين جدول VTX الذي يمكن استخدامه مع <a href=\"https:\/\/github.com\/betaflight\/betaflight-tx-lua-scripts\/\" target=\"_blank\" rel=\"noopener noreferrer\">نصوص Betaflight TX Lua<\/a>.<br><br>يمكن للإصدار 1.6.0 وما فوق استخدام الملف كما هو، ولكن بالنسبة للإصدارات الأقدم من النصوص، يجب إعادة تسميته ليطابق اسم النموذج على جهاز الإرسال (TX).",
+        "description": "Tooltip message for the Save Lua script button in the VTX tab"
+    },
+    "vtxButtonLoadFile": {
+        "message": "تحميل من ملف",
+        "description": "Load to file button in the VTX tab"
+    },
+    "vtxButtonLoadClipboard": {
+        "message": "تحميل من الحافظة",
+        "description": "Paste from clipboard button in the VTX tab"
+    },
+    "vtxButtonSave": {
+        "message": "حفظ",
+        "description": "Save button in the VTX tab"
+    },
+    "buttonSaving": {
+        "message": "جاري الحفظ",
+        "description": "Show state of the Save button in the VTX\/LED tab"
+    },
+    "buttonSaved": {
+        "message": "تم الحفظ",
+        "description": "Saved action button in the VTX\/LED tab"
+    },
+    "vtxSmartAudioUnlocked": {
+        "message": "{{version}} غير مقفل",
+        "description": "Indicates if SA device is unlocked"
+    },
+    "mainHelpArmed": {
+        "message": "تشغيل المحرك"
+    },
+    "mainHelpFailsafe": {
+        "message": "نمط الأمان (Failsafe)"
+    },
+    "mainHelpLink": {
+        "message": "حالة المسار التسلسلي"
+    },
+    "configurationEscProtocol": {
+        "message": "بروتوكول متحكم السرعة الإلكتروني (ESC)\/المحرك"
+    },
+    "configurationEscProtocolHelp": {
+        "message": "اختر بروتوكول المحرك الخاص بك. <br>تأكد من التحقق من أن البروتوكول مدعوم من قبل متحكم السرعة الإلكتروني (ESC) الخاص بك، يجب أن تكون هذه المعلومات على موقع الشركة المصنعة."
+    },
+    "configurationunsyndePwm": {
+        "message": "سرعة PWM للمحرك منفصلة عن سرعة PID"
+    },
+    "configurationUnsyncedPWMFreq": {
+        "message": "تردد PWM للبطارية"
+    },
+    "configurationDshotBidir": {
+        "message": "DShot ثنائي الاتجاه (يتطلب برنامج متحكم السرعة الإلكتروني (ESC) مدعوم)",
+        "description": "Feature for the ESC\/Motor"
+    },
+    "configurationDshotBidirHelp": {
+        "message": "يرسل بيانات متحكم السرعة الإلكتروني (ESC) إلى وحدة تحكم الطيران (FC) عبر بيانات DShot. مطلوب لتصفية RPM والخمول الديناميكي. <br> <br>ملاحظة: يتطلب متحكم سرعة إلكتروني (ESC) متوافقًا مع البرنامج المناسب، مثل JESC أو Jazzmac أو BLHeli-32.",
+        "description": "Description of the Bidirectional DShot feature of the ESC\/Motor"
+    },
+    "configurationGyroFrequency": {
+        "message": "تردد تحديث Gyro"
+    },
+    "configurationPidProcessDenom": {
+        "message": "تردد دورة PID"
+    },
+    "configurationPidProcessDenomHelp": {
+        "message": "التردد الأقصى لدورة PID محدد بواسطة التردد الأقصى الذي يمكن إرسال التحديثات به بواسطة اختيار متحكم السرعة الإلكتروني (ESC) \/ بروتوكول المحرك."
+    },
+    "configurationGyroUse32kHz": {
+        "message": "تفعيل تردد 32 كيلوهرتز لأخذ العينات"
+    },
+    "configurationGyroUse32kHzHelp": {
+        "message": "تردد تحديث الجيروسكوب 32 كيلوهرتز ممكن فقط إذا كانت شريحة الجيروسكوب تدعمه (حاليًا MPU6500 و MPU9250 و ICM20xxx إذا كانت متصلة عبر SPI). إذا كنت في شك، فاستشر مواصفات لوحتك."
+    },
+    "configurationAccHardware": {
+        "message": "مقياس التسارع"
+    },
+    "configurationBaroHardware": {
+        "message": "مقياس الضغط الجوي"
+    },
+    "configurationMagHardware": {
+        "message": "المقياس المغناطيسي"
+    },
+    "configurationMagDeclinationNoGps": {
+        "message": "تعذر تحديد الموقع. صِل وحدة GPS أو اسمح للمتصفح بالوصول إلى الموقع."
+    },
+    "configurationMagDeclinationSet": {
+        "message": "تم ضبط الانحراف المغناطيسي على {{declination}}° حسب الموقع المكتشف."
+    },
+    "configurationMagInclination": {
+        "message": "الميل المغناطيسي"
+    },
+    "configurationMagInclinationHelp": {
+        "message": "الزاوية بين المجال المغناطيسي للأرض والمستوى الأفقي في موقعك. تشير القيم الموجبة إلى أن المجال يتجه إلى الأسفل (نصف الكرة الشمالي)"
+    },
+    "configurationMagFieldStrengthLabel": {
+        "message": "شدة المجال"
+    },
+    "configurationMagFieldStrengthHelp": {
+        "message": "الشدة الكلية للمجال المغناطيسي للأرض في موقعك بوحدة نانو تسلا (nT). تتراوح القيم النموذجية بين 25,000 و65,000 nT"
+    },
+    "sensorConfigMagDetect": {
+        "message": "اكتشاف"
+    },
+    "sensorConfigMagUpdate": {
+        "message": "تحديث"
+    },
+    "sensorConfigDeclinationAutoSet": {
+        "message": "تم اكتشاف الانحراف المغناطيسي تلقائيًا بقيمة {{value}}° لموقعك."
+    },
+    "sensorConfigDeclinationDrift": {
+        "message": "الانحراف المحفوظ هو {{saved}}°، لكن GPS يكتشف {{detected}}° لهذا الموقع. اضغط تحديث للتصحيح."
+    },
+    "magCalibrationCancel": {
+        "message": "إلغاء"
+    },
+    "magCalibrationClear": {
+        "message": "مسح"
+    },
+    "magCalibrationModeOptions": {
+        "message": "خيارات وضع المعايرة"
+    },
+    "magCalibrationRetry": {
+        "message": "إعادة المحاولة"
+    },
+    "magCalibrationWaiting": {
+        "message": "بانتظار الحركة... حرّك الطائرة لبدء المعايرة."
+    },
+    "magCalibrationCollecting": {
+        "message": "دوّر الطائرة ببطء عبر جميع الاتجاهات."
+    },
+    "magCalibrationComplete": {
+        "message": "اكتملت المعايرة."
+    },
+    "magCalibrationError": {
+        "message": "فشلت المعايرة. حاول مرة أخرى في مكان أقل تداخلًا مغناطيسيًا."
+    },
+    "magCalibrationNoMovement": {
+        "message": "لم يتم اكتشاف حركة لمدة 30 ثانية. تم إلغاء المعايرة."
+    },
+    "magCalibrationSamples": {
+        "message": "العينات"
+    },
+    "magCalibrationQualityGood": {
+        "message": "جيد"
+    },
+    "magCalibrationQualityFair": {
+        "message": "مقبول"
+    },
+    "magCalibrationQualityPoor": {
+        "message": "ضعيف"
+    },
+    "magCalibrationFirmwareOffsets": {
+        "message": "إزاحات Firmware"
+    },
+    "magCalibrationUnguided": {
+        "message": "معايرة Firmware (قديمة)"
+    },
+    "magCalibrationUnguidedDesc": {
+        "message": "دوّر بحرية — يحفظ Firmware تلقائيًا بعد 30 ثانية"
+    },
+    "magCalibrationUnguidedTitle": {
+        "message": "معايرة Firmware"
+    },
+    "magCalibrationUnguidedInstruction": {
+        "message": "لديك 30 ثانية لتدوير الطائرة في جميع الاتجاهات. سيحفظ Firmware قيم المعايرة تلقائيًا عند انتهاء الوقت."
+    },
+    "magCalibrationUnguidedDone": {
+        "message": "اكتملت معايرة Firmware!"
+    },
+    "magCalibrationCheck": {
+        "message": "تحقق"
+    },
+    "magCalibrationCheckDesc": {
+        "message": "عرض بيانات Magnetometer المباشرة باستخدام المعايرة الحالية"
+    },
+    "magCalibrationCheckTitle": {
+        "message": "جارٍ التحقق من المعايرة"
+    },
+    "magCalibrationCheckInstruction": {
+        "message": "تأكد من اتجاه ومعايرة Magnetometer. ضع الطائرة بشكل مستوٍ مع الأفق، ووجّه مقدمتها إلى اتجاه معروف على البوصلة (يمكن استخدام الهاتف لمعرفة اتجاه الشمال)، ثم تأكد من ظهور النقاط الجديدة في الموقع المتوقع على العرض ثلاثي الأبعاد. تشير قيم شدة المجال لكل محور وشكل النقاط الكروي إلى دقة المعايرة. إذا ظهرت النقاط في أماكن خاطئة تمامًا، فمن المرجح أن اتجاه Magnetometer غير صحيح."
+    },
+    "magCalibrationCalValues": {
+        "message": "قيم المعايرة"
+    },
+    "magCalibrationSaveValues": {
+        "message": "حفظ القيم"
+    },
+    "magCalibrationSaveSuccess": {
+        "message": "تم حفظ قيم المعايرة"
+    },
+    "magCalibrationSaveError": {
+        "message": "فشل حفظ قيم المعايرة"
+    },
+    "magCalibrationFull": {
+        "message": "معايرة واكتشاف المحاذاة"
+    },
+    "magCalibrationFullDesc": {
+        "message": "تدوير المركبة في جميع الاتجاهات لمعايرة المستشعر واكتشاف اتجاهه التصاعدي تلقائيا."
+    },
+    "magCalibrationFullTitle": {
+        "message": "معايرة واكتشاف محاذاة"
+    },
+    "magCalibrationFullInstruction": {
+        "message": "اتبع الخطوات أدناه مع إبقاء الطائرة ثابتة أثناء كل دورة كاملة. يزداد عدد المناطق عند الوصول إلى زوايا جديدة — حاول تغطية المناطق العشرين جميعها."
+    },
+    "magCalibrationFullStepCounter": {
+        "message": "الخطوة {{n}} من {{total}}"
+    },
+    "magCalibrationFullStep1": {
+        "message": "أبقِ الطائرة مستوية ودوّرها ببطء دورة كاملة 360°."
+    },
+    "magCalibrationFullStep2": {
+        "message": "اقلب الطائرة رأسًا على عقب ودوّرها ببطء دورة كاملة أخرى 360°."
+    },
+    "magCalibrationFullStep3": {
+        "message": "وجّه مقدمة الطائرة إلى الأعلى مباشرة ودوّرها دورة كاملة حول هذا المحور."
+    },
+    "magCalibrationFullStep4": {
+        "message": "وجّه مقدمة الطائرة إلى الأسفل مباشرة ودوّرها دورة كاملة."
+    },
+    "magCalibrationFullStep5": {
+        "message": "ضع الطائرة على جانبها الأيسر ودوّرها دورة كاملة."
+    },
+    "magCalibrationFullStep6": {
+        "message": "ضع الطائرة على جانبها الأيمن ودوّرها دورة كاملة."
+    },
+    "magCalibrationFullStep7": {
+        "message": "نفّذ عدة قلبات أمامية بطيئة مع توجيه الطائرة إلى اتجاه مختلف في كل مرة."
+    },
+    "magCalibrationFullStep8": {
+        "message": "نفّذ عدة قلبات خلفية بطيئة، مع توجيه الطائرة إلى اتجاه مختلف في كل مرة."
+    },
+    "magCalibrationFullZones": {
+        "message": "تمت تغطية {{covered}} \/ {{total}} منطقة"
+    },
+    "magCalibrationFullCompute": {
+        "message": "إنهاء المعايرة"
+    },
+    "magCalibrationFullCoverageHint": {
+        "message": "وتعطي المناطق الأكثر تغطية دقةً أعلى - هدف 20 إلى 20 لتحقيق أفضل معايرة واتساق للكشف."
+    },
+    "magCalibrationFullCoverage": {
+        "message": "التغطية:"
+    },
+    "magCalibrationFullAlignment": {
+        "message": "المحاذاة:"
+    },
+    "magCalibrationFullCustomAngles": {
+        "message": "Roll {{roll}}° Pitch {{pitch}}° Yaw {{yaw}}°"
+    },
+    "magCalibrationFullOffsets": {
+        "message": "المعايرة:"
+    },
+    "magCalibrationFullResidual": {
+        "message": "القيمة المتبقية:"
+    },
+    "magCalibrationFullCopyCli": {
+        "message": "نسخ أوامر CLI"
+    },
+    "magCalibrationFullApply": {
+        "message": "تطبيق"
+    },
+    "magCalibrationFullExport": {
+        "message": "تصدير النموذج"
+    },
+    "magCalibrationFullInsufficientSamples": {
+        "message": "عدد العينات غير كافٍ — استمر في الدوران مدة أطول"
+    },
+    "magCalibrationFullNoGeo": {
+        "message": "لا يوجد GPS أو المتصفح أو موقع IP - أدخل الإحداثيات يدوياً للاستمرار"
+    },
+    "magCalibrationManualLocationTitle": {
+        "message": "الموقع مطلوب للمعايرة"
+    },
+    "magCalibrationManualLocationPrompt": {
+        "message": "أدخل خط العرض وخط الطول يدويا عن طريق الاختيار من خرائط جوجل. لا يوجد قفل للطائرة بدون طيار GPS وقد فشل جهازك في توفير بيانات الموقع. الموقع مطلوب لمعايرة مقياس المغناطيس."
+    },
+    "magCalibrationManualLocationPlaceholder": {
+        "message": "على سبيل المثال 63.728263, -68.446117"
+    },
+    "magCalibrationManualLocationInvalid": {
+        "message": "تنسيق الإحداثيات غير صالح. الرجاء إدخال كالتالي: خط العرض، خط الطول (على سبيل المثال 63.728263، -68.446117)"
+    },
+    "magCalibrationManualLocationFailed": {
+        "message": "لا يمكن حساب مرجع مغناطيسي لتلك الإحداثيات. الرجاء التحقق منها والمحاولة مرة أخرى."
+    },
+    "magCalibrationFullCliCopied": {
+        "message": "تم نسخ أوامر CLI إلى الحافظة"
+    },
+    "magCalibrationFullCliCopyFailed": {
+        "message": "تعذر النسخ إلى الحافظة"
+    },
+    "magCalibrationFullCustomUnsupported": {
+        "message": "إصدار Firmware {{version}} قديم جدًا لمحاذاة Magnetometer المخصصة CUSTOM (يتطلب {{min}} أو أحدث). حدّث Firmware ثم طبّق الإعداد."
+    },
+    "magCalibrationFullApplied": {
+        "message": "تم تطبيق المعايرة وحفظها"
+    },
+    "magCalibrationDiscard": {
+        "message": "تجاهل"
+    },
+    "magVizPointCloud": {
+        "message": "سحابة النقاط"
+    },
+    "magVizHeatmap": {
+        "message": "خريطة حرارية Voxel"
+    },
+    "magVizProjection": {
+        "message": "إسقاط ثلاثي"
+    },
+    "magVizPolar": {
+        "message": "الكثافة القطبية"
+    },
+    "magVizWaitingForData": {
+        "message": "بانتظار البيانات…"
+    },
+    "magVizAxisField": {
+        "message": "المجال"
+    },
+    "magVizAgeLegendOld": {
+        "message": "القديم"
+    },
+    "magVizAgeLegendNew": {
+        "message": "الجديد"
+    },
+    "configurationSmallAngle": {
+        "message": "زاوية التشغيل القصوى [بالدرجات]"
+    },
+    "configurationSmallAngleHelp": {
+        "message": "لن يتم تشغيل الطائرة إذا تجاوز ميلها عدد الدرجات المحدد. ينطبق ذلك فقط عند تفعيل مقياس التسارع. ضبط القيمة على 180 يعطّل هذا الفحص عمليًا."
+    },
+    "configurationBatteryVoltage": {
+        "message": "جهد البطارية"
+    },
+    "configurationBatteryCurrent": {
+        "message": "تيار البطارية"
+    },
+    "configurationBatteryMeterType": {
+        "message": "نوع مقياس البطارية"
+    },
+    "configurationBatteryMinimum": {
+        "message": "الحد الأدنى لجهد الخلية"
+    },
+    "configurationBatteryMaximum": {
+        "message": "الحد الأقصى لجهد الخلية"
+    },
+    "configurationBatteryWarning": {
+        "message": "جهد الخلية التحذيري"
+    },
+    "configurationBatteryScale": {
+        "message": "مقياس الجهد"
+    },
+    "configurationCurrentMeterType": {
+        "message": "نوع مقياس التيار"
+    },
+    "configurationCurrent": {
+        "message": "مستشعر التيار"
+    },
+    "configurationCurrentScale": {
+        "message": "قياس جهد الخرج إلى ملي أمبير [1\/10 من mV\/A]"
+    },
+    "configurationCurrentOffset": {
+        "message": "الإزاحة بخطوات ملي فولت"
+    },
+    "configurationBatteryMultiwiiCurrent": {
+        "message": "تمكين الدعم لإخراج تيار Multiwii MSP القديم"
+    },
+    "pidTuningProfile": {
+        "message": "الملف الشخصي"
+    },
+    "pidTuningProfileTip": {
+        "message": "يمكن تخزين ما يصل إلى 3 (2 لبعض وحدات التحكم) ملفات تعريف PID مختلفة على وحدة تحكم الطيران. تتضمن ملفات تعريف PID إعدادات pid و d setpoint و angle\/horizon في علامة التبويب هذه. بمجرد التواجد في الميدان، يمكن استخدام أوامر عصا بسيطة (انظر التعليمات عبر الإنترنت) للتبديل بين ملفات التعريف."
+    },
+    "pidTuningRateProfile": {
+        "message": "ملف تعريف المعدل"
+    },
+    "pidTuningRateProfileTip": {
+        "message": "يمكن تخزين ما يصل إلى 3 ملفات تعريف معدل مختلفة لكل ملف تعريف على وحدة تحكم الطيران. تتضمن ملفات تعريف المعدل الإعدادات لـ 'معدل RC' و 'المعدل' و 'RC Expo' و 'الدفع' و 'TPA'. التبديل بين ملفات تعريف المعدل ممكن أثناء الطيران، عن طريق إعداد مفتاح 3 مواضع لـ 'اختيار ملف تعريف المعدل' في علامة تبويب 'التعديلات'."
+    },
+    "pidTuningRateSetup": {
+        "message": "المعدلات الأساسية\/الاكرو"
+    },
+    "pidTuningRateSetupHelp": {
+        "message": "اضبط هذه القيم لتعيين معدلاتك. استخدم معدل RC لزيادة المعدل الأقصى بشكل عام، استخدم Super Rate للحصول على معدلات أعلى في نهاية حركة العصا، استخدم RC Expo لجعل منتصف العصا يشعر بالنعومة.",
+        "description": "Rate table helpicon message"
+    },
+    "pidTuningDelta": {
+        "message": "طريقة المشتق"
+    },
+    "pidTuningDeltaError": {
+        "message": "الخطأ"
+    },
+    "pidTuningDeltaMeasurement": {
+        "message": "القياسات"
+    },
+    "pidTuningDeltaTip": {
+        "message": "يوفر <b>Derivative from Error<\/b> استجابة مباشرة أكثر للعصي ويُفضّل غالبًا للسباقات.<br \/><br \/>يوفر <b>Derivative from Measurement<\/b> استجابة أكثر سلاسة للعصي، وهو أنسب للطيران الحر Freestyle."
+    },
+    "pidTuningPidControllerTip": {
+        "message": "<b>Legacy مقابل Betaflight (الفاصلة العائمة):<\/b> تحجيم PID ومنطقه متطابقان تمامًا، لذلك لا يلزم بالضرورة إعادة الضبط. يُعد Legacy نسخة مطوّرة ومعاد كتابتها من متحكم PID القديم في Betaflight، وهو متحكم أساسي يعتمد على حسابات الأعداد الصحيحة. أما متحكم PID في Betaflight فيستخدم حسابات الفاصلة العائمة، ويتضمن العديد من الميزات الجديدة المصممة خصيصًا للطائرات متعددة المراوح. <br> <b>الفاصلة العائمة مقابل الأعداد الصحيحة:<\/b> تحجيم PID ومنطقه متطابقان تمامًا، ولا حاجة إلى إعادة الضبط. لا تحتوي لوحات F1 على وحدة FPU مدمجة، لذلك تزيد حسابات الفاصلة العائمة الحمل على CPU، بينما تحسّن حسابات الأعداد الصحيحة الأداء، لكن حسابات الفاصلة العائمة قد توفر دقة أعلى قليلًا.\n"
+    },
+    "pidTuningFilterTip": {
+        "message": "<b>فلتر الجيروسكوب البرمجي:<\/b> فلتر تمرير منخفض للجيروسكوب. استخدم قيمة أقل للحصول على فلتر أقوى.<br><b>فلتر مركّبة D:<\/b> فلتر تمرير منخفض لمركّبة D. قد يؤثر في ضبط D. استخدم قيمة أقل للحصول على فلتر أقوى. <br><b>فلتر  Yaw:<\/b> فلتر خرج محور Yaw، وقد يفيد في التجميعات التي تعاني تشويشًا على هذا المحور."
+    },
+    "pidTuningRatesTip": {
+        "message": "العب بالمعدلات وشاهد كيف تؤثر على منحنى العصا"
+    },
+    "configurationCamera": {
+        "message": "الكاميرا"
+    },
+    "configurationPersonalization": {
+        "message": "التخصيصات الشخصية"
+    },
+    "craftName": {
+        "message": "اسم الطائرة"
+    },
+    "configurationCraftNameHelp": {
+        "message": "يمكن عرضه في السجلات وأسماء ملفات النسخ الاحتياطي و OSD.<\/br>يمكن تعيينه عبر متغير سطر الأوامر (CLI) <b>craft_name<\/b>."
+    },
+    "configurationPilotName": {
+        "message": "اسم الطيار"
+    },
+    "configurationPilotNameHelp": {
+        "message": "يمكن عرضه في OSD.<\/br>يمكن تعيينه عبر متغير سطر الأوامر (CLI) <b>pilot_name<\/b>."
+    },
+    "configurationFpvCamAngleDegrees": {
+        "message": "زاوية كاميرا FPV [بالدرجات]"
+    },
+    "onboardLoggingBlackbox": {
+        "message": "جهاز تسجيل الصندوق الأسود (Blackbox)"
+    },
+    "onboardLoggingSerialPort": {
+        "message": "منفذ تسلسلي"
+    },
+    "onboardLoggingSerialPortHelp": {
+        "message": "UART يستخدم عندما يكون جهاز التسجيل متسلسل. تعيين على الخانة السوداء نفسها من API 1.49؛ علامة التبويب المنفذ تظهر فقط."
+    },
+    "onboardLoggingSerialBaud": {
+        "message": "سرعة الاتصال التسلسلي"
+    },
+    "onboardLoggingSerialBaudHelp": {
+        "message": "سرعة الاتصال  لمنفذ التسجيل المتسلسل."
+    },
+    "onboardLoggingRateOfLogging": {
+        "message": "معدل تسجيلات الصندوق الأسود"
+    },
+    "onboardLoggingDebugFields": {
+        "message": "الحقول المتضمنة للتصحيح"
+    },
+    "onboardLoggingDebugMode": {
+        "message": "وضع تصحيح الصندوق الأسود"
+    },
+    "onboardLoggingDebugModeUnknown": {
+        "message": "غير معروف"
+    },
+    "onboardLoggingSerialLogger": {
+        "message": "جهاز التسجيل التسلسلي الخارجي"
+    },
+    "onboardLoggingFlashLogger": {
+        "message": "شريحة dataflash المدمجة"
+    },
+    "onboardLoggingEraseInProgress": {
+        "message": "جاري المسح، يرجى الانتظار..."
+    },
+    "onboardLoggingOnboardSDCard": {
+        "message": "بطاقة SD المدمجة"
+    },
+    "onboardLoggingMsc": {
+        "message": "وضع تخزين كبير السعة (MSC)"
+    },
+    "onboardLoggingMscNote": {
+        "message": "أعد التشغيل في وضع <strong>جهاز تخزين كبير السعة (MSC)<\/strong>. بمجرد التفعيل، سيتم التعرف على الذاكرة المدمجة أو بطاقة SD على وحدة تحكم الطيران الخاصة بك كجهاز تخزين من قبل جهاز الكمبيوتر الخاص بك، وسيسمح لك بتنزيل ملفات السجل الخاصة بك. قم بطرد وإعادة تشغيل وحدة تحكم الطيران الخاصة بك لمغادرة وضع جهاز تخزين كبير السعة."
+    },
+    "onboardLoggingRebootMscText": {
+        "message": "تفعيل وضع جهاز تخزين كبير السعة"
+    },
+    "onboardLoggingMscNotReady": {
+        "message": "لا يمكن تفعيل وضع تخزين كبير السعة لأن وحدة التخزين غير جاهزة."
+    },
+    "dialogConfirmResetTitle": {
+        "message": "تأكيد"
+    },
+    "dialogConfirmResetNote": {
+        "message": "تحذير: هل أنت متأكد أنك تريد إعادة تعيين <strong>جميع الإعدادات<\/strong> إلى حالة غير م configured؟ هذا <strong>ليس<\/strong> \"إعادة تعيين إلى إعدادات المصنع\". قد يسبب مشاكل غير متوقعة، وقد يكون من الضروري إعادة تثبيت البرنامج الثابت الخاص بك لتتمكن من الاتصال مرة أخرى."
+    },
+    "dialogConfirmResetConfirm": {
+        "message": "إعادة تعيين"
+    },
+    "dialogConfirmResetClose": {
+        "message": "إلغاء"
+    },
+    "modeCameraWifi": {
+        "message": "زر Wi-Fi للكاميرا"
+    },
+    "modeCameraPower": {
+        "message": "زر تشغيل الكامرة"
+    },
+    "modeCameraChangeMode": {
+        "message": "تغيير نمط الكاميرا"
+    },
+    "flashTab": {
+        "message": "تحديث البرنامج الثابت"
+    },
+    "cliAutoComplete": {
+        "message": "الإكمال التلقائي المتقدم لسطر الأوامر (CLI)"
+    },
+    "firmwareBackupOnFlash": {
+        "message": "إنشاء نسخة احتياطية قبل تثبيت الهدف الجديد"
+    },
+    "darkTheme": {
+        "message": "تمكين السمة الداكنة"
+    },
+    "colorTheme": {
+        "message": "لون السمة",
+        "description": "Color theme settings"
+    },
+    "colorThemeYellow": {
+        "message": "أصفر (الافتراضي)",
+        "description": "Default yellow color theme"
+    },
+    "colorThemeAmber": {
+        "message": "كهرماني",
+        "description": "Amber color theme"
+    },
+    "colorThemeContrast": {
+        "message": "تباين عالٍ",
+        "description": "Contrast color theme"
+    },
+    "uiScale": {
+        "message": "مقياس الواجهة",
+        "description": "Scale the entire user interface up or down"
+    },
+    "pidTuningRatesType": {
+        "message": "نوع المعدلات"
+    },
+    "pidTuningRatesTypeTip": {
+        "message": "تغيير نوع Rates سيغيّر منحنى Rates وطريقة ضبطه.<br><br><a href='https:\/\/rates.metamarc.com' target='_blank' rel='noopener noreferrer'>rates.metamarc.com<\/a>"
+    },
+    "pidTuningRcRateRaceflight": {
+        "message": "المعدل"
+    },
+    "pidTuningRcExpoRaceflight": {
+        "message": "Expo"
+    },
+    "pidTuningRateRaceflight": {
+        "message": "Acro+"
+    },
+    "pidTuningRcExpoKISS": {
+        "message": "منحنى RC"
+    },
+    "pidTuningRateQuickRates": {
+        "message": "أقصى معدل"
+    },
+    "pidTuningRcRateActual": {
+        "message": "حساسية المركز"
+    },
+    "pidTuningAcroCenterSensitiviy": {
+        "message": "حساسية المركز-الأقصى"
+    },
+    "dialogRatesTypeTitle": {
+        "message": "تغيير نوع المعدلات"
+    },
+    "dialogRatesTypeNote": {
+        "message": "<span class=\"message-negative\"><b>تحذير: أنت تقوم بتغيير نوع المعدلات.<\/b><\/span> إذا قمت بتغيير نوع المعدلات، سيتم تعيين معدلاتك إلى منحنى افتراضي."
+    },
+    "dialogRatesTypeConfirm": {
+        "message": "تغيير"
+    },
+    "gpsSbasAutoDetect": {
+        "message": "الكشف التلقائي",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasEuropeanEGNOS": {
+        "message": "الأوروبي EGNOS",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasNorthAmericanWAAS": {
+        "message": "الأمريكي الشمالي WAAS",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasJapaneseMSAS": {
+        "message": "الياباني MSAS",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasIndianGAGAN": {
+        "message": "الهندي GAGAN",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasNone": {
+        "message": "لا شيء",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "dialogFileNameTitle": {
+        "message": "اسم الملف"
+    },
+    "dialogFileNameDescription": {
+        "message": "سيتم حفظ الملف في المجلد 'Android\/data\/betaflight-app\/{{folder}}' داخل وحدة التخزين الداخلية."
+    },
+    "dialogFileAlreadyExistsTitle": {
+        "message": "هذا الملف موجود بالفعل!"
+    },
+    "dialogFileAlreadyExistsDescription": {
+        "message": "Overwrite ?"
+    },
+    "cordovaCheckingWebview": {
+        "message": "جاري التحقق من تطبيقات webview ..."
+    },
+    "cordovaIncompatibleWebview": {
+        "message": "Webview غير متوافق"
+    },
+    "cordovaWebviewTroubleshootingMsg": {
+        "message": "يجب عليك تحديث webview لجهازك من أجل استخدام تطبيق Betaflight."
+    },
+    "cordovaWebviewTroubleshootingMsg2": {
+        "message": "الأداة أدناه مخصصة لمساعدتك في تثبيت webview جديد أو تحديث webview مثبت مسبقًا."
+    },
+    "cordovaAvailableWebviews": {
+        "message": "تطبيقات webview المتاحة على جهازك"
+    },
+    "cordovaWebviewInstall": {
+        "message": "تثبيت تطبيق <b>{{app}}<\/b> يمكنه حل مشكلة التوافق هذه."
+    },
+    "cordovaWebviewInstallBtn": {
+        "message": "التثبيت من متجر Google Play"
+    },
+    "cordovaWebviewUninstall": {
+        "message": "إلغاء تثبيت تطبيق <b>{{app}}<\/b> يمكنه حل مشكلة التوافق هذه. إذا لم تتمكن من إلغاء تثبيته، فحاول تعطيله من تطبيق الإعدادات."
+    },
+    "cordovaWebviewUninstallBtn1": {
+        "message": "إلغاء التثبيت من متجر Google Play"
+    },
+    "cordovaWebviewUninstallBtn2": {
+        "message": "إلغاء التثبيت \/ التعطيل من الإعدادات"
+    },
+    "cordovaWebviewUpdate": {
+        "message": "تحديث تطبيق <b>{{app}}<\/b> يمكنه حل مشكلة التوافق هذه."
+    },
+    "cordovaWebviewUpdateBtn": {
+        "message": "التحديث من متجر Google Play"
+    },
+    "cordovaWebviewEnable": {
+        "message": "انتقل إلى قسم معلومات الجهاز في الإعدادات واضغط على رقم الإصدار 10 مرات لتفعيل 'خيارات المطور'. ثم افتح خيارات المطور واختر <b>{{app}}<\/b> كمزوّد WebView."
+    },
+    "cordovaWebviewEnableBtn": {
+        "message": "فتح الإعدادات"
+    },
+    "cordovaWebviewIncompatible": {
+        "message": "يبدو أن جهازك غير متوافق. حاول البحث عن طرق أخرى لتحديث webview الخاص بك"
+    },
+    "cordovaNoWebview": {
+        "message": "لا يوجد تطبيق webview مثبت \/ مفعل"
+    },
+    "cordovaWebviewUsed": {
+        "message": "مستخدم"
+    },
+    "cordovaExitAppTitle": {
+        "message": "تأكيد"
+    },
+    "cordovaExitAppMessage": {
+        "message": "هل تريد حقًا إغلاق التطبيق؟"
+    },
+    "dropDownSelectAll": {
+        "message": "[تحديد\/إلغاء تحديد الكل]",
+        "description": "Select all item in the drop down\/multiple select"
+    },
+    "dropDownFilterDisabled": {
+        "message": "تحديد...",
+        "description": "Text indicating nothing is selected in the drop down\/multiple select (filter disabled)"
+    },
+    "dropDownAll": {
+        "message": "الكل",
+        "description": "Text indicating everything is selected in the drop down\/multiple select"
+    },
+    "tabPresets": {
+        "message": "الإعدادات المسبقة",
+        "description": "Presets tab title"
+    },
+    "presetsReload": {
+        "message": "إعادة تحميل",
+        "description": "Text on the reload button that appears when there in an error loading presets index"
+    },
+    "presetsAuthor": {
+        "message": "المؤلف:",
+        "description": "Hint text in the presets detailed dialog"
+    },
+    "presetsKeywords": {
+        "message": "الكلمات المفتاحية:",
+        "description": "Hint text in the presets detailed dialog"
+    },
+    "presetsSourceRepository": {
+        "message": "المصدر:",
+        "description": "Text prefixing user defined name of the preset repository containing a preset"
+    },
+    "presetsVersions": {
+        "message": "البرنامج الثابت:",
+        "description": "Hint text in the presets detailed dialog"
+    },
+    "presetsOfficial": {
+        "message": "رسمي",
+        "description": "Hint text in the presets detailed dialog indication preset is official"
+    },
+    "presetsCommunity": {
+        "message": "المجتمع",
+        "description": "Hint text in the presets detailed dialog indication preset is not official but community"
+    },
+    "presetsExperimental": {
+        "message": "تجريبي",
+        "description": "Hint text in the presets detailed dialog indication preset is not official but experimental"
+    },
+    "presetsApply": {
+        "message": "اختيار",
+        "description": "Button to pick a preset"
+    },
+    "presetsViewOnline": {
+        "message": "عرض عبر الإنترنت&hellip;",
+        "description": "Link text for opening preset file online"
+    },
+    "presetsOpenDiscussion": {
+        "message": "مناقشة&hellip;",
+        "description": "Link text for opening preset discussion"
+    },
+    "presetsShowCli": {
+        "message": "إظهار CLI",
+        "description": "Button to show CLI code of a preset"
+    },
+    "presetsHideCli": {
+        "message": "إخفاء CLI",
+        "description": "Button to hide CLI code of a preset"
+    },
+    "presetsOptions": {
+        "message": "الخيارات",
+        "description": "Text label for Options drop down select"
+    },
+    "presetsFilterCategory": {
+        "message": "الفئات",
+        "description": "UI filter name"
+    },
+    "presetsFilterKeyword": {
+        "message": "Keywords",
+        "description": "UI filter name"
+    },
+    "presetsFilterAuthor": {
+        "message": "Authors",
+        "description": "UI filter name"
+    },
+    "presetsFilterFirmware": {
+        "message": "Firmwares",
+        "description": "UI filter name"
+    },
+    "presetsFilterStatus": {
+        "message": "الحالة",
+        "description": "UI filter name - official\/community\/experimental"
+    },
+    "presetsLoadError": {
+        "message": "خطأ في تحميل الإعدادات المسبقة من الإنترنت",
+        "description": "Error report when failed to load presets index or a specific preset"
+    },
+    "presetsButtonSave": {
+        "message": "حفظ وإعادة التشغيل",
+        "description": "A button that saves all applied presets - analogous to 'save' command in CLI"
+    },
+    "presetsButtonCancel": {
+        "message": "إلغاء",
+        "description": "A button that restarts FC without saving applied presets - analogous to 'exit' command in CLI"
+    },
+    "presetsApplyingPresets": {
+        "message": "جاري تطبيق التكوين...",
+        "description": "First label in the progress dialog when applying configuration (presets or user config)"
+    },
+    "presetsPleaseWait": {
+        "message": "يرجى الانتظار.",
+        "description": "Second label in the progress dialog when applying presets"
+    },
+    "presetsCliErrorsWarning": {
+        "message": "<span class='message-negative'>تحذير!<\/span><br\/>تم تطبيق الإعدادات مع وجود أخطاء CLI.",
+        "description": "Text to show when there are CLI errors after applying presets or user configuration"
+    },
+    "presetsSaveAnyway": {
+        "message": "حفظ على أي حال",
+        "description": "Save anyway button on the CLI errors presets dialog"
+    },
+    "presetsWarningDialogTitle": {
+        "message": "تحذير!",
+        "description": "Warning title in the warning dialog in the presets"
+    },
+    "presetsWarningDialogYesButton": {
+        "message": "موافق",
+        "description": "Agree button in the presets warning dialog"
+    },
+    "presetsWarningDialogNoButton": {
+        "message": "إلغاء",
+        "description": "Cancel button in the presets warning dialog"
+    },
+    "presetsFavoriteAddAriaLabel": {
+        "message": "إضافة إعداد مسبق",
+        "description": "Accessible label for the button that favorites a preset"
+    },
+    "presetsFavoriteRemoveAriaLabel": {
+        "message": "إزالة إعداد مسبق",
+        "description": "Accessible label for the button that removes a preset from favorites"
+    },
+    "presetsWiki": {
+        "message": "ويكي الإعدادات المسبقة",
+        "description": "Button to open Presets Wiki link"
+    },
+    "presetsBackupSave": {
+        "message": "حفظ نسخة احتياطية",
+        "description": "Button to backup current configuration to file"
+    },
+    "presetsBackupLoad": {
+        "message": "تحميل نسخة احتياطية",
+        "description": "Button to load backup from the file"
+    },
+    "presetsVirtualModeCliUnsupported": {
+        "message": "يتطلّب تطبيق الإعدادات المسبقة وأخذ النسخ الاحتياطية استخدام تبويب CLI، وهو غير متاح في الوضع الافتراضي.",
+        "description": "Warning shown when a presets CLI action is attempted in Virtual Mode"
+    },
+    "mspCliFirmwareTooOld": {
+        "message": "يتطلب هذا الإجراء Betaflight Firmware {{required}} أو أحدث (المتصل حاليًا {{current}}). يرجى تحديث Firmware لمتحكم الطيران قبل المتابعة.",
+        "description": "Warning shown when an MSP CLI action is attempted on firmware that does not support MSP CLI"
+    },
+    "firmwareFlasherRestoreBackup": {
+        "message": "استعادة النسخة الاحتياطية",
+        "description": "Button to restore pre-flash backup from flasher tab"
+    },
+    "firmwareFlasherRestoreBackupTitle": {
+        "message": "استعادة النسخة الاحتياطية قبل التفليش",
+        "description": "Title for the restore backup confirmation dialog"
+    },
+    "firmwareFlasherRestoreBackupConfirm": {
+        "message": "سيؤدي هذا إلى استعادة نسخة الإعدادات الاحتياطية التي أُخذت قبل التفليش. هل تريد المتابعة؟",
+        "description": "Confirmation message before restoring a pre-flash backup"
+    },
+    "firmwareFlasherRestoreBackupSuccess": {
+        "message": "تمت استعادة نسخة الإعدادات الاحتياطية بنجاح.",
+        "description": "Success message after restoring a pre-flash backup"
+    },
+    "firmwareFlasherRestoreBackupSuccessSkipped": {
+        "message": "تمت استعادة النسخة الاحتياطية للإعدادات، وتم تخطي {{count}} سطر.",
+        "description": "Success message after restoring a pre-flash backup when some CLI lines were skipped"
+    },
+    "firmwareFlasherRestoreBackupFailed": {
+        "message": "فشلت الاستعادة: {{1}}",
+        "description": "Error message when restoring a pre-flash backup fails"
+    },
+    "firmwareFlasherRestoreConnectionFailed": {
+        "message": "تعذر الاتصال بمتحكم الطيران لإجراء الاستعادة.",
+        "description": "Error message when connection fails during restore"
+    },
+    "firmwareFlasherNoBackupAvailable": {
+        "message": "لا توجد نسخة احتياطية متاحة للاستعادة.",
+        "description": "Error message when no backup data is cached for restore"
+    },
+    "presetsLoadingDumpAll": {
+        "message": "جاري تحميل التكوين الحالي من وحدة تحكم الطيران",
+        "description": "Title for the waiting dialog when loading dump all into a file"
+    },
+    "dumpAllNotSavedWarning": {
+        "message": "حدث خطأ في أثناء حفظ الإعدادات الحالية",
+        "description": "Message appears on presets tab when saving current diff all into a file has failed"
+    },
+    "presetSources": {
+        "message": "مصادر الإعدادات المسبقة...",
+        "description": "A button to show preset sources dialog"
+    },
+    "presetsSourcesDialogTitle": {
+        "message": "مصادر الإعدادات المسبقة",
+        "description": "A button to show preset sources dialog"
+    },
+    "presetsSourcesDialogAddNew": {
+        "message": "إضافة مصدر جديد",
+        "description": "A button to show preset sources dialog"
+    },
+    "presetsSourcesDialogDefaultSourceName": {
+        "message": "مصدر إعداد مسبق مخصص جديد",
+        "description": "A default preset source (repo) name"
+    },
+    "presetsSourcesDialogSaveSource": {
+        "message": "حفظ",
+        "description": "Presets tab, sources dialog, button to save new or editable source"
+    },
+    "presetsSourcesDialogResetSource": {
+        "message": "إعادة تعيين",
+        "description": "Presets tab, sources dialog, button to reset source after modifications"
+    },
+    "presetsSourcesDialogMakeSourceActive": {
+        "message": "جعله نشطًا",
+        "description": "Presets tab, sources dialog, button to make selected source active"
+    },
+    "presetsSourcesDialogMakeSourceDisable": {
+        "message": "جعله معطلًا",
+        "description": "Presets tab, sources dialog, button to make selected source disabled"
+    },
+    "presetsSourcesDialogDeleteSource": {
+        "message": "حذف",
+        "description": "Presets tab, sources dialog, button to delete selected source"
+    },
+    "presetsWarningNotOfficialSource": {
+        "message": "<span class=\"message-negative\">تحذير!<\/span> تم تحديد مصدر إعداد مسبق لطرف ثالث.",
+        "description": "Warning message that shows up when a third party preset source is selected"
+    },
+    "presetsFailedToLoadRepositories": {
+        "message": "<span class=\"message-negative\">تحذير!<\/span> فشل تحميل المستودعات التالية: <b>{{repos}}<\/b>",
+        "description": "Warning message that shows up when we fail to load some repositories"
+    },
+    "presetsWarningBackup": {
+        "message": "يرجى التأكد من نسخ تكوينك الحالي احتياطيًا (زر '$t(presetsBackupSave.message)' أو عبر CLI إذا كان الزر معطلًا) <strong>قبل<\/strong> اختيار وتطبيق الإعدادات المسبقة. وإلا فلا توجد طريقة للعودة إلى التكوين السابق بعد تطبيق الإعدادات المسبقة.",
+        "description": "Warning message that shows up at the top of the presets tab"
+    },
+    "presets_sources_dialog_warning": {
+        "message": "<span class=\"message-negative\">تحذير!<\/span> استخدام مصادر الإعدادات المسبقة لطرف ثالث يمكن أن يكون خطيرًا.<br\/>تأكد من إضافة واستخدام المصادر الموثوقة فقط. مصادر الإعدادات المسبقة الخبيثة أو السيئة ستعطل تكوين طائرتك ويمكن أن تضر بأجهزتك بشكل محتمل.",
+        "description": "Warning message that shows up at the top of the preset sources dialog"
+    },
+    "presetsWarningWrongVersionConfirmation": {
+        "message": "الإعداد المسبق المختار يتطلب إصدار برنامج ثابت $1<br\/> إصدار البرنامج الثابت الحالي هو $2",
+        "description": "Warning message that shows up at the top of the preset sources dialog"
+    },
+    "presetsNoPresetsFound": {
+        "message": "لم يتم العثور على إعدادات مسبقة لمعايير البحث المحددة",
+        "description": "Message that appears on presets tab if no presets were found"
+    },
+    "presetsTooManyPresetsFound": {
+        "message": "تم الوصول إلى الحد الأقصى لعدد الإعدادات المسبقة المعروضة",
+        "description": "Message that appears on presets tab if too many presets found"
+    },
+    "presetsOptionsPlaceholder": {
+        "message": "انتباه! راجع قائمة الخيارات",
+        "description": "Placeholder for the options list dropdown"
+    },
+    "presetsVersionMismatch": {
+        "message": "عدم تطابق إصدار مصدر الإعداد المسبق.<br\/>الإصدار المطلوب: {{versionRequired}}<br\/>إصدار مصدر الإعداد المسبق: {{versionSource}}<br\/>استخدام مصدر الإعداد المسبق هذا يمكن أن يكون خطيرًا.<br\/>هل تريد المتابعة؟",
+        "description": "Placeholder for the options list dropdown"
+    },
+    "presetsReviewOptionsWarning": {
+        "message": "يرجى مراجعة قائمة الخيارات قبل اختيار هذا الإعداد المسبق.",
+        "description": "Dialog text to prompt user to review options for the preset"
+    },
+    "firmwareFlasherBuildConfigurationHead": {
+        "message": "إعدادات البناء\n"
+    },
+    "firmwareFlasherBuildOptions": {
+        "message": "خيارات أخرى"
+    },
+    "firmwareFlasherRemoveBuildOption": {
+        "message": "إزالة {{option}}",
+        "description": "Accessible label for the remove button on a selected build option badge."
+    },
+    "firmwareFlasherSelectProtocol": {
+        "message": "اختر البروتوكول"
+    },
+    "firmwareFlasherSelectOptions": {
+        "message": "اختر الخيارات"
+    },
+    "firmwareFlasherSelectBranch": {
+        "message": "اختر الفرع أو أدخل رقم PR \/ قيمة commit hash"
+    },
+    "firmwareFlasherSearchBoard": {
+        "message": "ابحث عن لوحة..."
+    },
+    "firmwareFlasherBuildRadioProtocols": {
+        "message": "بروتوكول الراديو"
+    },
+    "firmwareFlasherBuildTelemetryProtocols": {
+        "message": "بروتوكول Telemetry"
+    },
+    "firmwareFlasherBuildMotorProtocols": {
+        "message": "بروتوكول المحرك"
+    },
+    "firmwareFlasherBuildOsdProtocols": {
+        "message": "بروتوكول OSD"
+    },
+    "firmwareFlasherConfigurationFile": {
+        "message": "اسم ملف التكوين:"
+    },
+    "firmwareFlasherRadioProtocolDescription": {
+        "message": "حدد بروتوكول الراديو الذي تريد تضمينه في هذا البناء. لاحظ أن هذه قائمة منسدلة، ولكن يمكن تحديد عنصر واحد فقط."
+    },
+    "firmwareFlasherTelemetryProtocolDescription": {
+        "message": "حدد بروتوكول Telemetry الذي تريد تضمينه في هذا البناء. لاحظ أن هذه قائمة منسدلة، ولكن يمكن تحديد عنصر واحد فقط. هناك أيضًا بعض بروتوكولات Telemetry التي سيتم تمكينها، بغض النظر عن اختيارك هنا بناءً على بروتوكول الراديو المحدد، على سبيل المثال CRSF."
+    },
+    "firmwareFlasherOptionLabelTelemetryProtocolIncluded": {
+        "message": "مضمن تلقائيًا"
+    },
+    "firmwareFlasherOptionsDescription": {
+        "message": "حدد الخيارات العامة التي تريد تضمينها في هذا البناء. لاحظ أن هذه قائمة منسدلة، ويمكن تحديد عناصر متعددة. العناصر مثل الإصلاحات، على سبيل المثال AKK VTX، مدرجة هنا."
+    },
+    "firmwareFlasherMotorProtocolDescription": {
+        "message": "حدد بروتوكول المحرك (ESC) الذي تريد تضمينه في هذا البناء. لاحظ أن هذه قائمة منسدلة، ولكن يمكن تحديد عنصر واحد فقط."
+    },
+    "firmwareFlasherOsdProtocolDescription": {
+        "message": "حدد بروتوكول OSD الذي تريد تضمينه في هذا البناء. لاحظ أن هذه قائمة منسدلة، ولكن يمكن تحديد عنصر واحد فقط."
+    },
+    "firmwareFlasherBranchDescription": {
+        "message": "مفيد بشكل خاص للمطورين، يمكنك تحديد طلب سحب مدمج، أو تحديد SHA لـ commit، أو تحديد طلب سحب 'لم يتم دمجه بعد' عن طريق كتابة # متبوعًا برقم طلب السحب، على سبيل المثال #1234 (هذا اختصار للفرع 'pull\/1234\/head')."
+    },
+    "firmwareFlasherCustomDefinesDescription": {
+        "message": "للمطورين، يمكنك إضافة أي defines تحتاجها، مفصولة بـ `مسافة`، ولكن بدون البادئة `USE_`، سيتم إضافتها تلقائيًا لك."
+    },
+    "firmwareFlasherBuildCustomDefines": {
+        "message": "Defines مخصصة"
+    },
+    "firmwareFlasherOSDProtocolNotSelected": {
+        "message": "بروتوكول OSD غير محدد"
+    },
+    "firmwareFlasherOSDProtocolNotSelectedDescription": {
+        "message": "يجب عليك تحديد بروتوكول OSD لبناء برنامج ثابت."
+    },
+    "firmwareFlasherOSDProtocolSelect": {
+        "message": "حدد بروتوكول OSD"
+    },
+    "firmwareFlasherOSDProtocolNotSelectedContinue": {
+        "message": "المتابعة بدون بروتوكول OSD"
+    },
+    "firmwareFlasherOptionLabelVerifiedPartner": {
+        "message": "شريك تم التحقق منه ✅"
+    },
+    "firmwareFlasherOptionLabelVendorCommunity": {
+        "message": "⚠️ المورّد \/ المجتمع"
+    },
+    "firmwareFlasherOptionLabelLegacy": {
+        "message": "قديم"
+    },
+    "firmwareFlasherOptionLabelNotQualified": {
+        "message": "⚠️ Target مدعوم من المجتمع \/ الشركة المصنّعة — غير مدعوم رسميًا ⚠️"
+    },
+    "coreBuild": {
+        "message": "المعالج فقط"
+    },
+    "coreBuildModeDescription": {
+        "message": "يبني هذا الخيار برنامجًا ثابتًا يحتوي على برامج تشغيل الأجهزة (وبعض المميزات المحدودة). وهو متاح للمساعدة في اكتشاف الأجهزة على وحدة تحكم الطيران، ويتم توفيره لتلك الراحة فقط. لن تكون جميع المميزات متاحة (الأجهزة فقط) باستخدام هذا الخيار."
+    },
+    "showDevToolsOnStartup": {
+        "message": "فتح أدوات المطور تلقائيًا في وضع التطوير",
+        "description": "Text for the option to enable automatic opening of DevTools in debug mode"
+    },
+    "betaflightSupportButton": {
+        "message": "ويكي",
+        "description": "Text for the button to open the support URL"
+    },
+    "showNotifications": {
+        "message": "إظهار الإشعارات للعمليات الطويلة"
+    },
+    "notificationsDeniedTitle": {
+        "message": "الإشعارات محظورة",
+        "description": "Title when Notifications has no or denied permissions"
+    },
+    "notificationsDenied": {
+        "message": "الإشعارات محظورة. يرجى تمكينها في إعدادات المتصفح الخاص بك. وإلا، فلن تتلقى إشعارات حول العمليات الطويلة. إذا كنت تستخدم Chrome، فيمكنك تمكين الإشعارات بالنقر على أيقونة القفل في شريط العناوين وتحديد 'إعدادات الموقع'.",
+        "description": "Message when Notifications has no or denied permissions"
+    },
+    "flashEraseDoneNotification": {
+        "message": "تم الانتهاء من مسح dataflash",
+        "description": "Notification message when flash erase is done"
+    },
+    "flashDownloadDoneNotification": {
+        "message": "تم تنزيل سجلات dataflash",
+        "description": "Notification message when flash logs are done downloading"
+    },
+    "programmingSuccessfulNotification": {
+        "message": "تم برمجة وحدة تحكم الطيران (FC) بنجاح",
+        "description": "Notification message when programming is successful"
+    },
+    "programmingFailedNotification": {
+        "message": "فشلت برمجة وحدة تحكم الطيران (FC)",
+        "description": "Notification message when programming is unsuccessful"
+    },
+    "osdTextElementLidar": {
+        "message": "السونار",
+        "description": "Displays distance from sonar sensor in cm"
+    },
+    "osdTextElementCustomSerialText": {
+        "message": "نص Serial مخصص",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCustomSerialText": {
+        "message": "يعرض نصًا مخصصًا مستلمًا من منفذ Serial"
+    },
+    "osdTextElementBatteryProfileName": {
+        "message": "الملف: اسم ملف تعريف البطارية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementBatteryProfileName": {
+        "message": "يعرض اسم أو رقم ملف تعريف البطارية النشط"
+    },
+    "osdTextElementWpNumber": {
+        "message": "رقم نقطة المسار",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNumber": {
+        "message": "يعرض رقم نقطة المسار الحالية\/الإجمالي لخطة الطيران النشطة"
+    },
+    "osdTextElementWpCurrentLat": {
+        "message": "خط عرض نقطة المسار",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLat": {
+        "message": "يعرض خط عرض نقطة المسار الحالية"
+    },
+    "osdTextElementWpCurrentLon": {
+        "message": "خط طول نقطة المسار",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLon": {
+        "message": "يعرض خط طول نقطة المسار الحالية"
+    },
+    "osdTextElementWpCurrentAlt": {
+        "message": "ارتفاع نقطة المسار",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentAlt": {
+        "message": "يعرض ارتفاع نقطة المسار الحالية"
+    },
+    "osdTextElementWpDistance": {
+        "message": "المسافة إلى نقطة المسار",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDistance": {
+        "message": "يعرض المسافة إلى نقطة المسار الحالية"
+    },
+    "osdTextElementWpDirection": {
+        "message": "اتجاه نقطة المسار",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDirection": {
+        "message": "يعرض سهم اتجاه يشير إلى نقطة المسار الحالية"
+    },
+    "osdTextElementWpNextNumber": {
+        "message": "رقم نقطة المسار التالية",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNextNumber": {
+        "message": "يعرض رقم نقطة المسار التالية في خطة الطيران النشطة"
+    },
+    "osdTextElementWpEta": {
+        "message": "الوقت المتوقع للوصول إلى نقطة المسار",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpEta": {
+        "message": "يعرض الوقت المتوقع للوصول إلى نقطة المسار الحالية"
+    },
+    "osdTextElementNavMap": {
+        "message": "خريطة الملاحة",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNavMap": {
+        "message": "خريطة مصغرة تعرض نقطة Home وخطة الطيران والمسار الذي تم قطعه"
+    },
+    "osdTextElementPosHoldReady": {
+        "message": "تثبيت الموقع جاهز",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPosHoldReady": {
+        "message": "يعرض ما إذا كانت شروط الدخول إلى Position Hold مستوفاة قبل تفعيل مفتاح الوضع"
+    },
+    "osdSetupPreviewCheckRulers": {
+        "message": "المسطرة",
+        "description": "Label for the checkbox to toggle OSD preview rulers around the preview"
+    },
+    "tabUserProfile": {
+        "message": "مِلَفّ المستخدم"
+    },
+    "labelEmail": {
+        "message": "البريد الإلكتروني"
+    },
+    "placeholderEmailAddress": {
+        "message": "أدخل عنوان البريد الإلكتروني"
+    },
+    "userEmailRequired": {
+        "message": "البريد الإلكتروني مطلوب"
+    },
+    "profileLoginMessage": {
+        "message": "الرجاء تسجيل الدخول لعرض ملفك الشخصي."
+    },
+    "tabBackups": {
+        "message": "النُّسَخ الاحتياطية"
+    },
+    "userPasskeyDeleteSuccess": {
+        "message": "تم حذف مفتاح المرور Passkey بنجاح"
+    },
+    "userPasskeyDeleteFailed": {
+        "message": "فشل حذف مفتاح المرور Passkey"
+    },
+    "userTokenDeleteSuccess": {
+        "message": "تم حذف الرمز بنجاح"
+    },
+    "userTokenDeleteFailed": {
+        "message": "فشل حذف الرمز"
+    },
+    "userProfileLoadFailed": {
+        "message": "فشل تحميل المِلَفّ الشخصي للمستخدم"
+    },
+    "userTokenLoadFailed": {
+        "message": "فشل تحميل رموز المستخدم"
+    },
+    "userPasskeyLoadFailed": {
+        "message": "فشل تحميل مفتاح الدخول Passkey"
+    },
+    "userProfileUpdateSuccess": {
+        "message": "تم تحديث المِلَفّ الشخصي بنجاح"
+    },
+    "userProfileUpdateFailed": {
+        "message": "فشل تحديث المِلَفّ الشخصي"
+    },
+    "userBackupsLoadFailed": {
+        "message": "فشل تحميل النسخ الاحتياطية"
+    },
+    "userBackupDownloadFailed": {
+        "message": "فشل تنزيل النسخة الاحتياطية"
+    },
+    "userBackupFileEmpty": {
+        "message": "ملف النسخة الاحتياطية فارغ"
+    },
+    "userBackupUpdateSuccess": {
+        "message": "تم تحديث النسخة الاحتياطية بنجاح"
+    },
+    "userBackupUpdateFailed": {
+        "message": "فشل تحديث النسخة الاحتياطية"
+    },
+    "userBackupDeleteSuccess": {
+        "message": "تم حذف النسخة الاحتياطية بنجاح"
+    },
+    "userBackupDeleteFailed": {
+        "message": "فشل حذف النسخة الاحتياطية"
+    },
+    "actionRestore": {
+        "message": "استعادة"
+    },
+    "titleRestoreBackup": {
+        "message": "استعادة النسخة الاحتياطية"
+    },
+    "userBackupRestoreConfirm": {
+        "message": "هل تريد تطبيق النسخة الاحتياطية \"{{name}}\" على متحكم الطيران المتصل؟ سيتم استبدال الإعدادات الحالية."
+    },
+    "userBackupRestoreInProgress": {
+        "message": "جارٍ استعادة النسخة الاحتياطية..."
+    },
+    "userBackupRestoreSuccess": {
+        "message": "تمت استعادة النسخة الاحتياطية بنجاح"
+    },
+    "userBackupRestoreFailed": {
+        "message": "فشل استعادة النسخة الاحتياطية"
+    },
+    "userBackupRestoreErrors": {
+        "message": "<span class='message-negative'>تحذير!<\/span><br\/>تم تطبيق النسخة الاحتياطية مع وجود أخطاء CLI."
+    },
+    "userPasskeyNoPasskeys": {
+        "message": "لا توجد مفاتيح مرور Passkey متاحة"
+    },
+    "userTokenNoTokens": {
+        "message": "لا توجد رموز متاحة"
+    },
+    "profileBackupSuccess": {
+        "message": "تم النسخ الاحتياطي بنجاح"
+    },
+    "profileBackupApiSuccess": {
+        "message": "تم حفظ النسخة الاحتياطية في API بنجاح"
+    },
+    "profileBackupApiFail": {
+        "message": "فشل حفظ النسخة الاحتياطية في API"
+    },
+    "profileBackupEmptyResult": {
+        "message": "فشل النسخ الاحتياطي"
+    },
+    "labelLogin": {
+        "message": "تسجيل الدخول"
+    },
+    "labelSignOut": {
+        "message": "تسجيل الخروج"
+    },
+    "labelAvatarUrl": {
+        "message": "رابط صورة العرض"
+    },
+    "placeholderAvatarUrl": {
+        "message": "أدخل رابط URL لصورة العرض الخاصة بك"
+    },
+    "labelCreatePasskey": {
+        "message": "إنشاء مفتاح مرور Passkey"
+    },
+    "labelUsePasskey": {
+        "message": "استخدم مفتاح المرور Passkey"
+    },
+    "labelSignInWithPasskey": {
+        "message": "تسجيل الدخول باستخدام مفتاح المرور Passkey"
+    },
+    "labelSendVerificationCode": {
+        "message": "إرسال رمز التحقق"
+    },
+    "labelSignInWithEmailCode": {
+        "message": "تسجيل الدخول برمز يرسل إلى بريدك الإلكتروني"
+    },
+    "labelBackToPasskey": {
+        "message": "العودة لتسجيل الدخول بمفتاح المرور Passkey"
+    },
+    "labelBack": {
+        "message": "رجوع"
+    },
+    "labelNoPasskeyPrompt": {
+        "message": "ليس لديك مفتاح مرور Passkey؟"
+    },
+    "labelSetOnePasskeyUp": {
+        "message": "إنشاء مفتاح مرور Passkey"
+    },
+    "descriptionPasskeyLogin": {
+        "message": "استخدم مفتاح المرور Passkey الخاص بك لتسجيل الدخول"
+    },
+    "descriptionCodeRequest": {
+        "message": "سوف نرسل لك رمز التحقق عبر البريد الإلكتروني"
+    },
+    "descriptionCodeEntered": {
+        "message": "ادخل رمز التحقق المرسل إلى $1"
+    },
+    "titleEnterVerificationCode": {
+        "message": "أدخل رمز التحقق"
+    },
+    "labelVerificationCode": {
+        "message": "رمز التحقق"
+    },
+    "labelCode": {
+        "message": "رمز"
+    },
+    "userLoggingIn": {
+        "message": "جاري تسجيل الدخول..."
+    },
+    "userSignedOut": {
+        "message": "تم تسجيل الخروج"
+    },
+    "userSignOutFailed": {
+        "message": "فشل تسجيل الخروج"
+    },
+    "userLoginSuccess": {
+        "message": "تم تسجيل الدخول بنجاح"
+    },
+    "userLoginFailed": {
+        "message": "فشل تسجيل الدخول"
+    },
+    "userCreatePasskeyFailed": {
+        "message": "فشل إنشاء مفتاح المرور"
+    },
+    "userCreatePasskeySuccess": {
+        "message": "تم إنشاء مفتاح المرور بنجاح"
+    },
+    "userVerifyingCode": {
+        "message": "جارٍ التحقق من الرمز..."
+    },
+    "userCreatingPasskey": {
+        "message": "جارٍ إنشاء مفتاح المرور..."
+    },
+    "userCodeRequired": {
+        "message": "رمز التحقق مطلوب"
+    },
+    "userSendingCode": {
+        "message": "جارٍ إرسال رمز التحقق..."
+    },
+    "userSendCodeFailed": {
+        "message": "فشل إرسال رمز التحقق"
+    },
+    "dataWaitingForData": {
+        "message": "في انتظار البيانات..."
+    },
+    "labelId": {
+        "message": "المعرف"
+    },
+    "labelCreated": {
+        "message": "تم إنشاؤه"
+    },
+    "labelLastUsed": {
+        "message": "اخر استخدام"
+    },
+    "labelActions": {
+        "message": "الإجراءات"
+    },
+    "labelDetails": {
+        "message": "التفاصيل"
+    },
+    "labelExpiry": {
+        "message": "تاريخ انتهاء الصَّلاحِيَة"
+    },
+    "labelDescription": {
+        "message": "الوصف"
+    },
+    "labelDate": {
+        "message": "التاريخ"
+    },
+    "actionDownload": {
+        "message": "تنزيل"
+    },
+    "actionBackup": {
+        "message": "نسخ احتياطي"
+    },
+    "actionEdit": {
+        "message": "تحرير"
+    },
+    "actionDelete": {
+        "message": "حذف"
+    },
+    "actionSave": {
+        "message": "حفظ"
+    },
+    "titleEditProfile": {
+        "message": "تعديل المِلَفّ الشخصي"
+    },
+    "titleLogin": {
+        "message": "تسجيل الدخول"
+    },
+    "labelName": {
+        "message": "الإسم"
+    },
+    "labelAddress": {
+        "message": "العنوان"
+    },
+    "labelCountry": {
+        "message": "الدولة"
+    },
+    "confirmDelete": {
+        "message": "هل أنت متأكد؟ سيتم حذف: {{item}}؟"
+    },
+    "itemBackup": {
+        "message": "نسخ احتياطي"
+    },
+    "itemToken": {
+        "message": "الرمز"
+    },
+    "itemPasskey": {
+        "message": "مفتاح مرور Passkey"
+    },
+    "notLoggedIn": {
+        "message": "لم تقم بتسجيل الدخول"
+    },
+    "backupNoBackupsAvailable": {
+        "message": "لا يتوفر أي نسخ احتياطي"
+    },
+    "backupRequiresConnection": {
+        "message": "اتصل بمتحكم الطيران لتفعيل هذا الإجراء",
+        "description": "Tooltip shown on disabled backup and restore buttons when no flight controller is connected"
+    },
+    "titleEditBackup": {
+        "message": "تعديل النسخة الاحتياطية"
+    },
+    "backupMcuUnknown": {
+        "message": "MCU غير معروف"
+    },
+    "sectionUserTokens": {
+        "message": "رموز المستخدم"
+    },
+    "sectionUserPasskeys": {
+        "message": "مفتاح مرور Passkey الخاص بالمستخدم"
+    },
+    "osdPresetPositionAlignTitle": {
+        "message": "محاذاة إلى الموضع",
+        "description": "Label for the preset position alignment menu in the OSD elements list"
+    },
+    "osdPresetPositionChooseTitle": {
+        "message": "اختر الموضع",
+        "description": "Title for the preset position grid popup in the OSD elements list"
+    },
+    "tabPreflight": {
+        "message": "ماقبل الطيران"
+    },
+    "preflightTitle": {
+        "message": "فحص ماقبل الطيران للبيئة المحيطة"
+    },
+    "preflightLocation": {
+        "message": "موقع الرحلة"
+    },
+    "preflightUseMyLocation": {
+        "message": "إستخدام الموقع الخاص بي"
+    },
+    "preflightDetecting": {
+        "message": "جارٍ البحث..."
+    },
+    "preflightOr": {
+        "message": "أو أدخل الإحداثيات:"
+    },
+    "preflightLatitude": {
+        "message": "خط العرض"
+    },
+    "preflightLongitude": {
+        "message": "خط الطول"
+    },
+    "preflightApply": {
+        "message": "تطبيق"
+    },
+    "preflightLaunchStatus": {
+        "message": "حالة التشغيل"
+    },
+    "preflightStatusGo": {
+        "message": "انطلق"
+    },
+    "preflightStatusCaution": {
+        "message": "تنبيه"
+    },
+    "preflightStatusWarning": {
+        "message": "تحذير"
+    },
+    "preflightStatusNoGo": {
+        "message": "غير مناسب للطيران"
+    },
+    "preflightStatusNoData": {
+        "message": "لا يوجد بيانات"
+    },
+    "preflightCheckWind": {
+        "message": "الرياح"
+    },
+    "preflightCheckVisibility": {
+        "message": "الرؤية"
+    },
+    "preflightCheckPrecipitation": {
+        "message": "هطول الأمطار"
+    },
+    "preflightCheckSolar": {
+        "message": "شمسي"
+    },
+    "preflightLevelUnknown": {
+        "message": "غير معروف"
+    },
+    "preflightWmoClearSky": {
+        "message": "السماء صافية"
+    },
+    "preflightWmoMainlyClear": {
+        "message": "صافي غالباً"
+    },
+    "preflightWmoPartlyCloudy": {
+        "message": "غائم جزئيًا"
+    },
+    "preflightWmoOvercast": {
+        "message": "غائم كليًا"
+    },
+    "preflightWmoFog": {
+        "message": "ضباب"
+    },
+    "preflightWmoRimeFog": {
+        "message": "ضباب الصقيع المترسّب"
+    },
+    "preflightWmoLightDrizzle": {
+        "message": "رذاذ خفيف"
+    },
+    "preflightWmoModerateDrizzle": {
+        "message": "رذاذ متوسط"
+    },
+    "preflightWmoDenseDrizzle": {
+        "message": "رذاذ كثيف"
+    },
+    "preflightWmoLightFreezingDrizzle": {
+        "message": "رذاذ متجمد خفيف"
+    },
+    "preflightWmoDenseFreezingDrizzle": {
+        "message": "رذاذ متجمد كثيف"
+    },
+    "preflightWmoSlightRain": {
+        "message": "أمطار خفيفة"
+    },
+    "preflightWmoModerateRain": {
+        "message": "أمطار متوسطة"
+    },
+    "preflightWmoHeavyRain": {
+        "message": "أمطار غزيرة"
+    },
+    "preflightWmoLightFreezingRain": {
+        "message": "أمطار متجمدة خفيفة"
+    },
+    "preflightWmoHeavyFreezingRain": {
+        "message": "أمطار متجمدة غزيرة"
+    },
+    "preflightWmoSlightSnow": {
+        "message": "ثلوج خفيفة"
+    },
+    "preflightWmoModerateSnow": {
+        "message": "ثلوج متوسطة"
+    },
+    "preflightWmoHeavySnow": {
+        "message": "ثلوج كثيفة"
+    },
+    "preflightWmoSnowGrains": {
+        "message": "حبيبات ثلج"
+    },
+    "preflightWmoSlightRainShowers": {
+        "message": "زخات مطر خفيفة"
+    },
+    "preflightWmoModerateRainShowers": {
+        "message": "زخات مطر متوسطة"
+    },
+    "preflightWmoViolentRainShowers": {
+        "message": "زخات مطر شديدة"
+    },
+    "preflightWmoSlightSnowShowers": {
+        "message": "زخات ثلج خفيفة"
+    },
+    "preflightWmoHeavySnowShowers": {
+        "message": "زخات ثلج كثيفة"
+    },
+    "preflightWmoThunderstorm": {
+        "message": "عاصفة رعدية"
+    },
+    "preflightWmoThunderstormSlightHail": {
+        "message": "عاصفة رعدية مع بَرَد خفيف"
+    },
+    "preflightWmoThunderstormHeavyHail": {
+        "message": "عاصفة رعدية مع بَرَد كثيف"
+    },
+    "preflightKpLow": {
+        "message": "منخفض"
+    },
+    "preflightKpModerate": {
+        "message": "متوسط"
+    },
+    "preflightKpElevated": {
+        "message": "مرتفع"
+    },
+    "preflightKpStorm": {
+        "message": "عاصف"
+    },
+    "preflightWindCalm": {
+        "message": "هادئ"
+    },
+    "preflightWindLight": {
+        "message": "خفيف"
+    },
+    "preflightWindModerate": {
+        "message": "متوسط"
+    },
+    "preflightWindStrong": {
+        "message": "قوي"
+    },
+    "preflightWindDangerous": {
+        "message": "خطر"
+    },
+    "preflightVisExcellent": {
+        "message": "ممتاز"
+    },
+    "preflightVisGood": {
+        "message": "جيد"
+    },
+    "preflightVisReduced": {
+        "message": "منخفض"
+    },
+    "preflightVisPoor": {
+        "message": "ضعيف"
+    },
+    "preflightPrecipNone": {
+        "message": "لا شيء"
+    },
+    "preflightPrecipLight": {
+        "message": "خفيف"
+    },
+    "preflightPrecipModerate": {
+        "message": "متوسط"
+    },
+    "preflightPrecipHeavy": {
+        "message": "شديد"
+    },
+    "preflightDewNoRisk": {
+        "message": "لا يوجد مخاطر"
+    },
+    "preflightDewLowRisk": {
+        "message": "خطورة منخفضة"
+    },
+    "preflightDewFogLikely": {
+        "message": "احتمال ضباب\/تكاثف"
+    },
+    "preflightDewFogExpected": {
+        "message": "يُتوقّع تكوّن الضباب على العدسة"
+    },
+    "preflightUvLow": {
+        "message": "منخفض"
+    },
+    "preflightUvModerate": {
+        "message": "معتدل"
+    },
+    "preflightUvHigh": {
+        "message": "مرتفع"
+    },
+    "preflightUvVeryHigh": {
+        "message": "مرتفع جداً"
+    },
+    "preflightBatteryRisk": {
+        "message": "خطر على البطارية"
+    },
+    "preflightBatteryOk": {
+        "message": "المدى الطبيعي"
+    },
+    "preflightBatteryCool": {
+        "message": "أداء منخفض، يُنصح بتدفئة البطاريات"
+    },
+    "preflightBatteryCold": {
+        "message": "انخفاض حادّ في السَّعَة"
+    },
+    "preflightBatteryHot": {
+        "message": "خطر الانتفاخ، احفظها في الظل"
+    },
+    "preflightBatteryExtreme": {
+        "message": "لاتقم بالطيران، حرارة شديدة"
+    },
+    "preflightCheckBattery": {
+        "message": "البطارية"
+    },
+    "preflightCheckDensityAlt": {
+        "message": "ارتفاع الكثافة"
+    },
+    "preflightFeelsLike": {
+        "message": "درجة الحرارة المحسوسة"
+    },
+    "preflightFogRisk": {
+        "message": "توقّع تكوّن الضباب"
+    },
+    "preflightFogUnlikely": {
+        "message": "غير مرجح"
+    },
+    "preflightFogLow": {
+        "message": "خطورة منخفضة"
+    },
+    "preflightFogModerate": {
+        "message": "خطورة متوسطة"
+    },
+    "preflightFogHigh": {
+        "message": "خطورة عالية"
+    },
+    "preflightElevation": {
+        "message": "الارتفاع"
+    },
+    "preflightDensityAlt": {
+        "message": "ارتفاع الكثافة"
+    },
+    "preflightDaNormal": {
+        "message": "أداء طبيعي"
+    },
+    "preflightDaReduced": {
+        "message": "قوة رفع منخفضة قليلا"
+    },
+    "preflightDaLow": {
+        "message": "انخفاض ملحوظ في الأداء"
+    },
+    "preflightDaPoor": {
+        "message": "انخفاض كبير في قوة الرفع"
+    },
+    "preflightCivilTwilight": {
+        "message": "فترة الشفق المدني"
+    },
+    "preflightRefresh": {
+        "message": "تحديث"
+    },
+    "preflightCurrentWeather": {
+        "message": "الطقس الحالي"
+    },
+    "preflightWind": {
+        "message": "سرعة الرياح"
+    },
+    "preflightGusts": {
+        "message": "هبات الرياح"
+    },
+    "preflightVisibility": {
+        "message": "الرؤية"
+    },
+    "preflightPrecipitation": {
+        "message": "هطول أمطار"
+    },
+    "preflightCloudCover": {
+        "message": "الغطاء السحابي"
+    },
+    "preflightHumidity": {
+        "message": "الرطوبة"
+    },
+    "preflightPressure": {
+        "message": "الضغط الجوي"
+    },
+    "preflightDewPoint": {
+        "message": "نقطة الندى"
+    },
+    "preflightFlightWindow": {
+        "message": "نافذة الطيران"
+    },
+    "preflightSunrise": {
+        "message": "شروق الشمس"
+    },
+    "preflightSunset": {
+        "message": "غروب الشمس"
+    },
+    "preflightDaylight": {
+        "message": "ضوء النهار"
+    },
+    "preflightUvIndex": {
+        "message": "مؤشر الأشعة فوق البنفسجية"
+    },
+    "preflightTempRange": {
+        "message": "نطاق درجة الحرارة"
+    },
+    "preflightCurrentlyDay": {
+        "message": "حالياً"
+    },
+    "preflightDaytime": {
+        "message": "ساعات النهار"
+    },
+    "preflightNighttime": {
+        "message": "ساعات الليل"
+    },
+    "preflightWindForecast": {
+        "message": "توقّعات الرياح حسب الارتفاع"
+    },
+    "preflightWindForecastHelp": {
+        "message": "تُعدّ سرعات الرياح على الارتفاعات المختلفة بالغة الأهمية لرحلات FPV طويلة المدى وعالية الارتفاع. تزداد قوة الرياح عادةً كلّما ارتفعت."
+    },
+    "preflightTime": {
+        "message": "الوقت"
+    },
+    "preflightWind10m": {
+        "message": "10 م"
+    },
+    "preflightWind80m": {
+        "message": "80 م"
+    },
+    "preflightWind120m": {
+        "message": "120 متر"
+    },
+    "preflightGustsShort": {
+        "message": "الهبات"
+    },
+    "preflightRainProb": {
+        "message": "المطر %"
+    },
+    "preflightWindUnit": {
+        "message": "سرعات الرياح بالمتر في الثانية. الارتفاعات فوق مستوى سطح الأرض (AGL)."
+    },
+    "preflightSolarActivity": {
+        "message": "النشاط الشمسي"
+    },
+    "preflightSolarHelp": {
+        "message": "يُسبّب النشاط الشمسي العالي (Kp > 5) تشويشاً على الغلاف الأيوني، ممّا قد يُقلّل من دقّة GPS ويؤثّر على موثوقية الإنقاذ عبر GPS."
+    },
+    "preflightGeoStorm": {
+        "message": "عاصفة جيومغناطيسية"
+    },
+    "preflightSolarRadiation": {
+        "message": "الإشعاع الشمسي"
+    },
+    "preflightRadioBlackout": {
+        "message": "انقطاع الاتصال الراديوي"
+    },
+    "preflightLastMeasurement": {
+        "message": "اخر قياس"
+    },
+    "preflightLoadingSolar": {
+        "message": "جارٍ تحميل بيانات الشمس..."
+    },
+    "preflightGNSS": {
+        "message": "حالة GNSS \/ GPS"
+    },
+    "preflightGNSSHelp": {
+        "message": "تتأثّر جودة إشارة أقمار GNSS بالنشاط الشمسي. قد تُقلّل قيم Kp المرتفعة من دقّة تحديد الموقع عبر GPS وتُضعف موثوقية الإنقاذ عبر GPS."
+    },
+    "preflightGNSSNote": {
+        "message": "تتأثّر دقّة GPS بالظروف الشمسية والجيومغناطيسية. وصّل طائرتك للاطّلاع على بيانات الأقمار الصناعية المباشرة في تبويب GPS."
+    },
+    "preflightKpEffect": {
+        "message": "التأثير على الغلاف الأيوني"
+    },
+    "preflightGPSRescue": {
+        "message": "حالة الإنقاذ عبر GPS"
+    },
+    "preflightMagDeclination": {
+        "message": "انحراف مغناطيسي"
+    },
+    "preflightMagInclination": {
+        "message": "ميل مغناطيسي"
+    },
+    "preflightGNSSPlanner": {
+        "message": "أداة تخطيط أقمار GNSS"
+    },
+    "preflightAirspace": {
+        "message": "المجال الجوي والمناطق التي يحظر الطيران بها"
+    },
+    "preflightAirspaceNote": {
+        "message": "تحقّق دائماً من قيود المجال الجوي المحلية وإشعارات NOTAM قبل الطيران. تختلف القواعد بحسب الدولة والمنطقة."
+    },
+    "preflightDroneSafetyMap": {
+        "message": "خريطة سلامة الدرون (Altitude Angel)"
+    },
+    "preflightAirspaceExplorer": {
+        "message": "خريطة المجال الجوي SkyVector"
+    },
+    "preflightNOTAMs": {
+        "message": "إشعارات FAA NOTAM (الولايات المتحدة)"
+    },
+    "preflightNOTAMsEU": {
+        "message": "إشعارات EUROCONTROL NOTAM (الاتحاد الأوروبي)"
+    },
+    "preflightMap": {
+        "message": "خريطة الموقع"
+    },
+    "preflightNoData": {
+        "message": "حدّد موقعاً لتحميل بيانات البيئة"
+    },
+    "preflightAttribution": {
+        "message": "بيانات الطقس: Open-Meteo.com (CC BY 4.0) | البيانات الشمسية: NOAA Space Weather Prediction Center"
+    },
+    "preflightSavedLocationsPlaceholder": {
+        "message": "المواقع المحفوظة..."
+    },
+    "preflightLoadLocation": {
+        "message": "تحميل"
+    },
+    "preflightSaveLocation": {
+        "message": "حفظ"
+    },
+    "preflightSavedLocationsFull": {
+        "message": "تم الوصول إلى الحد الأقصى وهو 5 مواقع محفوظة"
+    },
+    "preflightLocationLabel": {
+        "message": "اسم الموقع (20 حرف كحد أقصى)"
+    },
+    "preflightDeleteLocation": {
+        "message": "حذف الموقع المحدد"
+    },
+    "preflightRenameLocation": {
+        "message": "إعادة تسمية الموقع المحدد"
+    },
+    "preflightRenameLocationBtn": {
+        "message": "إعادة التسمية"
+    },
+    "preflightCoordinates": {
+        "message": "الإحداثيات"
+    },
+    "preflightSaveLocationBtn": {
+        "message": "حفظ الموقع"
+    },
+    "preflightConfirmSave": {
+        "message": "حفظ"
+    },
+    "preflightCancel": {
+        "message": "إلغاء"
+    },
+    "preflightGeolocationFailed": {
+        "message": "تعذر اكتشاف الموقع. الرجاء إدخال الإحداثيات يدوياً."
+    },
+    "preflightIpConsentMessage": {
+        "message": "فشل تحديد الموقع عبر المتصفح. يمكن تحديد موقعك التقريبي باستخدام عنوان IP الخاص بك عبر ipapi.co، وهي خدمة طرف ثالث."
+    },
+    "preflightIpConsentAllow": {
+        "message": "سماح"
+    },
+    "preflightIpConsentDeny": {
+        "message": "لا، شكراً"
+    },
+    "preflightMapSatellite": {
+        "message": "عرض القمر الصناعي"
+    },
+    "preflightMapHybrid": {
+        "message": "عرض هجين للقمر الصناعي والشارع"
+    },
+    "preflightMapStreet": {
+        "message": "عرض خريطة الشوارع"
+    },
+    "preflightMapZoomIn": {
+        "message": "تكبير"
+    },
+    "preflightMapZoomOut": {
+        "message": "تصغير"
+    },
+    "preflightMapFullscreen": {
+        "message": "ملء الشاشة"
+    },
+    "preflightKpMinimal": {
+        "message": "تأثير ضئيل على GPS"
+    },
+    "preflightKpDegraded": {
+        "message": "احتمال تدهور دقّة GPS"
+    },
+    "preflightKpSevere": {
+        "message": "يُتوقّع تعارض ملحوظ على إشارة GPS"
+    },
+    "preflightGpsRescueUnknown": {
+        "message": "تحقّق من النشاط الشمسي أولاً"
+    },
+    "preflightGpsRescueReliable": {
+        "message": "الإنقاذ عبر GPS خِيار موثوق"
+    },
+    "preflightGpsRescueUnreliable": {
+        "message": "قد يكون الإنقاذ عبر GPS خِيار غير موثوق"
+    },
+    "preflightGpsRescueNotRecommended": {
+        "message": "لا يُنصح باستخدام الإنقاذ عبر GPS"
+    },
+    "preflightForecast": {
+        "message": "توقعات الطقس لـ 5 أيام"
+    },
+    "preflightForecastHelp": {
+        "message": "نظرة يومية على الطقس للمساعدة في التخطيط لجلسات الطيران القادمة"
+    },
+    "preflightForecastDay": {
+        "message": "اليوم"
+    },
+    "preflightForecastWeather": {
+        "message": "الطقس"
+    },
+    "preflightNotamProvider": {
+        "message": "مزود NOTAM"
+    },
+    "preflightNotamProviderNone": {
+        "message": "معطّل"
+    },
+    "preflightNotamProviderFaa": {
+        "message": "FAA NOTAM API (الولايات المتحدة، يتطلب مفتاح API)"
+    },
+    "preflightNotamProviderOpenaip": {
+        "message": "OpenAIP (المجال الجوي العالمي، يتطلب مفتاح API)"
+    },
+    "preflightNotamFaaApiKeyLabel": {
+        "message": "مفتاح FAA API (client_id:client_secret)"
+    },
+    "preflightNotamOpenAipApiKeyLabel": {
+        "message": "مفتاح OpenAIP API"
+    },
+    "preflightNotamRadius": {
+        "message": "نطاق البحث"
+    },
+    "preflightNotamRadiusUnitNm": {
+        "message": "ميل بحري"
+    },
+    "preflightNotamRadiusUnitKm": {
+        "message": "كم"
+    },
+    "preflightNotamSettings": {
+        "message": "إعدادات بيانات المجال الجوي"
+    },
+    "preflightNotamPrivacyNote": {
+        "message": "ترسل بيانات المجال الجوي إحداثياتك إلى المزود المحدد. لا يتم إرسال أي بيانات شخصية إضافية."
+    },
+    "preflightNotamLoading": {
+        "message": "جارٍ جلب بيانات المجال الجوي..."
+    },
+    "preflightNotamEmpty": {
+        "message": "لم يتم العثور على إشعارات لهذا الموقع ونطاق البحث"
+    },
+    "preflightNotamApiKeyRequired": {
+        "message": "يتطلب المزود المحدد مفتاح API. أدخل مفتاحك في الإعدادات أعلاه."
+    },
+    "preflightNotamFetchError": {
+        "message": "فشل جلب بيانات المجال الجوي"
+    },
+    "preflightNotamActiveNow": {
+        "message": "نشط الآن"
+    },
+    "preflightNotamPermanent": {
+        "message": "دائم"
+    },
+    "preflightNotamExpired": {
+        "message": "منتهي الصلاحية"
+    },
+    "preflightNotamTypeTfr": {
+        "message": ""
+    },
+    "preflightNotamTypeSua": {
+        "message": ""
+    },
+    "preflightNotamTypeSnow": {
+        "message": "SNOWTAM"
+    },
+    "preflightNotamTypeAsh": {
+        "message": "ASHTAM"
+    },
+    "preflightNotamTypeNotam": {
+        "message": "NOTAM"
+    },
+    "preflightNotamAltFrom": {
+        "message": "السفلي"
+    },
+    "preflightNotamAltTo": {
+        "message": "العلوي"
+    },
+    "preflightNotamShowMore": {
+        "message": "عرض المزيد"
+    },
+    "preflightNotamShowLess": {
+        "message": "عرض أقل"
+    },
+    "preflightNotamLastFetched": {
+        "message": "آخر تحديث تم الحصول عليه "
+    }
+}

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -279,6 +279,10 @@
         "message": "$t(language_default.message)",
         "description": "Don't translate!!!"
     },
+    "language_ar": {
+        "message": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629",
+        "description": "Don't translate!!!"
+    },
     "language_ca": {
         "message": "Catal\u00e0",
         "description": "Don't translate!!!"

--- a/src/App.vue
+++ b/src/App.vue
@@ -246,8 +246,8 @@ watch(
     display: none;
     position: fixed;
     top: 0;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     z-index: 2001;
     /* Explicit, not inherited from the Tailwind reset: the height below is an outer height, and
        #content's matching padding-top depends on it staying one. */

--- a/src/blackbox-viewer/components/KeysDialog.vue
+++ b/src/blackbox-viewer/components/KeysDialog.vue
@@ -181,7 +181,7 @@ const layout = [
 .keys-kbd {
     display: inline-block;
     padding: 0.05rem 0.35rem;
-    margin-right: 0.15rem;
+    margin-inline-end: 0.15rem;
     font-family: ui-monospace, SFMono-Regular, monospace;
     font-size: 0.65rem;
     line-height: 1.5;

--- a/src/blackbox-viewer/css/main.css
+++ b/src/blackbox-viewer/css/main.css
@@ -38,8 +38,8 @@
 @media (max-width: 675px) {
     .app-main-pane,
     .blackbox-viewer-root.has-log div.log-seek-bar {
-        padding-left: 0;
-        padding-right: 0;
+        padding-inline-start: 0;
+        padding-inline-end: 0;
     }
 
     .app-main-pane .graph-row {
@@ -68,7 +68,7 @@
     }
 
     .video-top-controls .toolbar-panel {
-        margin-right: 2px;
+        margin-inline-end: 2px;
     }
 
     div.graph-row {
@@ -79,7 +79,7 @@
 /* With video */
 @media (max-width: 920px) {
     .blackbox-viewer-root.has-video .video-top-controls .toolbar-panel {
-        margin-right: 1px;
+        margin-inline-end: 1px;
     }
 }
 
@@ -89,10 +89,10 @@
     position: fixed;
     top: 15px;
     bottom: 100px;
-    left: 0;
-    right: 0;
-    padding-left: 15px;
-    padding-right: 15px;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
+    padding-inline-start: 15px;
+    padding-inline-end: 15px;
     display: none;
 }
 
@@ -125,7 +125,7 @@
     background-color: var(--surface-100);
     color: var(--text-secondary);
     padding: 0.75rem;
-    margin-left: 6px;
+    margin-inline-start: 6px;
     border-radius: 6px;
     border: 1px solid var(--border-color, #e5e5e5);
     min-width: 135px;
@@ -156,7 +156,7 @@
 #graphCanvas {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
     background-color: var(--graph-background);
@@ -168,7 +168,7 @@
 #stickCanvas {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     display: none;
 }
 
@@ -183,9 +183,9 @@
     position: absolute;
     display: block;
     top: 0;
-    right: 0;
+    inset-inline-end: 0;
     bottom: 0;
-    left: 0;
+    inset-inline-start: 0;
     z-index: 9999;
     content: "";
     background-color: var(--surface-200, hsl(0, 0%, 50%));
@@ -196,9 +196,9 @@
     position: absolute;
     display: block;
     top: calc(30%);
-    right: 0;
+    inset-inline-end: 0;
     bottom: 0;
-    left: 0;
+    inset-inline-start: 0;
     z-index: 10001;
     content: "No GPS Data";
     text-align: center;
@@ -234,7 +234,7 @@
     overflow: hidden;
     opacity: 0;
     top: 0;
-    left: 340px;
+    inset-inline-start: 340px;
     z-index: 9;
     position: absolute;
 }
@@ -267,8 +267,8 @@
     height: 0;
     overflow: hidden;
     opacity: 0;
-    left: 5px;
-    float: left;
+    inset-inline-start: 5px;
+    float: inline-start;
     z-index: 9;
     position: absolute;
     min-width: 150px;
@@ -284,22 +284,22 @@
     height: 0;
     overflow: hidden;
     opacity: 0;
-    left: 170px;
-    float: left;
+    inset-inline-start: 170px;
+    float: inline-start;
     z-index: 9;
     position: absolute;
     min-width: 160px;
 }
 
 .analyser .analyser-slider-x {
-    left: 975px;
+    inset-inline-start: 975px;
     top: 5px;
     position: absolute;
     z-index: 9;
 }
 
 .analyser .analyser-slider-y {
-    left: 1085px;
+    inset-inline-start: 1085px;
     top: 30px;
     position: absolute;
     z-index: 9;
@@ -342,7 +342,7 @@
 #seekbarToolbar {
     position: absolute;
     top: 8px;
-    left: 20px;
+    inset-inline-start: 20px;
 }
 
 .log-seek-bar:hover .non-shift #seekbarType {
@@ -363,7 +363,7 @@
 .log-graph video {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 100%;
     height: 100%;
     display: block;
@@ -376,8 +376,8 @@
 .graph-legend-field {
     margin-bottom: 0.5em;
     cursor: pointer;
-    padding-left: 0.7em;
-    padding-right: 0.7em;
+    padding-inline-start: 0.7em;
+    padding-inline-end: 0.7em;
 }
 
 .graph-legend-field-name:hover {
@@ -385,7 +385,7 @@
 }
 
 .graph-legend-field-value {
-    float: right;
+    float: inline-end;
 }
 
 .graph-legend-field-settings {
@@ -393,7 +393,7 @@
     color: var(--button-text);
     opacity: 0.8;
     font-weight: bold;
-    padding-left: 0.3em;
+    padding-inline-start: 0.3em;
 }
 
 .graph-legend-field.highlight > .graph-legend-field-settings {
@@ -407,8 +407,8 @@
 
 .graph-legend-field-visibility {
     cursor: pointer;
-    float: right;
-    margin-left: 0.7em;
+    float: inline-end;
+    margin-inline-start: 0.7em;
 }
 
 .blackbox-viewer-root.has-video .graph-row,
@@ -449,20 +449,20 @@
 
 .video-top-controls .toolbar-panel {
     display: inline-block;
-    margin-right: 12px;
-    padding-right: 12px;
+    margin-inline-end: 12px;
+    padding-inline-end: 12px;
     vertical-align: middle;
-    border-right: 1px solid var(--border-color, #e5e5e5);
+    border-inline-end: 1px solid var(--border-color, #e5e5e5);
 }
 
 .video-top-controls .toolbar-panel:last-child {
-    border-right: none;
-    margin-right: 0;
-    padding-right: 0;
+    border-inline-end: none;
+    margin-inline-end: 0;
+    padding-inline-end: 0;
 }
 
 .blackbox-viewer-root.dark .video-top-controls .toolbar-panel {
-    border-right-color: var(--surface-800, hsl(0, 0%, 25%));
+    border-inline-end-color: var(--surface-800, hsl(0, 0%, 25%));
 }
 
 .video-top-controls h4 {
@@ -501,8 +501,8 @@
     display: block;
     position: fixed;
     bottom: 32px;
-    padding-left: 15px;
-    padding-right: 15px;
+    padding-inline-start: 15px;
+    padding-inline-end: 15px;
 }
 
 .log-workspace-panel {

--- a/src/components/EscDshotDirection/Styles.css
+++ b/src/components/EscDshotDirection/Styles.css
@@ -35,7 +35,7 @@
 }
 
 .escDshotDirectionToggleNarrow {
-    margin-right: 12px;
+    margin-inline-end: 12px;
     display: flex;
     align-items: center;
 }
@@ -65,15 +65,15 @@
     display: block;
     width: 160px;
     height: 160px;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     margin-top: auto;
     margin-bottom: auto;
 }
 
 #escDshotDirectionDialog-MainContent h4 {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     font-weight: 500;
 }
 
@@ -94,8 +94,8 @@
 
 #escDshotDirectionDialog-SelectMotorButtonsWrapper,
 #escDshotDirectionDialog-WizardMotorButtons {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
 }
 
 #escDshotDirectionDialog-SelectMotorButtonsWrapper .regular-button,
@@ -103,8 +103,8 @@
     font-size: 15px;
     line-height: 34px;
     padding: 0px;
-    margin-left: 4px;
-    margin-right: 4px;
+    margin-inline-start: 4px;
+    margin-inline-end: 4px;
     border-radius: 17px;
     width: 34px;
     height: 34px;
@@ -126,13 +126,13 @@
 }
 
 #escDshotDirectionDialog-CommandsWrapper {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
 }
 
 #escDshotDirectionDialog-CommandSpin {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     width: 224px;
     display: block;
     text-align: center;
@@ -141,8 +141,8 @@
 #escDshotDirectionDialog-CommandsWrapper .regular-button {
     width: 130px;
     text-align: center;
-    margin-left: 5px;
-    margin-right: 5px;
+    margin-inline-start: 5px;
+    margin-inline-end: 5px;
 }
 
 .escDshotDirectionErrorTextBlock {
@@ -156,8 +156,8 @@
 
 #escDshotDirectionDialog-SpinWizard,
 #escDshotDirectionDialog-StopWizard {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     width: 160px;
     text-align: center;
 }
@@ -173,14 +173,14 @@
 .escDshotDirectionDialog-StartButton {
     width: 80px;
     text-align: center;
-    margin-left: 0px;
-    margin-right: 16px;
+    margin-inline-start: 0px;
+    margin-inline-end: 16px;
     margin-top: 0px;
     margin-bottom: 0px;
 }
 
 .escDshotDirectionDialog-Buttons {
-    float: left;
+    float: inline-start;
     margin: 0px;
 }
 

--- a/src/components/MotorOutputReordering/Styles.css
+++ b/src/components/MotorOutputReordering/Styles.css
@@ -30,7 +30,7 @@
 }
 
 #dialogMotorOutputReorderSave {
-    margin-right: 0px;
+    margin-inline-end: 0px;
 }
 
 .motorsRemapToggleParentContainer {
@@ -45,7 +45,7 @@
 }
 
 .motorsRemapToggleNarrow {
-    margin-right: 12px;
+    margin-inline-end: 12px;
     display: flex;
     align-items: center;
 }
@@ -67,8 +67,8 @@
 #motorOutputReorderSaveStartOverButtonsPanel {
     position: absolute;
     bottom: 4px;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     padding: 0 10px;
     box-sizing: border-box;
 }

--- a/src/components/data-flash/DataFlash.vue
+++ b/src/components/data-flash/DataFlash.vue
@@ -109,8 +109,8 @@ const usageClass = computed(() => {
     flex-direction: row;
     flex-wrap: nowrap;
     border-radius: 3px;
-    margin-left: 5px;
-    margin-right: 5px;
+    margin-inline-start: 5px;
+    margin-inline-end: 5px;
 }
 .dataflash-contents_global div {
     height: 5px;
@@ -136,9 +136,9 @@ const usageClass = computed(() => {
 .dataflash-contents_global div span {
     position: absolute;
     top: -18px;
-    left: 0;
+    inset-inline-start: 0;
     width: 120px;
-    text-align: left;
+    text-align: start;
     color: silver;
 }
 
@@ -193,7 +193,7 @@ const usageClass = computed(() => {
 
 .data-flash--compact .noflash_global {
     margin: 0;
-    text-align: left;
+    text-align: start;
     color: var(--text);
 }
 </style>

--- a/src/components/device-picker/DevicePicker.vue
+++ b/src/components/device-picker/DevicePicker.vue
@@ -113,7 +113,7 @@ export default defineComponent({
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    margin-left: auto;
+    margin-inline-start: auto;
     align-items: start;
     gap: 0.5rem;
 }

--- a/src/components/dialogs/BoardAlignmentWizardDialog.vue
+++ b/src/components/dialogs/BoardAlignmentWizardDialog.vue
@@ -1070,7 +1070,7 @@ defineExpose({ show, close });
 
 .wizard-warning {
     background: var(--warning-500-15, rgba(255, 187, 0, 0.15));
-    border-left: 3px solid var(--warning-500, #f0b400);
+    border-inline-start: 3px solid var(--warning-500, #f0b400);
     padding: 8px 12px;
     font-size: 13px;
     border-radius: 2px;
@@ -1092,7 +1092,7 @@ defineExpose({ show, close });
 
 .wizard-result-table th:first-child,
 .wizard-result-table td:first-child {
-    text-align: left;
+    text-align: start;
 }
 
 .wizard-result-detected td {
@@ -1142,8 +1142,8 @@ defineExpose({ show, close });
 .wizard-timeline-step:not(:first-child)::before {
     content: "";
     position: absolute;
-    left: -50%;
-    right: 50%;
+    inset-inline-start: -50%;
+    inset-inline-end: 50%;
     top: 11px;
     height: 2px;
     background: var(--surface-300);
@@ -1258,7 +1258,7 @@ defineExpose({ show, close });
 .attitude-overlay {
     position: absolute;
     top: 0.5rem;
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     font-size: 0.75rem;
     color: var(--surface-950);
     pointer-events: none;
@@ -1280,7 +1280,7 @@ defineExpose({ show, close });
 .yaw-reset-btn {
     position: absolute;
     top: 0.5rem;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     z-index: 10;
 }
 </style>

--- a/src/components/dialogs/EscDshotDirectionDialog.vue
+++ b/src/components/dialogs/EscDshotDirectionDialog.vue
@@ -584,8 +584,8 @@ defineExpose({
     display: block;
     width: 160px;
     height: 160px;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     margin-top: auto;
     margin-bottom: auto;
 }

--- a/src/components/dialogs/LogDialog.vue
+++ b/src/components/dialogs/LogDialog.vue
@@ -135,6 +135,6 @@ watch(open, (isOpen) => {
 
 .log-timestamp {
     color: var(--quietHeader);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
 }
 </style>

--- a/src/components/dialogs/MotorOutputReorderingDialog.vue
+++ b/src/components/dialogs/MotorOutputReorderingDialog.vue
@@ -392,6 +392,6 @@ defineExpose({
 }
 
 .regular-button.left {
-    margin-right: 10px;
+    margin-inline-end: 10px;
 }
 </style>

--- a/src/components/dialogs/ReportProblemsDialog.vue
+++ b/src/components/dialogs/ReportProblemsDialog.vue
@@ -1,10 +1,5 @@
 <template>
-    <UModal
-        :open="open"
-        :title="$t('warningTitle')"
-        :close="false"
-        :dismissible="false"
-    >
+    <UModal :open="open" :title="$t('warningTitle')" :close="false" :dismissible="false">
         <template #body>
             <div class="dialogReportProblems-header" v-html="$t('reportProblemsDialogHeader')"></div>
             <ul class="dialogReportProblems-list">
@@ -65,13 +60,13 @@ defineExpose({
 
 .dialogReportProblems-list {
     margin: 10px 0;
-    padding-left: 0;
+    padding-inline-start: 0;
     list-style: none;
 }
 
 .dialogReportProblems-listItem {
     list-style: circle;
-    margin-left: 20px;
+    margin-inline-start: 20px;
     margin-bottom: 5px;
 }
 

--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -1591,7 +1591,7 @@ onBeforeUnmount(() => {
 .mag-sphere-axis-legend {
     position: absolute;
     top: 6px;
-    right: 6px;
+    inset-inline-end: 6px;
     display: flex;
     gap: 8px;
     font-size: 0.75em;
@@ -1623,7 +1623,7 @@ onBeforeUnmount(() => {
 .mag-sphere-age-legend {
     position: absolute;
     top: 26px;
-    right: 6px;
+    inset-inline-end: 6px;
     display: flex;
     align-items: center;
     gap: 4px;
@@ -1650,8 +1650,8 @@ onBeforeUnmount(() => {
 .mag-sphere-legend {
     position: absolute;
     bottom: 6px;
-    left: 6px;
-    right: 6px;
+    inset-inline-start: 6px;
+    inset-inline-end: 6px;
     font-size: 0.7em;
     color: rgba(255, 255, 255, 0.5);
     pointer-events: none;

--- a/src/components/elements/ChannelRangePips.vue
+++ b/src/components/elements/ChannelRangePips.vue
@@ -71,7 +71,7 @@ export default defineComponent({
     content: "";
     position: absolute;
     bottom: 20px;
-    left: 50%;
+    inset-inline-start: 50%;
     transform: translateX(-50%);
     width: 2px;
     height: 16px;

--- a/src/components/elements/WikiButton.vue
+++ b/src/components/elements/WikiButton.vue
@@ -42,7 +42,7 @@ export default defineComponent({
 
 <style scoped>
 .wiki-btn-wrapper {
-    float: right;
+    float: inline-end;
     margin-top: -45px;
 }
 

--- a/src/components/quad-status/BatteryIcon.vue
+++ b/src/components/quad-status/BatteryIcon.vue
@@ -96,7 +96,7 @@ export default defineComponent({
 .quad-status-contents {
     position: absolute;
     top: 10px;
-    left: 14px;
+    inset-inline-start: 14px;
     height: 10px;
     width: 31px;
 }
@@ -111,7 +111,7 @@ export default defineComponent({
     width: 60px;
     transition: none;
     margin-top: 4px;
-    margin-left: -4px;
+    margin-inline-start: -4px;
     background-repeat: no-repeat;
 }
 
@@ -150,14 +150,14 @@ export default defineComponent({
 
 .battery-icon--compact {
     margin-top: 0;
-    margin-left: 0;
+    margin-inline-start: 0;
     height: 24px;
     width: 48px;
 }
 
 .battery-icon--compact .quad-status-contents {
     top: 8px;
-    left: 11px;
+    inset-inline-start: 11px;
     width: 26px;
     height: 8px;
 }

--- a/src/components/quad-status/BatteryLegend.vue
+++ b/src/components/quad-status/BatteryLegend.vue
@@ -26,13 +26,13 @@ const reading = computed(() => {
     position: relative;
     top: -2px;
     margin-top: 0;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     width: 40px;
-    text-align: left;
+    text-align: start;
     color: var(--surface-800);
-    margin-left: -8px;
-    padding-right: 4px;
+    margin-inline-start: -8px;
+    padding-inline-end: 4px;
 }
 
 .battery-legend--compact {

--- a/src/components/quad-status/BottomStatusIcons.vue
+++ b/src/components/quad-status/BottomStatusIcons.vue
@@ -56,8 +56,8 @@ const setActiveLink = computed(() => performance.now() - props.lastReceivedTimes
     height: 31px;
     max-width: 105px;
     margin-top: 2px;
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
 }
 
 .bottomStatusIcons--compact {

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -329,7 +329,7 @@ export default defineComponent({
         max-width: 100%;
         flex-wrap: wrap;
         justify-content: center;
-        border-top-left-radius: 0;
+        border-start-start-radius: 0;
     }
     .tab-cli .content_toolbar.toolbar_fixed_bottom::before {
         display: none;

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -1951,30 +1951,30 @@ export default defineComponent({
         li {
             list-style: initial;
             list-style-type: circle;
-            margin-left: 30px;
+            margin-inline-start: 30px;
         }
     }
     .options {
         position: relative;
         line-height: 18px;
-        text-align: left;
+        text-align: start;
         label {
             display: flex;
             align-items: center;
             gap: 0.5rem;
             input {
-                margin-right: 0;
+                margin-inline-end: 0;
             }
             .helpicon {
                 float: none;
-                margin-left: 3px;
+                margin-inline-start: 3px;
                 margin-top: 0;
                 display: inline-block;
                 align-self: center;
             }
         }
         #flash_manual_baud_rate {
-            margin-left: 0.5rem;
+            margin-inline-start: 0.5rem;
         }
     }
     .board-selection-grid {
@@ -2006,8 +2006,8 @@ export default defineComponent({
     .board-selection-grid .help-icon-cell {
         grid-column: 2;
         text-align: center;
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
+        padding-inline-start: 0.5rem;
+        padding-inline-end: 0.5rem;
         width: 30px;
     }
 
@@ -2041,7 +2041,7 @@ export default defineComponent({
         position: relative;
         top: auto;
         height: auto;
-        right: auto;
+        inset-inline-end: auto;
         z-index: auto;
         pointer-events: all;
         display: flex;
@@ -2147,7 +2147,7 @@ export default defineComponent({
     .default_btn {
         width: fit-content;
         padding-top: 0.25rem;
-        padding-right: 0.25rem;
+        padding-inline-end: 0.25rem;
         a {
             padding: 0.15rem 0.5rem;
         }
@@ -2166,14 +2166,14 @@ export default defineComponent({
     }
 
     .release_info_grid strong {
-        text-align: right;
+        text-align: end;
         white-space: nowrap;
-        padding-right: 1rem;
+        padding-inline-end: 1rem;
     }
 
     .release_info_grid span,
     .release_info_grid a {
-        text-align: left;
+        text-align: start;
     }
 
     .release_info_grid .board_support {
@@ -2239,13 +2239,13 @@ export default defineComponent({
     }
 
     .cloud_build_grid strong {
-        text-align: right;
+        text-align: end;
         white-space: nowrap;
-        padding-right: 1rem;
+        padding-inline-end: 1rem;
     }
 
     .cloud_build_grid a {
-        text-align: left;
+        text-align: start;
     }
 
     .cloud_build_grid .status_wrapper {
@@ -2255,7 +2255,7 @@ export default defineComponent({
     }
 
     #cloudTargetStatus {
-        padding-left: 0.5rem;
+        padding-inline-start: 0.5rem;
     }
 
     .release_info_grid .btn {
@@ -2343,7 +2343,7 @@ export default defineComponent({
     justify-content: end;
     gap: 0.5rem;
     padding: 0.75rem 1rem 0.75rem 1rem;
-    border-top-left-radius: 1.5rem;
+    border-start-start-radius: 1.5rem;
     &::before {
         width: 1.5rem;
         aspect-ratio: 1;
@@ -2351,7 +2351,7 @@ export default defineComponent({
         mask: url(../images/corner.svg);
         background-color: var(--surface-300);
         position: absolute;
-        left: -1.5rem;
+        inset-inline-start: -1.5rem;
         bottom: 0;
     }
     .btn {
@@ -2362,7 +2362,7 @@ export default defineComponent({
             border-radius: 3px;
             border: 1px solid var(--primary-600);
             color: #000;
-            float: right;
+            float: inline-end;
             font-weight: bold;
             font-size: 12px;
             display: block;
@@ -2382,7 +2382,7 @@ export default defineComponent({
                 box-shadow: inset 0 1px 5px rgba(0, 0, 0, 0.35);
             }
             .helpicon {
-                margin-left: 5px;
+                margin-inline-start: 5px;
             }
         }
         a.disabled {
@@ -2404,7 +2404,7 @@ export default defineComponent({
         border-radius: 3px;
         border: 1px solid var(--primary-600);
         color: #000;
-        float: right;
+        float: inline-end;
         font-weight: bold;
         font-size: 12px;
         display: block;
@@ -2498,7 +2498,7 @@ export default defineComponent({
     max-height: 250px;
     overflow-y: auto;
     width: 100%;
-    left: 0;
+    inset-inline-start: 0;
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.6);
 }
 
@@ -2626,23 +2626,23 @@ export default defineComponent({
 /* List styling for recovery and warning text - using :deep to pierce scoped styles */
 :deep(.note-text-format ul) {
     list-style: none !important;
-    margin-left: 0.5rem !important;
+    margin-inline-start: 0.5rem !important;
     margin-top: 0.5rem !important;
     margin-bottom: 0.5rem !important;
-    padding-left: 0 !important;
+    padding-inline-start: 0 !important;
 }
 
 :deep(.note-text-format li) {
     margin-bottom: 0.25rem !important;
-    margin-left: 0 !important;
-    padding-left: 1.5em !important; /* space for dash */
+    margin-inline-start: 0 !important;
+    padding-inline-start: 1.5em !important; /* space for dash */
     text-indent: -1.5em !important; /* hanging indent so wrapped lines align after dash */
     position: relative;
 }
 
 :deep(.note-text-format li::before) {
     content: "– " !important;
-    margin-right: 0.5rem !important;
+    margin-inline-end: 0.5rem !important;
     color: var(--text) !important;
 }
 
@@ -2653,7 +2653,7 @@ export default defineComponent({
 
         ul {
             margin: 0.5rem 0;
-            padding-left: 1.5rem;
+            padding-inline-start: 1.5rem;
             list-style-type: disc;
         }
 
@@ -2672,7 +2672,7 @@ export default defineComponent({
 /* Unstable firmware dialog list styling */
 #dialogUnstableFirmwareAcknowledgement {
     :deep(ul) {
-        margin-left: 1.5rem;
+        margin-inline-start: 1.5rem;
         margin-top: 0.5rem;
         margin-bottom: 0.5rem;
     }
@@ -2680,7 +2680,7 @@ export default defineComponent({
     :deep(li) {
         list-style: disc;
         margin-bottom: 0.25rem;
-        margin-left: 0.5rem;
+        margin-inline-start: 0.5rem;
     }
 }
 </style>

--- a/src/components/tabs/FlightPlan/FlightPlanMap.vue
+++ b/src/components/tabs/FlightPlan/FlightPlanMap.vue
@@ -531,8 +531,8 @@ onUnmounted(() => {
 .map-loading {
     position: absolute;
     top: 0;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     bottom: 0;
     display: flex;
     align-items: center;

--- a/src/components/tabs/FlightPlan/WaypointList.vue
+++ b/src/components/tabs/FlightPlan/WaypointList.vue
@@ -255,13 +255,13 @@ const handleDragEnd = (event) => {
 }
 
 .waypoint-item:first-child {
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
+    border-start-start-radius: 8px;
+    border-start-end-radius: 8px;
 }
 
 .waypoint-item:last-child {
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
+    border-end-start-radius: 8px;
+    border-end-end-radius: 8px;
     border-bottom: none;
 }
 
@@ -271,7 +271,7 @@ const handleDragEnd = (event) => {
 
 .waypoint-item.selected {
     background: var(--primary-500);
-    border-left: 3px solid var(--primary-700);
+    border-inline-start: 3px solid var(--primary-700);
 }
 
 .waypoint-item.selected .waypoint-order {
@@ -294,7 +294,7 @@ const handleDragEnd = (event) => {
     align-items: center;
     justify-content: center;
     font-weight: bold;
-    margin-right: 0.75rem;
+    margin-inline-end: 0.75rem;
     flex-shrink: 0;
 }
 

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -1025,7 +1025,7 @@ export default defineComponent({
         .map-controls {
             position: fixed;
             bottom: 0;
-            left: 0;
+            inset-inline-start: 0;
             width: 100vw !important;
             z-index: 1000;
         }

--- a/src/components/tabs/HelpTab.vue
+++ b/src/components/tabs/HelpTab.vue
@@ -90,7 +90,7 @@ export default defineComponent({
         background-size: 12px;
 
         span {
-            margin-left: 17px;
+            margin-inline-start: 17px;
             display: block;
 
             a {

--- a/src/components/tabs/LandingTab.vue
+++ b/src/components/tabs/LandingTab.vue
@@ -190,13 +190,13 @@ export default defineComponent({
     :deep(.list) {
         ul {
             margin-top: 2px;
-            padding-left: 20px;
+            padding-inline-start: 20px;
             list-style: inside;
         }
         li {
             padding: 2px 0;
             list-style-type: disc;
-            margin-left: 0;
+            margin-inline-start: 0;
             display: list-item;
         }
     }
@@ -231,8 +231,8 @@ export default defineComponent({
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     margin-top: 5px;
     color: var(--text);
     font-size: 14px;
@@ -258,7 +258,7 @@ export default defineComponent({
     margin-bottom: 15px;
 
     .logoSocialMedia {
-        float: left;
+        float: inline-start;
         width: 30px;
 
         img {
@@ -273,7 +273,7 @@ export default defineComponent({
 
     .socialMediaText {
         margin-top: 0;
-        margin-left: 35px;
+        margin-inline-start: 35px;
         display: block;
         font-weight: normal;
         font-size: 12px;
@@ -281,8 +281,8 @@ export default defineComponent({
 }
 
 .languageSwitcher {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     text-align: center;
 
     .selected_language {

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -1105,7 +1105,7 @@ watch(auxChannelValue, (newVal) => {
     margin-bottom: 1.5rem;
     padding: 0.75rem;
     background: var(--surface-100);
-    border-left: 3px solid var(--primary-500);
+    border-inline-start: 3px solid var(--primary-500);
 }
 
 .section {
@@ -1118,8 +1118,8 @@ watch(auxChannelValue, (newVal) => {
 /* Grid Container */
 .grid-container {
     position: relative;
-    float: left;
-    margin-right: 30px;
+    float: inline-start;
+    margin-inline-end: 30px;
     width: calc(29px * 16 + 3px);
     height: calc(29px * 16 + 3px);
 }
@@ -1128,7 +1128,7 @@ watch(auxChannelValue, (newVal) => {
 .gridSections {
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     z-index: 0;
     width: calc(29px * 16 + 3px);
     height: calc(29px * 16 + 3px);
@@ -1141,7 +1141,7 @@ watch(auxChannelValue, (newVal) => {
 .gridSections .block {
     width: 25%;
     height: 25%;
-    float: left;
+    float: inline-start;
     border: 1px solid var(--surface-500);
     box-sizing: border-box;
 }
@@ -1149,7 +1149,7 @@ watch(auxChannelValue, (newVal) => {
 /* Controls Panel */
 .controls {
     position: relative;
-    float: left;
+    float: inline-start;
     width: 325px;
 }
 
@@ -1270,7 +1270,7 @@ watch(auxChannelValue, (newVal) => {
 .select span {
     display: block;
     margin-bottom: 5px;
-    margin-left: 3px;
+    margin-inline-start: 3px;
 }
 
 /* Function-specific select backgrounds — reach USelect's trigger button */
@@ -1355,7 +1355,7 @@ watch(auxChannelValue, (newVal) => {
 
 .modifiers .sliders-group {
     margin-top: 5px;
-    margin-left: 20px;
+    margin-inline-start: 20px;
     width: 100%;
 }
 
@@ -1379,7 +1379,7 @@ watch(auxChannelValue, (newVal) => {
 
 .slider-value {
     min-width: 2.5rem;
-    text-align: right;
+    text-align: end;
     font-variant-numeric: tabular-nums;
     font-size: 12px;
     color: var(--text);
@@ -1506,7 +1506,7 @@ watch(auxChannelValue, (newVal) => {
 .colorDefineSliderLabel {
     width: 15px;
     display: inline-block;
-    margin-right: 5px;
+    margin-inline-end: 5px;
 }
 
 .colorDefineSliderContainer input {
@@ -1517,7 +1517,7 @@ watch(auxChannelValue, (newVal) => {
 .colorDefineSliderValue {
     width: 30px;
     display: inline-block;
-    text-align: right;
+    text-align: end;
 }
 
 /* Directions */
@@ -1533,7 +1533,7 @@ watch(auxChannelValue, (newVal) => {
     grid-template-rows: 30px 30px 30px;
     gap: 4px;
     vertical-align: middle;
-    margin-right: 12px;
+    margin-inline-end: 12px;
 }
 
 .directions :deep(button) {

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -1076,7 +1076,7 @@ export default defineComponent({
             width: 100%;
             height: 26px;
             top: 0;
-            left: 0;
+            inset-inline-start: 0;
             text-align: center;
             line-height: 24px;
             color: white;
@@ -1090,7 +1090,7 @@ export default defineComponent({
         }
         dd {
             display: block;
-            margin-left: 130px;
+            margin-inline-start: 130px;
             height: 20px;
             line-height: 20px;
         }
@@ -1145,8 +1145,8 @@ export default defineComponent({
                 top: 26px;
                 margin-top: 4px;
                 text-align: center;
-                left: 0;
-                right: 0;
+                inset-inline-start: 0;
+                inset-inline-end: 0;
                 white-space: nowrap;
             }
         }
@@ -1171,8 +1171,8 @@ export default defineComponent({
                 top: 26px;
                 margin-top: 4px;
                 text-align: center;
-                left: 0;
-                right: 0;
+                inset-inline-start: 0;
+                inset-inline-end: 0;
                 white-space: nowrap;
             }
         }
@@ -1212,7 +1212,7 @@ export default defineComponent({
         clear: left;
     }
     .blackboxDebugModeText {
-        margin-left: 7px !important;
+        margin-inline-start: 7px !important;
     }
     .sdcard-status {
         padding-top: 4px;

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -1717,7 +1717,7 @@ onUnmounted(() => {
     background-size: cover;
     background-repeat: no-repeat;
     margin-top: 20px;
-    margin-left: 20px;
+    margin-inline-start: 20px;
 }
 
 .tab-osd-char {
@@ -1751,7 +1751,7 @@ onUnmounted(() => {
     content: "";
     position: absolute;
     top: 50%;
-    left: 40%;
+    inset-inline-start: 40%;
     border-top: 0.3em dashed var(--gimbalCrosshair);
     width: 20%;
     transform: translateY(-50%);
@@ -1762,7 +1762,7 @@ onUnmounted(() => {
     content: "";
     position: absolute;
     top: 50%;
-    left: 40%;
+    inset-inline-start: 40%;
     border-top: 0.3em dashed var(--gimbalCrosshair);
     width: 20%;
     transform: translateY(-50%) rotate(90deg);
@@ -1790,7 +1790,7 @@ onUnmounted(() => {
     border-radius: 2px;
     font-size: 10px;
     line-height: 0;
-    margin-left: 4px;
+    margin-inline-start: 4px;
 }
 
 .tab-osd-preset-btn:hover {
@@ -1808,8 +1808,8 @@ onUnmounted(() => {
     display: inline-block;
     min-width: 140px;
     top: -5px;
-    left: 100%;
-    margin-left: 5px;
+    inset-inline-start: 100%;
+    margin-inline-start: 5px;
     padding: 2px;
     background-color: var(--surface-50);
     border: 1px solid var(--surface-500);
@@ -1845,9 +1845,9 @@ onUnmounted(() => {
 
 .tab-osd-context-menu-content {
     position: absolute;
-    left: 100%;
+    inset-inline-start: 100%;
     top: -5px;
-    margin-left: 5px;
+    margin-inline-start: 5px;
     display: none;
     opacity: 0;
     z-index: 10002;

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -652,7 +652,7 @@ onMounted(async () => {
 
 /* ── Table base ───────────────────────────────────────────────────── */
 .tab-pid_tuning table {
-    float: left;
+    float: inline-start;
     margin: 0;
     border-collapse: collapse;
     width: 100%;
@@ -664,27 +664,27 @@ onMounted(async () => {
     background-color: var(--surface-400);
 }
 .tab-pid_tuning .cf th {
-    border-right: solid 1px var(--surface-500);
+    border-inline-end: solid 1px var(--surface-500);
     height: 19px;
     font-weight: normal;
     padding: 4px;
     color: var(--text);
-    text-align: left;
+    text-align: start;
     background: var(--surface-300);
 }
 .tab-pid_tuning .cf th:first-child {
-    border-top-left-radius: 3px;
+    border-start-start-radius: 3px;
 }
 .tab-pid_tuning .cf th:last-child {
-    border-right: 0;
-    border-top-right-radius: 3px;
+    border-inline-end: 0;
+    border-start-end-radius: 3px;
 }
 .tab-pid_tuning .cf td:first-child {
-    border-bottom-left-radius: 3px;
+    border-end-start-radius: 3px;
 }
 .tab-pid_tuning .cf td:last-child {
-    border-bottom-right-radius: 3px;
-    border-right: 0;
+    border-end-end-radius: 3px;
+    border-inline-end: 0;
     padding-bottom: 0;
 }
 .tab-pid_tuning .cf input {
@@ -703,14 +703,14 @@ onMounted(async () => {
 }
 /* ── Curves & canvas ──────────────────────────────────────────────── */
 .tab-pid_tuning .throttle_curve {
-    float: right;
+    float: inline-end;
     width: 100%;
     background-size: 200%;
     height: 164px;
 }
 .tab-pid_tuning .curves {
-    float: left;
-    margin-right: 10px;
+    float: inline-start;
+    margin-inline-end: 10px;
 }
 .tab-pid_tuning .rate_curve {
     height: 362px;
@@ -723,7 +723,7 @@ onMounted(async () => {
 .tab-pid_tuning table td {
     border-bottom: 0 solid var(--surface-500);
     padding: 0.5rem;
-    border-right: 1px solid var(--surface-500);
+    border-inline-end: 1px solid var(--surface-500);
 }
 .tab-pid_tuning table th {
     padding: 0;
@@ -734,11 +734,11 @@ onMounted(async () => {
     color: var(--text);
 }
 .tab-pid_tuning table tr td:first-child {
-    text-align: left;
+    text-align: start;
 }
 .tab-pid_tuning table tr td:last-child {
-    border-right: 0 solid var(--surface-500);
-    text-align: left;
+    border-inline-end: 0 solid var(--surface-500);
+    text-align: start;
 }
 .tab-pid_tuning table .groupSwitchValue {
     display: inline-flex;
@@ -782,24 +782,24 @@ onMounted(async () => {
 .tab-pid_tuning .pid_titlebar {
     color: #fff;
     background-color: var(--surface-300);
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
 }
 .tab-pid_tuning .pid_titlebar th {
     padding: 0.5rem;
     text-align: center;
-    border-right: 1px solid var(--surface-500);
+    border-inline-end: 1px solid var(--surface-500);
 }
 .tab-pid_tuning .pid_titlebar th:first-child {
-    text-align: left;
-    border-top-left-radius: 3px;
+    text-align: start;
+    border-start-start-radius: 3px;
 }
 .tab-pid_tuning .pid_titlebar th:last-child {
-    border-right: none;
-    border-top-right-radius: 3px;
+    border-inline-end: none;
+    border-start-end-radius: 3px;
 }
 .tab-pid_tuning .pid_titlebar td:first-child {
-    text-align: left;
+    text-align: start;
 }
 .tab-pid_tuning .pid_titlebar .name-helpicon-flex {
     display: flex;
@@ -807,7 +807,7 @@ onMounted(async () => {
     justify-content: space-around;
 }
 .tab-pid_tuning .pid_titlebar .name-helpicon-flex .helpicon {
-    margin-right: 0;
+    margin-inline-end: 0;
 }
 
 /* ── Optional / accel PID sections ────────────────────────────────── */
@@ -843,11 +843,11 @@ onMounted(async () => {
     width: 100%;
 }
 .tab-pid_tuning table.compensation .helpicon {
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline-start: auto;
+    margin-inline-end: 0;
 }
 .tab-pid_tuning table.compensation .suboption {
-    margin-left: 2%;
+    margin-inline-start: 2%;
     display: flex;
     flex-flow: row wrap-reverse;
     align-items: center;
@@ -864,7 +864,7 @@ onMounted(async () => {
     box-sizing: border-box;
 }
 .tab-pid_tuning table.compensation .suboption label {
-    margin-left: 5px;
+    margin-inline-start: 5px;
 }
 .tab-pid_tuning table.filterTable.compensation td:first-child {
     width: 5%;
@@ -902,11 +902,11 @@ onMounted(async () => {
     text-align: center;
 }
 .tab-pid_tuning .new_rates td:first-child {
-    border-bottom-left-radius: 0;
-    padding-left: 10px;
+    border-end-start-radius: 0;
+    padding-inline-start: 10px;
 }
 .tab-pid_tuning .new_rates td:last-child span {
-    margin-right: auto;
+    margin-inline-end: auto;
 }
 
 /* ── Misc helpers ─────────────────────────────────────────────────── */
@@ -926,7 +926,7 @@ onMounted(async () => {
 }
 .tab-pid_tuning .number .helpicon {
     margin-top: 3px;
-    margin-right: 0;
+    margin-inline-end: 0;
 }
 .tab-pid_tuning .number {
     margin-bottom: 5px;
@@ -934,7 +934,7 @@ onMounted(async () => {
     padding-bottom: 5px;
     border-bottom: 1px solid var(--surface-500);
     width: 100%;
-    float: left;
+    float: inline-start;
 }
 .tab-pid_tuning .number:last-child {
     padding-bottom: 5px;
@@ -948,36 +948,36 @@ onMounted(async () => {
     font-weight: normal;
 }
 .tab-pid_tuning .spacer_left {
-    padding-left: 0;
-    float: right;
+    padding-inline-start: 0;
+    float: inline-end;
     width: calc(100% - 20px);
 }
 .tab-pid_tuning .numberspacer {
-    float: left;
+    float: inline-start;
     width: 65px;
     height: 21px;
 }
 .tab-pid_tuning .right {
-    float: right;
+    float: inline-end;
 }
 .tab-pid_tuning .pids {
-    float: left;
+    float: inline-start;
     width: 25%;
 }
 .tab-pid_tuning .roll {
-    border-bottom-left-radius: 3px;
+    border-end-start-radius: 3px;
 }
 .tab-pid_tuning .pidTuningLevel {
-    float: left;
+    float: inline-start;
 }
 .tab-pid_tuning .borderleft {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
 }
 .tab-pid_tuning .textleft {
     width: 25%;
-    float: left;
-    text-align: left;
+    float: inline-start;
+    text-align: start;
 }
 .tab-pid_tuning .topspacer {
     margin-top: 5px;
@@ -990,7 +990,7 @@ onMounted(async () => {
     height: 35px;
     width: 14px;
     margin-top: -23px;
-    margin-left: 8px;
+    margin-inline-start: 8px;
 }
 
 /* ── Rates preview ────────────────────────────────────────────────── */
@@ -1002,8 +1002,8 @@ onMounted(async () => {
 .tab-pid_tuning .rates_preview {
     position: absolute;
     top: 0;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     bottom: 0;
     background-size: 100%;
 }
@@ -1032,13 +1032,13 @@ onMounted(async () => {
     padding: 0;
 }
 .tab-pid_tuning .rc_curve_bg {
-    float: left;
+    float: inline-start;
 }
 .tab-pid_tuning .new_rates_last-child {
     border-bottom: none;
 }
 .tab-pid_tuning .filter {
-    padding-left: 5px;
+    padding-inline-start: 5px;
 }
 
 /* ── Dialog ───────────────────────────────────────────────────────── */
@@ -1055,7 +1055,7 @@ onMounted(async () => {
 }
 .tab-pid_tuning dialog select {
     border: 1px solid var(--surface-500);
-    margin-left: 5px;
+    margin-inline-start: 5px;
     width: 120px;
 }
 
@@ -1125,7 +1125,7 @@ onMounted(async () => {
     border-bottom: none;
 }
 .tab-pid_tuning .sliderLabels tr td:first-child {
-    text-align: right;
+    text-align: end;
     width: 20%;
 }
 .tab-pid_tuning .sliderLabels tr td:nth-child(2) {
@@ -1146,7 +1146,7 @@ onMounted(async () => {
 }
 .tab-pid_tuning .tuningPIDSliders .pid_titlebar th:first-child {
     width: 20%;
-    text-align: left;
+    text-align: start;
 }
 .tab-pid_tuning .tuningPIDSliders .pid_titlebar th:first-child div {
     display: inline-block;
@@ -1164,7 +1164,7 @@ onMounted(async () => {
 }
 .tab-pid_tuning .tuningFilterSliders .pid_titlebar th:first-child {
     width: 10%;
-    border-right: none;
+    border-inline-end: none;
 }
 .tab-pid_tuning .tuningFilterSliders .pid_titlebar th:nth-child(2) {
     width: 30px;
@@ -1184,13 +1184,13 @@ onMounted(async () => {
     margin: 0;
 }
 .tab-pid_tuning .note-button td:nth-child(n) {
-    padding-left: 7px;
-    padding-right: 7px;
+    padding-inline-start: 7px;
+    padding-inline-end: 7px;
     text-align: center;
 }
 .tab-pid_tuning .note-button td:first-child {
     width: 75%;
-    border-right: none;
+    border-inline-end: none;
 }
 .tab-pid_tuning .note-button .regular-button {
     display: block;
@@ -1223,7 +1223,7 @@ onMounted(async () => {
 }
 .tab-pid_tuning .subtab-pid .cf_column_right {
     min-width: 300px;
-    margin-left: 15px;
+    margin-inline-start: 15px;
     flex: 1;
 }
 .tab-pid_tuning .subtab-pid .note {
@@ -1248,7 +1248,7 @@ onMounted(async () => {
     height: 80%;
 }
 .tab-pid_tuning .float-left {
-    float: left;
+    float: inline-start;
 }
 
 /* ── Fancy header (not under .tab-pid_tuning) ─────────────────────── */
@@ -1286,14 +1286,14 @@ onMounted(async () => {
 .fancy.header th {
     padding-bottom: 4px;
     padding-top: 4px;
-    padding-left: 5px;
+    padding-inline-start: 5px;
 }
 
 /* ── pid_mode (not under .tab-pid_tuning) ─────────────────────────── */
 .pid_mode {
     background-color: var(--surface-400);
     margin: 0;
-    text-align: left;
+    text-align: start;
     padding: 0.25rem 0.5rem;
     font-size: 12px;
     border-bottom: 1px solid var(--surface-500);
@@ -1345,19 +1345,19 @@ onMounted(async () => {
 
 /* ── Filter two-columns ───────────────────────────────────────────── */
 .subtab-filter table tr td:first-child {
-    text-align: right;
-    padding-left: 5px;
+    text-align: end;
+    padding-inline-start: 5px;
     width: 1%;
 }
 .subtab-filter .two_columns {
     display: flex;
 }
 .subtab-filter .two_columns .two_columns_first {
-    margin-right: 10px;
+    margin-inline-end: 10px;
     height: fit-content;
 }
 .subtab-filter .two_columns .two_columns_second {
-    margin-left: 10px;
+    margin-inline-start: 10px;
     height: fit-content;
 }
 
@@ -1367,8 +1367,8 @@ onMounted(async () => {
     position: relative;
     padding: 10px;
     border: 1px solid var(--surface-500);
-    border-bottom-right-radius: 8px;
-    border-bottom-left-radius: 8px;
+    border-end-end-radius: 8px;
+    border-end-start-radius: 8px;
     border-top: 0 solid var(--surface-500);
     background: transparent;
 }
@@ -1385,7 +1385,7 @@ onMounted(async () => {
     }
     .tab-pid_tuning .subtab-pid .cf_column_right {
         min-width: 100%;
-        margin-left: 0;
+        margin-inline-start: 0;
     }
     .tab-pid_tuning .subtab-rates .cf_column {
         min-width: 100%;
@@ -1434,7 +1434,7 @@ onMounted(async () => {
         color: #595959;
     }
     .tab-pid_tuning .sliderLabels tr.sliderHeaders td:first-child {
-        text-align: left;
+        text-align: start;
     }
     .tab-pid_tuning .tuningPIDSliders .pid_titlebar th:last-child,
     .tab-pid_tuning .tuningPIDSliders .pid_titlebar th:nth-child(2) {
@@ -1453,10 +1453,10 @@ onMounted(async () => {
         flex-wrap: wrap;
     }
     .subtab-filter .two_columns .two_columns_first {
-        margin-right: 0;
+        margin-inline-end: 0;
     }
     .subtab-filter .two_columns .two_columns_second {
-        margin-left: 0;
+        margin-inline-start: 0;
     }
 }
 

--- a/src/components/tabs/PreflightTab.vue
+++ b/src/components/tabs/PreflightTab.vue
@@ -1724,7 +1724,7 @@ export default defineComponent({
                 padding: 0.35rem 0.75rem;
                 white-space: nowrap;
                 em {
-                    margin-right: 4px;
+                    margin-inline-end: 4px;
                 }
             }
         }
@@ -1767,7 +1767,7 @@ export default defineComponent({
                 a {
                     padding: 0.35rem 0.5rem;
                     em {
-                        margin-right: 0;
+                        margin-inline-end: 0;
                     }
                 }
             }
@@ -1789,7 +1789,7 @@ export default defineComponent({
             color: var(--primary-500);
             font-weight: bold;
             em {
-                margin-right: 4px;
+                margin-inline-end: 4px;
             }
             .location-source {
                 color: var(--surface-600);
@@ -1802,7 +1802,7 @@ export default defineComponent({
             margin-top: 8px;
             color: #e74c3c;
             em {
-                margin-right: 4px;
+                margin-inline-end: 4px;
             }
         }
 
@@ -1826,7 +1826,7 @@ export default defineComponent({
             .ip-consent-actions {
                 display: flex;
                 gap: 6px;
-                margin-left: auto;
+                margin-inline-start: auto;
             }
         }
     }
@@ -1878,7 +1878,7 @@ export default defineComponent({
         .refresh-btn {
             width: auto;
             float: none;
-            margin-left: auto;
+            margin-inline-start: auto;
             margin-bottom: 0;
             a {
                 background: rgba(0, 0, 0, 0.1);
@@ -1891,7 +1891,7 @@ export default defineComponent({
                     color: inherit;
                 }
                 em {
-                    margin-right: 4px;
+                    margin-inline-end: 4px;
                 }
             }
         }
@@ -2009,14 +2009,14 @@ export default defineComponent({
     /* Status badge (inline) */
     .status-badge {
         font-size: 11px;
-        margin-left: 6px;
+        margin-inline-start: 6px;
     }
 
     .table-note {
         font-size: 11px;
         color: var(--surface-600);
         margin-top: 4px;
-        text-align: right;
+        text-align: end;
     }
 
     /* 5-Day Forecast row highlights (applied via UTable meta.class.tr) */
@@ -2131,7 +2131,7 @@ export default defineComponent({
                     text-decoration: underline;
                 }
                 em {
-                    margin-right: 4px;
+                    margin-inline-end: 4px;
                     font-size: 10px;
                 }
             }
@@ -2168,7 +2168,7 @@ export default defineComponent({
                 }
 
                 em {
-                    margin-right: 8px;
+                    margin-inline-end: 8px;
                     width: 16px;
                     text-align: center;
                 }
@@ -2205,7 +2205,7 @@ export default defineComponent({
                 }
 
                 em {
-                    margin-right: 8px;
+                    margin-inline-end: 8px;
                     width: 16px;
                     text-align: center;
                 }
@@ -2287,7 +2287,7 @@ export default defineComponent({
             padding: 6px 8px;
 
             em {
-                margin-right: 4px;
+                margin-inline-end: 4px;
             }
         }
 
@@ -2303,7 +2303,7 @@ export default defineComponent({
                 text-align: center;
 
                 em {
-                    margin-right: 6px;
+                    margin-inline-end: 6px;
                 }
             }
 
@@ -2316,7 +2316,7 @@ export default defineComponent({
                 border-radius: 4px;
 
                 em {
-                    margin-right: 6px;
+                    margin-inline-end: 6px;
                 }
             }
 
@@ -2336,15 +2336,15 @@ export default defineComponent({
                 background: var(--surface-0);
 
                 &.notam-card-active {
-                    border-left: 3px solid var(--color-success-500);
+                    border-inline-start: 3px solid var(--color-success-500);
                 }
 
                 &.notam-card-future {
-                    border-left: 3px solid var(--color-warning-500);
+                    border-inline-start: 3px solid var(--color-warning-500);
                 }
 
                 &.notam-card-expired {
-                    border-left: 3px solid var(--surface-400);
+                    border-inline-start: 3px solid var(--surface-400);
                     opacity: 0.6;
                 }
             }
@@ -2365,7 +2365,7 @@ export default defineComponent({
             .notam-location {
                 color: var(--surface-600);
                 font-size: 11px;
-                margin-left: auto;
+                margin-inline-start: auto;
             }
 
             .notam-type-badge,
@@ -2437,7 +2437,7 @@ export default defineComponent({
 
             .notam-expand-link {
                 display: inline-block;
-                margin-left: 4px;
+                margin-inline-start: 4px;
                 font-size: 11px;
                 color: var(--primary-500);
                 text-decoration: underline;
@@ -2448,7 +2448,7 @@ export default defineComponent({
                 margin-top: 6px;
                 font-size: 11px;
                 color: var(--surface-500);
-                text-align: right;
+                text-align: end;
             }
         }
     }
@@ -2474,7 +2474,7 @@ export default defineComponent({
         .controls {
             position: absolute;
             top: 8px;
-            right: 8px;
+            inset-inline-end: 8px;
             display: flex;
             flex-direction: column;
             gap: 2px;
@@ -2515,12 +2515,12 @@ export default defineComponent({
             .controls {
                 position: fixed;
                 bottom: 0;
-                left: 0;
+                inset-inline-start: 0;
                 width: 100vw !important;
                 z-index: 1000;
                 flex-direction: row;
                 top: auto;
-                right: auto;
+                inset-inline-end: auto;
                 justify-content: center;
                 gap: 4px;
                 padding: 4px;
@@ -2534,7 +2534,7 @@ export default defineComponent({
         color: #e74c3c;
         padding: 8px;
         em {
-            margin-right: 4px;
+            margin-inline-end: 4px;
         }
     }
 

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -545,7 +545,7 @@ async function handleCliErrorsDialogClose() {
     color: white;
     box-sizing: border-box;
     user-select: text;
-    float: left;
+    float: inline-start;
 }
 
 .presets_cli_wrapper {

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -1609,7 +1609,7 @@ onUnmounted(() => {
     }
     .name {
         width: 5rem;
-        text-align: right;
+        text-align: end;
     }
     .meter {
         width: 100%;
@@ -1626,7 +1626,7 @@ onUnmounted(() => {
             position: absolute;
             width: 50px;
             text-align: center;
-            left: calc(50cqi - 25px);
+            inset-inline-start: calc(50cqi - 25px);
             color: var(--text);
         }
         .fill {
@@ -1657,8 +1657,8 @@ onUnmounted(() => {
 .plot_control {
     width: 14rem;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
     .value {
         padding: 4px;
         color: #fff;

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -2355,7 +2355,7 @@ onMounted(() => {
         .instruments-right {
             position: absolute;
             bottom: 1rem;
-            right: 1rem;
+            inset-inline-end: 1rem;
             display: flex;
             flex-direction: row;
             gap: 0.5rem;
@@ -2366,7 +2366,7 @@ onMounted(() => {
     .attitude-overlay {
         position: absolute;
         top: 0.75rem;
-        left: 0.75rem;
+        inset-inline-start: 0.75rem;
         font-size: 0.8rem;
         color: var(--surface-950);
 
@@ -2385,7 +2385,7 @@ onMounted(() => {
     .yaw-reset-btn {
         position: absolute;
         top: 0.75rem;
-        right: 0.75rem;
+        inset-inline-end: 0.75rem;
     }
 
     .align-detect-inline {
@@ -2431,7 +2431,7 @@ onMounted(() => {
     .mag-viz-mode-selector {
         position: absolute;
         top: 6px;
-        left: 6px;
+        inset-inline-start: 6px;
         z-index: 10;
         display: flex;
         gap: 2px;
@@ -2480,7 +2480,7 @@ onMounted(() => {
     .mag-cal-stats-inline dd {
         margin: 0;
         font-weight: 600;
-        text-align: right;
+        text-align: end;
     }
 
     .status-ok {

--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -829,7 +829,7 @@ function openBuildOptionsDialog() {
         :deep(.reset-zaxis) {
             position: absolute;
             top: 0.75rem;
-            right: 0.75rem;
+            inset-inline-end: 0.75rem;
             z-index: 100;
         }
     }
@@ -841,7 +841,7 @@ function openBuildOptionsDialog() {
             height: 100%;
             max-height: 32rem;
             top: 0;
-            left: 0;
+            inset-inline-start: 0;
             border-radius: 1rem;
         }
     }
@@ -884,7 +884,7 @@ function openBuildOptionsDialog() {
 .attitude_info {
     position: absolute;
     top: 1rem;
-    left: 1rem;
+    inset-inline-start: 1rem;
     margin: 0;
     font-weight: normal;
     color: var(--surface-950);
@@ -899,7 +899,7 @@ function openBuildOptionsDialog() {
 .instruments-right {
     position: absolute;
     bottom: 1rem;
-    right: 1rem;
+    inset-inline-end: 1rem;
     display: flex;
     flex-direction: row;
     gap: 0.5rem;
@@ -925,7 +925,7 @@ function openBuildOptionsDialog() {
     bottom: 20px;
 }
 .disarm-flag {
-    padding-right: 5px;
+    padding-inline-end: 5px;
     display: inline-block;
 }
 

--- a/src/components/tabs/UserProfileTab.vue
+++ b/src/components/tabs/UserProfileTab.vue
@@ -423,7 +423,7 @@ onUnmounted(() => {
         border-radius: 50%;
         object-fit: cover;
         border: 3px solid var(--surface-500);
-        margin-right: 20px;
+        margin-inline-end: 20px;
     }
 
     .profile-info {
@@ -437,7 +437,7 @@ onUnmounted(() => {
         .title {
             color: var(--color-primary-500);
             font-weight: 600;
-            margin-right: 5px;
+            margin-inline-end: 5px;
             min-width: 60px;
             display: inline-block;
         }
@@ -465,7 +465,7 @@ onUnmounted(() => {
             align-items: center;
         }
         .profile-photo {
-            margin-right: 0;
+            margin-inline-end: 0;
             margin-bottom: 20px;
         }
         .profile-info {

--- a/src/components/tabs/autotune/GainRecommendation.vue
+++ b/src/components/tabs/autotune/GainRecommendation.vue
@@ -315,7 +315,7 @@ async function onApply() {
     th,
     td {
         padding: 5px 10px;
-        text-align: left;
+        text-align: start;
         border-bottom: 1px solid var(--surface-200);
         font-size: 12px;
     }

--- a/src/components/tabs/firmware-flasher/FlasherFlashTab.vue
+++ b/src/components/tabs/firmware-flasher/FlasherFlashTab.vue
@@ -329,13 +329,13 @@ const showRestoreButton = computed(() => {
 }
 
 .release_info_grid strong {
-    text-align: right;
+    text-align: end;
     white-space: nowrap;
 }
 
 .release_info_grid span,
 .release_info_grid a {
-    text-align: left;
+    text-align: start;
 }
 
 .release_info_grid .board_support {

--- a/src/components/tabs/led_strip/LedGridPoint.vue
+++ b/src/components/tabs/led_strip/LedGridPoint.vue
@@ -108,7 +108,7 @@ const colorStyle = computed(() => {
 <style scoped>
 /* Base gPoint styles */
 .gPoint {
-    float: left;
+    float: inline-start;
     border: solid 1px var(--surface-500);
     width: 23px;
     height: 23px;
@@ -218,7 +218,7 @@ const colorStyle = computed(() => {
     text-align: center;
     font-size: 12px;
     display: block;
-    margin-left: -1px;
+    margin-inline-start: -1px;
     margin-top: -21px;
     width: 24px;
     height: 24px;
@@ -244,34 +244,34 @@ const colorStyle = computed(() => {
 
 .indicators .north {
     top: -9px;
-    left: 5px;
-    border-left: 7px solid transparent;
-    border-right: 7px solid transparent;
+    inset-inline-start: 5px;
+    border-inline-start: 7px solid transparent;
+    border-inline-end: 7px solid transparent;
     border-bottom: 7px solid rgba(0, 0, 0, 0.8);
 }
 
 .indicators .south {
     bottom: -8px;
-    left: 5px;
-    border-left: 7px solid transparent;
-    border-right: 7px solid transparent;
+    inset-inline-start: 5px;
+    border-inline-start: 7px solid transparent;
+    border-inline-end: 7px solid transparent;
     border-top: 7px solid rgba(0, 0, 0, 0.8);
 }
 
 .indicators .east {
     bottom: 7px;
-    right: -9px;
+    inset-inline-end: -9px;
     border-top: 7px solid transparent;
     border-bottom: 7px solid transparent;
-    border-left: 7px solid rgba(0, 0, 0, 0.8);
+    border-inline-start: 7px solid rgba(0, 0, 0, 0.8);
 }
 
 .indicators .west {
     bottom: 7px;
-    left: -9px;
+    inset-inline-start: -9px;
     border-top: 7px solid transparent;
     border-bottom: 7px solid transparent;
-    border-right: 7px solid rgba(0, 0, 0, 0.8);
+    border-inline-end: 7px solid rgba(0, 0, 0, 0.8);
 }
 
 .indicators .up {
@@ -279,7 +279,7 @@ const colorStyle = computed(() => {
     width: auto;
     height: auto;
     top: 0px;
-    left: 2px;
+    inset-inline-start: 2px;
     color: white;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
 }
@@ -289,7 +289,7 @@ const colorStyle = computed(() => {
     width: auto;
     height: auto;
     bottom: 17px;
-    right: 10px;
+    inset-inline-end: 10px;
     color: white;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
 }
@@ -321,16 +321,16 @@ const colorStyle = computed(() => {
 
 /* Overlay indicators */
 .gPoint.function-w .overlay-w {
-    float: left;
+    float: inline-start;
     height: 6px;
     width: 16px;
     background-image: radial-gradient(1px at 8px 50%, red 0%, red 2px, rgba(0, 0, 0, 0.3) 3px, rgba(0, 0, 0, 0) 4px);
     margin-top: -30px;
-    margin-left: -9px;
+    margin-inline-start: -9px;
 }
 
 .gPoint.function-v .overlay-v {
-    float: left;
+    float: inline-start;
     height: 6px;
     width: 16px;
     background-image: radial-gradient(
@@ -341,11 +341,11 @@ const colorStyle = computed(() => {
         rgba(0, 0, 0, 0) 4px
     );
     margin-top: -6px;
-    margin-left: 4px;
+    margin-inline-start: 4px;
 }
 
 .gPoint.function-i .overlay-i {
-    float: left;
+    float: inline-start;
     height: 6px;
     width: 16px;
     background-image: radial-gradient(
@@ -356,11 +356,11 @@ const colorStyle = computed(() => {
         rgba(0, 0, 0, 0) 4px
     );
     margin-top: -30px;
-    margin-left: 16px;
+    margin-inline-start: 16px;
 }
 
 .gPoint.function-t .overlay-t {
-    float: left;
+    float: inline-start;
     height: 6px;
     width: 16px;
     background-image: radial-gradient(
@@ -371,11 +371,11 @@ const colorStyle = computed(() => {
         rgba(0, 0, 0, 0) 4px
     );
     margin-top: -6px;
-    margin-left: -9px;
+    margin-inline-start: -9px;
 }
 
 .gPoint.function-o .overlay-o {
-    float: left;
+    float: inline-start;
     height: 6px;
     width: 16px;
     background-image: radial-gradient(
@@ -386,11 +386,11 @@ const colorStyle = computed(() => {
         rgba(0, 0, 0, 0) 4px
     );
     margin-top: -6px;
-    margin-left: 16px;
+    margin-inline-start: 16px;
 }
 
 .gPoint.function-b .overlay-b {
-    float: left;
+    float: inline-start;
     height: 6px;
     width: 16px;
     background-image: radial-gradient(
@@ -401,11 +401,11 @@ const colorStyle = computed(() => {
         rgba(0, 0, 0, 0) 4px
     );
     margin-top: -18px;
-    margin-left: -9px;
+    margin-inline-start: -9px;
 }
 
 .gPoint.function-y .overlay-y {
-    float: left;
+    float: inline-start;
     height: 6px;
     width: 16px;
     background-image: radial-gradient(
@@ -416,11 +416,11 @@ const colorStyle = computed(() => {
         rgba(0, 0, 0, 0) 4px
     );
     margin-top: -30px;
-    margin-left: 4px;
+    margin-inline-start: 4px;
 }
 
 .gPoint.function-s .overlay-s {
-    float: left;
+    float: inline-start;
     height: 6px;
     width: 16px;
     background-image: radial-gradient(
@@ -431,7 +431,7 @@ const colorStyle = computed(() => {
         rgba(0, 0, 0, 0) 4px
     );
     margin-top: -6px;
-    margin-left: 16px;
+    margin-inline-start: 16px;
 }
 
 /* Color overlay for color function */
@@ -440,11 +440,11 @@ const colorStyle = computed(() => {
 .gPoint.function-b .overlay-color,
 .gPoint.function-u .overlay-color,
 .gPoint .overlay-color {
-    float: left;
+    float: inline-start;
     height: 15px;
     width: 15px;
     margin-top: -23px;
-    margin-left: 4px;
+    margin-inline-start: 4px;
     border-radius: 4px;
     display: block;
 }

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -363,8 +363,8 @@ function handleOptionsToggle(event) {
     content: "";
     width: 0;
     height: 0;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
+    border-inline-start: 5px solid transparent;
+    border-inline-end: 5px solid transparent;
     border-top: 6px solid var(--ui-text);
     justify-self: end;
     opacity: 0.65;
@@ -372,8 +372,8 @@ function handleOptionsToggle(event) {
 }
 
 details[open] > .preset-options-summary {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
 }
 
 details[open] > .preset-options-summary::after {
@@ -405,16 +405,16 @@ details[open] > .preset-options-summary::after {
 
 .preset-description-html ul,
 .preset-description-html ol {
-    padding-left: 25px;
+    padding-inline-start: 25px;
 }
 
 .preset-description-html ul li {
-    padding-left: 12px;
+    padding-inline-start: 12px;
     list-style-type: disclosure-closed;
 }
 
 .preset-description-html ol li {
-    padding-left: 12px;
+    padding-inline-start: 12px;
     list-style-type: decimal;
 }
 

--- a/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
+++ b/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
@@ -218,8 +218,8 @@ body {
     width: 120px;
     height: 120px;
     background-color: var(--surface-200);
-    margin-left: 1.5rem;
-    margin-right: 1.5rem;
+    margin-inline-start: 1.5rem;
+    margin-inline-end: 1.5rem;
     margin-bottom: 2rem;
     display: inline-block;
     border-radius: 5px;
@@ -235,7 +235,7 @@ body {
 .crosshair-vert {
     width: 1px;
     height: 100%;
-    left: 50%;
+    inset-inline-start: 50%;
 }
 
 .crosshair-horz {
@@ -259,14 +259,14 @@ body {
     transform: rotate(-90deg);
     top: calc(50% - 0.5em);
     width: 100%;
-    left: calc(-50% - 1.5rem);
+    inset-inline-start: calc(-50% - 1.5rem);
 }
 
 .control-stick {
     background-color: var(--primary-500);
     width: 20px;
     height: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-top: -10px;
     display: block;
     border-radius: 100%;

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -202,12 +202,7 @@
             </UModal>
 
             <!-- Waiting Dialog -->
-            <UModal
-                v-model:open="waitingDialogOpen"
-                :close="false"
-                :dismissible="false"
-                title=""
-            >
+            <UModal v-model:open="waitingDialogOpen" :close="false" :dismissible="false" title="">
                 <template #body>
                     <div class="waiting-container">
                         <div class="waiting-spinner" aria-hidden="true"></div>
@@ -374,7 +369,7 @@ export default defineComponent({
 .dialog-close-button {
     position: absolute;
     top: 10px;
-    right: 10px;
+    inset-inline-end: 10px;
 }
 
 .dialog-title {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -82,10 +82,10 @@ a.disabled {
         -1px -1px;
 }
 .standard_input {
-    padding-left: 3px;
+    padding-inline-start: 3px;
     height: 20px;
     line-height: 20px;
-    text-align: left;
+    text-align: start;
     border-radius: 3px;
     font-size: 12px;
     font-weight: normal;
@@ -93,9 +93,9 @@ a.disabled {
     background: var(--surface-200);
 }
 .helpicon {
-    float: right;
+    float: inline-end;
     margin-top: 7px;
-    margin-right: 7px;
+    margin-inline-end: 7px;
     display: block;
     height: 14px;
     width: 14px;
@@ -118,7 +118,7 @@ a.disabled {
         border-radius: 3px;
         border: 1px solid var(--primary-600);
         color: var(--text);
-        float: right;
+        float: inline-end;
         font-weight: bold;
         font-size: 10px;
         line-height: 17px;
@@ -210,8 +210,8 @@ td [role="group"] {
         gap: 0.5rem;
     }
     .helpicon {
-        margin-right: 7px !important;
-        margin-left: auto !important;
+        margin-inline-end: 7px !important;
+        margin-inline-start: auto !important;
         float: none;
     }
 }
@@ -219,10 +219,10 @@ td [role="group"] {
     clear: both;
 }
 .left {
-    float: left;
+    float: inline-start;
 }
 .right {
-    float: right;
+    float: inline-end;
 }
 .margin-top {
     margin-top: 20px;
@@ -266,8 +266,8 @@ td [role="group"] {
     position: fixed;
     z-index: 1500;
     top: 0;
-    left: 0;
-    right: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     bottom: 0;
     display: block;
     backdrop-filter: blur(0.25rem);
@@ -433,7 +433,7 @@ each(@tabIcons, {
             mask: @value no-repeat center center;
             -webkit-mask: @value no-repeat center center;
             background-color: var(--surface-700);
-            margin-right: 4px;
+            margin-inline-end: 4px;
         }
         &:hover::before {
             background-color: var(--primary-500);
@@ -474,12 +474,12 @@ dialog {
             button {
                 margin-top: 0;
                 margin-bottom: 0;
-                margin-right: 20px;
+                margin-inline-end: 20px;
                 background-color: var(--primary-500);
                 border-radius: 3px;
                 border: 1px solid var(--primary-600);
                 color: #000;
-                float: left;
+                float: inline-start;
                 font-weight: bold;
                 font-size: 12px;
                 display: block;
@@ -573,7 +573,7 @@ dialog {
     justify-content: end;
     gap: 0.5rem;
     padding: 0.75rem 1rem 0.25rem 1rem;
-    border-top-left-radius: 1.5rem;
+    border-start-start-radius: 1.5rem;
     &::before {
         width: 1.5rem;
         aspect-ratio: 1;
@@ -581,7 +581,7 @@ dialog {
         mask: url(../images/corner.svg);
         background-color: var(--surface-300);
         position: absolute;
-        left: -1.5rem;
+        inset-inline-start: -1.5rem;
         bottom: 0;
     }
     .btn {
@@ -593,7 +593,7 @@ dialog {
             border-radius: 3px;
             border: 1px solid var(--primary-600);
             color: #000;
-            float: right;
+            float: inline-end;
             font-family: inherit;
             font-weight: bold;
             font-size: 12px;
@@ -615,7 +615,7 @@ dialog {
                 box-shadow: inset 0 1px 5px rgba(0, 0, 0, 0.35);
             }
             .helpicon {
-                margin-left: 5px;
+                margin-inline-start: 5px;
             }
         }
         a.disabled,
@@ -643,7 +643,7 @@ dialog {
         position: fixed;
         /* Sit directly on top of #status-bar, which grows by the bottom safe-area inset */
         bottom: calc(2.5rem + env(safe-area-inset-bottom, 0px));
-        right: 0;
+        inset-inline-end: 0;
     }
 }
 .content_toolbar.xs-compressed {
@@ -652,7 +652,7 @@ dialog {
 .toolbar_expand_btn {
     display: none;
     bottom: 15px;
-    left: 15px;
+    inset-inline-start: 15px;
     width: 20px;
     height: 20px;
     font-size: 20px;
@@ -665,15 +665,15 @@ dialog {
     margin-bottom: 0;
 }
 .full {
-    float: left;
+    float: inline-start;
     width: 100%;
 }
 .half {
-    float: left;
+    float: inline-start;
     width: 50%;
 }
 .third_left {
-    float: left;
+    float: inline-start;
     width: 33%;
 }
 .third_center {
@@ -681,37 +681,37 @@ dialog {
     width: 34%;
 }
 .third_right {
-    float: right;
+    float: inline-end;
     width: 33%;
 }
 .fourth {
-    float: left;
+    float: inline-start;
     width: 25%;
 }
 .threefourth_right {
-    float: right;
+    float: inline-end;
     width: 75%;
 }
 .threefourth_left {
-    float: left;
+    float: inline-start;
     width: 75%;
 }
 .twothird {
-    float: left;
+    float: inline-start;
     width: 67%;
 }
 .spacer {
     width: 100%;
 }
 .spacer_left {
-    padding-left: 15px;
-    float: left;
+    padding-inline-start: 15px;
+    float: inline-start;
     width: calc(100% - 15px);
 }
 .spacer_right {
-    padding-right: 15px;
+    padding-inline-end: 15px;
     width: calc(100% - 15px);
-    float: left;
+    float: inline-start;
 }
 .gui_warning {
     background: var(--error-transparent-1);
@@ -741,7 +741,7 @@ dialog {
     height: 50px;
     background-color: #e4e4e4;
     width: calc(100% + 40px);
-    margin-left: -20px;
+    margin-inline-start: -20px;
     box-shadow: rgba(0, 0, 0, 0) 0 -3px 8px;
     bottom: 0;
     margin-bottom: 0;
@@ -749,12 +749,12 @@ dialog {
         a {
             margin-top: 9px;
             margin-bottom: 0;
-            margin-right: 20px;
+            margin-inline-end: 20px;
             background-color: var(--primary-500);
             border-radius: 3px;
             border: 1px solid var(--primary-600);
             color: #000;
-            float: right;
+            float: inline-end;
             font-weight: bold;
             font-size: 12px;
             display: block;
@@ -774,7 +774,7 @@ dialog {
     position: relative;
     margin-bottom: 10px;
     margin-top: 0;
-    float: left;
+    float: inline-start;
     a,
     button {
         padding: 0.35rem 0 0.35rem 0;
@@ -816,7 +816,7 @@ dialog {
     -webkit-user-drag: none;
     margin-top: 8px;
     margin-bottom: 8px;
-    margin-right: 10px;
+    margin-inline-end: 10px;
     background-color: var(--primary-500);
     border-radius: 3px;
     border: 1px solid var(--primary-600);
@@ -849,7 +849,7 @@ dialog {
     -webkit-user-drag: none;
     margin-top: 8px;
     margin-bottom: 8px;
-    margin-right: 10px;
+    margin-inline-end: 10px;
     background-color: var(--error-500);
     border-radius: 3px;
     border: 1px solid var(--error-600);
@@ -938,7 +938,7 @@ table {
     border-radius: 3px;
     color: #ffffff;
     font-size: 11px;
-    margin-left: 3px;
+    margin-inline-start: 3px;
 }
 .gps_true {
     background-color: var(--primary-500);
@@ -946,7 +946,7 @@ table {
     border-radius: 3px;
     color: #ffffff;
     font-size: 11px;
-    margin-left: 3px;
+    margin-inline-start: 3px;
 }
 .tab-setup,
 .tab-landing,
@@ -1035,7 +1035,7 @@ table {
 .buildInfoBtn {
     position: relative;
     margin: 4px;
-    float: right;
+    float: inline-end;
     a {
         padding: 2px 5px 2px 5px;
         text-align: center;
@@ -1071,7 +1071,7 @@ table {
 .buildInfoClassOptions {
     margin-bottom: 0px;
     margin-top: 3px;
-    float: right;
+    float: inline-end;
     background-color: grey;
     padding: 2px 5px 2px 5px;
     border-radius: 4px;
@@ -1084,8 +1084,8 @@ table {
     background-color: var(--surface-300);
     height: 31px;
     margin-top: 2px;
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
 }
 .hidden {
     display: none;
@@ -1106,13 +1106,13 @@ table {
     box-sizing: border-box;
 }
 .grid-col {
-    margin-left: 7px;
-    margin-right: 7px;
+    margin-inline-start: 7px;
+    margin-inline-end: 7px;
     &:first-child {
-        margin-left: 0;
+        margin-inline-start: 0;
     }
     &:last-child {
-        margin-right: 0;
+        margin-inline-end: 0;
     }
 }
 
@@ -1265,9 +1265,9 @@ each(range(12), {
         margin-bottom: 10px;
     }
     .helpicon {
-        float: right;
+        float: inline-end;
         margin-top: 5px;
-        margin-right: 7px;
+        margin-inline-end: 7px;
         height: 14px;
         width: 14px;
         transition: none;
@@ -1296,7 +1296,7 @@ each(range(12), {
                 padding-bottom: 6px;
             }
             ::before {
-                padding-left: 3px;
+                padding-inline-start: 3px;
             }
         }
     }
@@ -1333,16 +1333,16 @@ each(range(12), {
         margin-bottom: 10px;
     }
     .spacer_box_title {
-        padding-left: 10px;
-        padding-right: 10px;
+        padding-inline-start: 10px;
+        padding-inline-end: 10px;
         padding-top: 3px;
         margin-bottom: 0;
-        float: left;
+        float: inline-start;
     }
     .helpicon {
-        float: right;
+        float: inline-end;
         margin-top: 5px;
-        margin-right: 7px;
+        margin-inline-end: 7px;
         height: 14px;
         width: 14px;
         transition: none;
@@ -1359,7 +1359,7 @@ each(range(12), {
         .btn {
             a,
             button {
-                margin-right: 15px;
+                margin-inline-end: 15px;
             }
         }
     }
@@ -1384,14 +1384,14 @@ each(range(12), {
         position: fixed;
         z-index: 2000;
         top: 0;
-        left: -100%;
+        inset-inline-start: -100%;
         bottom: 0;
         min-width: fit-content;
         transition: all 0.3s;
         padding: 1rem;
     }
     .tab_container.reveal {
-        left: 0;
+        inset-inline-start: 0;
         /* Clear the mobile top bar plus the status bar / display cutout above it */
         padding-top: calc(3.5rem + env(safe-area-inset-top, 0px));
     }
@@ -1428,8 +1428,8 @@ each(range(12), {
     each(range(12), {
         .grid-col.col@{value} {
             width: 100% !important;
-            margin-left: 0 !important;
-            margin-right: 0 !important;
+            margin-inline-start: 0 !important;
+            margin-inline-end: 0 !important;
         }
     });
 }
@@ -1509,7 +1509,7 @@ body.compact-header-layout {
         background-color: var(--surface-300);
         color: var(--text);
         border: 1px solid var(--surface-400);
-        margin-left: 5px;
+        margin-inline-start: 5px;
         cursor: pointer;
         &:hover {
             background-color: var(--surface-400);

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -6,6 +6,7 @@ import { get as getConfig, set as setConfig } from "./ConfigStorage.js";
 const i18n = {};
 
 const languagesAvailables = [
+    "ar",
     "ca",
     "da",
     "de",

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -59,8 +59,10 @@ i18n.init = function (cb) {
                     console.log("i18n system loaded");
                     const detectedLanguage = i18n.getMessage(`language_${getValidLocale("DEFAULT")}`);
                     i18n.addResources({ detectedLanguage: detectedLanguage });
+                    i18n.updatePageDirection();
                     i18next.on("languageChanged", function () {
                         i18n.localizePage(true);
+                        i18n.updatePageDirection();
                     });
                 }
                 if (cb !== undefined) {
@@ -135,6 +137,16 @@ i18n.getCurrentLocale = function () {
 
 i18n.existsMessage = function (key) {
     return i18next.exists(key);
+};
+
+i18n.isRtl = function (locale) {
+    return i18next.dir(locale) === "rtl";
+};
+
+i18n.updatePageDirection = function () {
+    const html = document.documentElement;
+    html.setAttribute("dir", i18n.isRtl() ? "rtl" : "ltr");
+    html.setAttribute("lang", i18n.getCurrentLocale());
 };
 
 /**


### PR DESCRIPTION
This pull request introduces right-to-left (RTL) language support across the project. This adds Arabic language support too to test it

The PR has been divided into three commits, to let it be reviewed easily:
- The first one adds support for detection of RTL languages
- The second one changes physical CSS properties for logical ones (this is the biggest commit)
- The third add the Arabic translation (thanks to BADER.FPV for the translation!)

**RTL and Logical CSS Properties:**

The second commit replaces physical properties with the equivalent logical ones. In this way, the layout does not change for LTR languages and must support the major part of RTL elements out of the box.
- Changed margin-right to margin-inline-end, margin-left to margin-inline-start, and similar adjustments across multiple Vue components and stylesheets.
- Replaced text-align: right with text-align: end and text-align: left with text-align: start for better alignment in RTL contexts.
- Adjusted border radius properties to use logical properties for consistency.

There are some "calculated" properties at some parts that probably will need some change, and maybe something is not totally right for RTL at some tab, but I think that this can be fixed at later PRs. I think now is good enough to merge it. I don't want to make this PR grow, specially because it touches a lot of files and if we don't merge it soon it will be nightmare of maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Arabic as an available language.
  * Arabic translations are now downloaded and displayed with right-to-left page direction.

* **Enhancements**
  * Updated layouts, controls, dialogs, and text alignment to adapt correctly to right-to-left languages.
  * Improved automatic language and text-direction handling when the language changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->