### PR TITLE
fix(status-bar): add missing i18n keys and keep phone controls off other layouts

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -996,6 +996,14 @@
         "message": "Connection:",
         "description": "Connection time text shown in the status bar"
     },
+    "statusbar_expand": {
+        "message": "Show status details",
+        "description": "Accessible label for the status bar expand button on the compact phone layout"
+    },
+    "statusbar_collapse": {
+        "message": "Hide status details",
+        "description": "Accessible label for the status bar collapse button on the compact phone layout"
+    },
     "dfu_connect_message": {
         "message": "Please use the Firmware Flasher to access DFU devices"
     },

--- a/src/components/status-bar/StatusBar.vue
+++ b/src/components/status-bar/StatusBar.vue
@@ -524,7 +524,10 @@ body.mobile-app-shell {
     }
 }
 
-#status-bar > * {
+/* Only the readout row: an `#status-bar > *` here would outrank the `display: none` on the tab
+   strip and the expand control by specificity, showing both outside the phone shell (desktop,
+   browser and installed PWA). */
+#status-bar > .status-bar__items {
     display: flex;
     align-items: center;
 }


### PR DESCRIPTION
## Summary

Two follow-ups to the phone shell redesign in #5477.

### Missing i18n messages

`StatusBar.vue` labels the expand control with `$t(expanded ? 'statusbar_collapse' : 'statusbar_expand')`, but neither key was added to `locales/en/messages.json`, so screen readers announced the raw key. Both are now defined next to the other `statusbar_*` entries.

Every other i18n key touched by #5477 (`App.vue`, `Sidebar.vue`, `useVisibleTabs.js`, `ConnectButton.vue`, `CliTab.vue`, `device_handler.js`, `tab_switch.js`, `TauriTcp.js`) was checked — these two were the only ones missing.

### Menu icons on the status bar outside the phone shell

The tab strip and the expand chevron are meant to appear only in the phone shell, and `body.mobile-app-shell` was being set correctly (native builds only, `src/js/main.js`). The controls leaked out through the cascade instead:

| selector | specificity | declaration |
| --- | --- | --- |
| `.status-bar__tabs` | `(0,1,0)` | `display: none` |
| `#status_expand_btn` | `(1,0,0)` | `display: none` |
| `#status-bar > *` | `(1,0,0)`, later in the file | `display: flex` |

The ID selector outranks the class for the tab strip, and ties-but-wins on source order for the expand button, so both rendered on desktop, in the browser and in an installed PWA. That rule only ever needed to apply to the readout row, so it is now scoped to `#status-bar > .status-bar__items`; the phone-shell rules that switch the controls on are untouched.

Note that an installed PWA on a phone still gets the desktop status bar rather than the floating phone bar — `mobile-app-shell` is deliberately native-only. That is unchanged here.

## Testing

- Status bar on desktop and in the browser: no tab icons, no expand chevron.
- Phone shell: tab strip, expand/collapse and the expanded readout panel behave as before.
- `npm run lint` and `prettier` pass (lint-staged ran on commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added accessible labels for expanding and collapsing status details on compact phone layouts, improving clarity for assistive technology users.

- **Bug Fixes**
  - Improved status bar layout styling so alignment applies correctly to the status readout without affecting tabs or the expand button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->