### PR TITLE
fix(virtual-fc): use reportable build options

### DIFF
--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -24,7 +24,8 @@ const Features = function (config) {
         { bit: 17, group: "other", name: "DISPLAY", haveTip: true, dependsOn: "DASHBOARD" },
         { bit: 18, group: "other", name: "OSD", haveTip: true, dependsOn: "OSD" },
         { bit: 20, group: "other", name: "CHANNEL_FORWARDING", dependsOn: "SERVOS" },
-        { bit: 21, group: "other", name: "TRANSPONDER", haveTip: true, dependsOn: "TRANSPONDER" },
+        // USE_TRANSPONDER is target-defined but absent from the reportable build-option table.
+        { bit: 21, group: "other", name: "TRANSPONDER", haveTip: true },
         { bit: 22, group: "other", name: "AIRMODE", haveTip: true },
         { bit: 25, group: "rxMode", mode: "select", name: "RX_SPI" },
         { bit: 27, group: "escSensor", name: "ESC_SENSOR" },

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -127,7 +127,6 @@ const VirtualFC = {
 
         virtualFC.CONFIG.buildInfo = "now";
         virtualFC.CONFIG.buildOptions = [
-            "USE_ESC_SENSOR",
             "USE_DASHBOARD",
             "USE_GPS",
             "USE_LED_STRIP",
@@ -136,12 +135,11 @@ const VirtualFC = {
             "USE_OSD_HD",
             "USE_VTX",
             "USE_SOFTSERIAL",
-            "USE_SONAR",
-            "USE_TELEMETRY",
+            "USE_RANGEFINDER",
             "USE_SERVOS",
-            "USE_TRANSPONDER",
             "USE_SERIALRX_CRSF",
             "USE_SERIALRX_SBUS",
+            "USE_TELEMETRY_SMARTPORT",
             "USE_DSHOT",
         ];
 

--- a/test/js/virtual_fc_build_options.test.js
+++ b/test/js/virtual_fc_build_options.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import VirtualFC from "../../src/js/VirtualFC";
+import { FIRMWARE_BUILD_OPTIONS } from "../../src/js/build_options.js";
+import CONFIGURATOR, {
+    API_VERSION_1_44,
+    API_VERSION_1_45,
+    API_VERSION_1_46,
+    API_VERSION_1_47,
+    API_VERSION_1_48,
+} from "../../src/js/data_storage";
+import FC from "../../src/js/fc";
+import Features from "../../src/js/Features";
+
+const VIRTUAL_API_VERSIONS = [API_VERSION_1_44, API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47, API_VERSION_1_48];
+
+describe("Virtual FC build options", () => {
+    it("only reports option names that firmware can emit", () => {
+        VirtualFC.setVirtualConfig();
+
+        const unreportable = FC.CONFIG.buildOptions.filter((option) => !Object.hasOwn(FIRMWARE_BUILD_OPTIONS, option));
+
+        expect(unreportable).toEqual([]);
+    });
+
+    it("only gates features on reportable option fragments", () => {
+        const definitions = new Features({ apiVersion: API_VERSION_1_48, buildOptions: [] }).getFeatures();
+        const optionNames = Object.keys(FIRMWARE_BUILD_OPTIONS);
+        const unmatched = definitions
+            .filter(
+                (feature) =>
+                    feature.dependsOn !== undefined &&
+                    !optionNames.some((option) => option.includes(feature.dependsOn)),
+            )
+            .map((feature) => ({ name: feature.name, dependsOn: feature.dependsOn }));
+
+        expect(unmatched).toEqual([]);
+    });
+
+    it.each(VIRTUAL_API_VERSIONS)(
+        "keeps the features it enables available after option filtering on API %s",
+        (apiVersion) => {
+            CONFIGURATOR.virtualApiVersion = apiVersion;
+            VirtualFC.setVirtualConfig();
+
+            const expectedStates = {
+                ESC_SENSOR: true,
+                SONAR: true,
+                TELEMETRY: true,
+                TRANSPONDER: true,
+            };
+            const actualStates = Object.fromEntries(
+                Object.keys(expectedStates).map((name) => [name, FC.FEATURE_CONFIG.features.isEnabled(name)]),
+            );
+
+            expect(actualStates).toEqual(expectedStates);
+        },
+    );
+});


### PR DESCRIPTION
Fixes #5431

## What changed

Virtual FC was reporting four build-option names that cannot be produced by the generated build-option table. This replaces the two load-bearing aliases with reportable options:

- `USE_SONAR` becomes `USE_RANGEFINDER`
- `USE_TELEMETRY` becomes `USE_TELEMETRY_SMARTPORT`

`ESC_SENSOR` is already ungated, so its fake fixture entry is removed. Transponder has no reportable build option, so its impossible dependency is removed and the UI keeps the existing fail-open behavior.

The API 1.46+ CRSF/GHST/FPORT/JETI telemetry fallback remains unchanged. SmartPort preserves API 1.45's explicit telemetry-option path without broadening that version boundary.

I kept substring matching because dependencies such as `TELEMETRY` and `OSD` intentionally represent option families. Changing it to exact matching would require a broader mapping and is not needed for this cleanup.

The new tests verify that every Virtual FC option is reportable, every feature dependency matches at least one generated option, and enabled Virtual FC features survive filtering across every selectable API from 1.44 through 1.48.

## Testing

- `NODE_OPTIONS=--no-experimental-webstorage npm test -- --run --reporter=dot` (99 files, 1,161 tests passed, including lint)
- `npm run build`
- Prettier and `git diff --check`
- Production browser build in Edge on Windows:
  - MSP 1.45: verified the Sonar panel and enabled Telemetry output
  - MSP 1.48: verified Sonar, Transponder, Telemetry output, and ESC Sensor remained available and enabled
