### PR TITLE
Fix rtl issues

### DIFF
--- a/src/components/tabs/HelpTab.vue
+++ b/src/components/tabs/HelpTab.vue
@@ -84,10 +84,18 @@ export default defineComponent({
         border-top: 1px dotted var(--surface-500);
         padding-top: 5px;
         padding-bottom: 5px;
-        background-image: url(../../images/arrow.svg);
-        background-repeat: no-repeat;
-        background-position: 0 8px;
-        background-size: 12px;
+        position: relative;
+
+        &::before {
+            content: "";
+            position: absolute;
+            inset-inline-start: 0;
+            top: 8px;
+            width: 12px;
+            height: 12px;
+            background: url(../../images/arrow.svg) no-repeat;
+            background-size: 12px;
+        }
 
         span {
             margin-inline-start: 17px;
@@ -97,6 +105,10 @@ export default defineComponent({
                 color: var(--primary-500);
             }
         }
+    }
+
+    html[dir="rtl"] & li::before {
+        transform: scaleX(-1);
     }
 
     .subline {

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -1532,6 +1532,7 @@ watch(auxChannelValue, (newVal) => {
     grid-template-columns: 30px 30px 30px 30px;
     grid-template-rows: 30px 30px 30px;
     gap: 4px;
+    direction: ltr;
     vertical-align: middle;
     margin-inline-end: 12px;
 }

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -930,7 +930,7 @@ onMounted(async () => {
 }
 .tab-pid_tuning .number {
     margin-bottom: 5px;
-    clear: left;
+    clear: inline-start;
     padding-bottom: 5px;
     border-bottom: 1px solid var(--surface-500);
     width: 100%;

--- a/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
+++ b/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
@@ -153,6 +153,8 @@ function transmitChannels() {
 }
 
 onMounted(() => {
+    i18n?.updatePageDirection(document);
+
     document.title = t("receiverButtonSticks");
     globalThis.addEventListener("mousemove", onMouseMove);
     globalThis.addEventListener("mouseup", onMouseUp);
@@ -266,7 +268,7 @@ body {
     background-color: var(--primary-500);
     width: 20px;
     height: 20px;
-    margin-inline-start: -10px;
+    margin-left: -10px;
     margin-top: -10px;
     display: block;
     border-radius: 100%;

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -144,8 +144,8 @@ i18n.isRtl = function (locale) {
     return i18next.dir(locale) === "rtl";
 };
 
-i18n.updatePageDirection = function () {
-    const html = document.documentElement;
+i18n.updatePageDirection = function (targetDocument = document) {
+    const html = targetDocument.documentElement;
     html.setAttribute("dir", i18n.isRtl() ? "rtl" : "ltr");
     html.setAttribute("lang", i18n.getCurrentLocale().replaceAll("_", "-"));
 };

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -147,7 +147,7 @@ i18n.isRtl = function (locale) {
 i18n.updatePageDirection = function () {
     const html = document.documentElement;
     html.setAttribute("dir", i18n.isRtl() ? "rtl" : "ltr");
-    html.setAttribute("lang", i18n.getCurrentLocale());
+    html.setAttribute("lang", i18n.getCurrentLocale().replaceAll("_", "-"));
 };
 
 /**


### PR DESCRIPTION
Fixes some known issues from the PR that added the RTL support.

This issues are being tracked here: https://github.com/betaflight/betaflight-configurator/issues/5482

Some things that remain:
- Some comments about BIDIR translations, waiting for the user to confirm the issue/solution in the issue
- The MSP receiver window, I think something is broken, it does not load when executing in local (it works when executing over the real published configurator), so I can't try to find the issue. I don't know if someone more can test it to see if it's a problem in my side or not.

I've created one commit for each issue, to make it easier the review, but maybe is better to squash all of them before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Help tab arrow display in right-to-left languages by applying the correct visual direction.
  - Preserved left-to-right layout for LED strip direction controls.
  - Improved number field layout in PID tuning for different writing directions.
  - Standardized document language metadata formatting for regional locales, such as `pt-BR`.
  - Corrected text direction handling in the Receiver MSP sticks popup for localized interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->