### PR TITLE
Fix tooltip and other NuxtUI elements in RTL

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-    <UApp :tooltip="{ delayDuration: 100 }" portal="#main-wrapper">
+    <UApp :dir="i18n.direction" :tooltip="{ delayDuration: 100 }" portal="#main-wrapper">
         <div class="app-wrapper">
             <div id="background" v-if="isMobileSidebarOpen" aria-hidden="true" @click="isRevealed = false"></div>
             <div id="side_menu_swipe"></div>

--- a/src/components/elements/HelpIcon.vue
+++ b/src/components/elements/HelpIcon.vue
@@ -1,5 +1,5 @@
 <template>
-    <UTooltip :delayDuration="0" arrow :content="{ side: 'right' }">
+    <UTooltip :delayDuration="0" arrow :content="{ side: i18n.direction.value === 'rtl' ? 'left' : 'right' }">
         <div class="p-0.5 rounded-full hover:bg-neutral-100/30 cursor-pointer duration-100 w-fit">
             <UIcon name="i-lucide-circle-question-mark" class="size-4" />
         </div>
@@ -10,6 +10,8 @@
 </template>
 
 <script setup>
+import { i18n } from "@/js/localization";
+
 defineProps({
     text: {
         type: String,

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -1,9 +1,12 @@
 import i18next from "i18next";
 import HttpBackend from "i18next-http-backend";
+import { ref } from "vue";
 import { gui_log } from "./gui_log.js";
 import { get as getConfig, set as setConfig } from "./ConfigStorage.js";
 
-const i18n = {};
+const i18n = {
+    direction: ref("ltr"),
+};
 
 const languagesAvailables = [
     "ar",
@@ -146,7 +149,11 @@ i18n.isRtl = function (locale) {
 
 i18n.updatePageDirection = function (targetDocument = document) {
     const html = targetDocument.documentElement;
-    html.setAttribute("dir", i18n.isRtl() ? "rtl" : "ltr");
+    const direction = i18n.isRtl() ? "rtl" : "ltr";
+
+    i18n.direction.value = direction;
+
+    html.setAttribute("dir", direction);
     html.setAttribute("lang", i18n.getCurrentLocale().replaceAll("_", "-"));
 };
 


### PR DESCRIPTION
According to https://github.com/betaflight/betaflight-configurator/issues/5482 the tooltips seems wrong in RTL languages.
I've observed that the Nuxt UI elements have all of them LTR as lenguage, this PR creates a reactive property in `localization.js` and Nuxt UI uses it.
I don't like to have reactive properties in a pure js file, but I don't know too much about all the migration that you have done in the latest months so if there's a better alternative, please tell me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved right-to-left (RTL) and left-to-right (LTR) layout handling throughout the app.
  * Tooltips now appear on the appropriate side based on the selected language direction.
  * Page direction updates dynamically when localization settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->