### PR TITLE
fix(cli): handle entry banner across serial reads

### DIFF
--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -23,7 +23,8 @@ const enterKeyCode = 13;
 const tabKeyCode = 9;
 const SERIAL_IDLE_MS = 250; // quiet period after which a command response is considered complete
 const CLI_ENTRY_MARKER = "CLI";
-const CLI_ENTRY_PROMPT = "\r\n# ";
+const CLI_PROMPT = "# ";
+const CLI_ENTRY_PROMPT = `\r\n${CLI_PROMPT}`;
 
 function removePromptHash(promptText) {
     return promptText.replace(/^# /, "");
@@ -536,7 +537,7 @@ export function useCli() {
             CONFIGURATOR.cliValid = true;
             // begin output history with the prompt (last line of welcome message)
             // this is to match the content of the history with what the user sees on this tab
-            outputHistory = "# ";
+            outputHistory = CLI_PROMPT;
 
             return CliAutoComplete.isEnabled() && !CliAutoComplete.isBuilding();
         }

--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -142,7 +142,9 @@ export function useCli() {
 
     let outputHistory = "";
     let cliBuffer = "";
+    /** @type {boolean} */
     let cliEntrySawMarker = false;
+    /** @type {string} */
     let cliEntrySuffix = "";
     let outputSuppressed = false;
 

--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -22,6 +22,8 @@ const carriageReturnCode = 13;
 const enterKeyCode = 13;
 const tabKeyCode = 9;
 const SERIAL_IDLE_MS = 250; // quiet period after which a command response is considered complete
+const CLI_ENTRY_MARKER = "CLI";
+const CLI_ENTRY_PROMPT = "\r\n# ";
 
 function removePromptHash(promptText) {
     return promptText.replace(/^# /, "");
@@ -140,6 +142,8 @@ export function useCli() {
 
     let outputHistory = "";
     let cliBuffer = "";
+    let cliEntrySawMarker = false;
+    let cliEntrySuffix = "";
     let outputSuppressed = false;
 
     // Refs for DOM elements
@@ -520,21 +524,29 @@ export function useCli() {
         }
     };
 
-    const validateCliEntry = (validateText) => {
-        if (!CONFIGURATOR.cliValid && validateText.includes("CLI")) {
+    /**
+     * Complete CLI-entry validation after the marker and prompt have been observed.
+     * @returns {boolean} true when autocomplete should start after the current read.
+     */
+    const validateCliEntry = () => {
+        if (!CONFIGURATOR.cliValid && cliEntrySawMarker) {
             gui_log(i18n.getMessage(getConfig("cliOnlyMode")?.cliOnlyMode ? "cliDevEnter" : "cliEnter"));
             CONFIGURATOR.cliValid = true;
             // begin output history with the prompt (last line of welcome message)
             // this is to match the content of the history with what the user sees on this tab
-            const lastLine = validateText.split("\n").pop();
-            outputHistory = lastLine;
+            outputHistory = "# ";
 
-            if (CliAutoComplete.isEnabled() && !CliAutoComplete.isBuilding()) {
-                CliAutoComplete.builderStart();
-            }
+            return CliAutoComplete.isEnabled() && !CliAutoComplete.isBuilding();
         }
+
+        return false;
     };
 
+    /**
+     * Process bytes received from the serial port.
+     * @param {{ data: ArrayBuffer } | ArrayBuffer | Uint8Array} readInfo
+     * @returns {void}
+     */
     const read = (readInfo) => {
         /*  Some info about handling line feeds and carriage return
 
@@ -547,8 +559,8 @@ export function useCli() {
             Chrome OS currently unknown
         */
         const data = new Uint8Array(readInfo.data ?? readInfo);
-        let validateText = "";
         let sequenceCharsToSkip = 0;
+        let startAutocompleteAfterRead = false;
 
         for (let i = 0; i < data.length; i++) {
             const byte = data[i];
@@ -558,8 +570,14 @@ export function useCli() {
             if (!CONFIGURATOR.cliValid && (isCRLF || state.startProcessing)) {
                 // try to catch part of valid CLI enter message (firmware message starts with CRLF)
                 state.startProcessing = true;
-                validateText += currentChar;
+                cliEntrySuffix = `${cliEntrySuffix}${currentChar}`.slice(-CLI_ENTRY_PROMPT.length);
+                if (cliEntrySuffix.endsWith(CLI_ENTRY_MARKER)) {
+                    cliEntrySawMarker = true;
+                }
                 writeToOutput(escapeHtml(currentChar));
+                if (cliEntrySuffix === CLI_ENTRY_PROMPT) {
+                    startAutocompleteAfterRead = validateCliEntry();
+                }
                 continue;
             }
 
@@ -601,7 +619,9 @@ export function useCli() {
 
         state.lastArrival = Date.now();
 
-        validateCliEntry(validateText);
+        if (startAutocompleteAfterRead) {
+            CliAutoComplete.builderStart();
+        }
 
         // fallback to native autocomplete
         if (!CliAutoComplete.isEnabled() && !CliAutoComplete.isSuppressingOutput()) {
@@ -612,6 +632,8 @@ export function useCli() {
     const initialize = async () => {
         outputHistory = "";
         cliBuffer = "";
+        cliEntrySawMarker = false;
+        cliEntrySuffix = "";
         outputSuppressed = false;
         state.startProcessing = false;
 

--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -27,7 +27,7 @@ const CLI_PROMPT = "# ";
 const CLI_ENTRY_PROMPT = `\r\n${CLI_PROMPT}`;
 
 function removePromptHash(promptText) {
-    return promptText.replace(/^# /, "");
+    return promptText.startsWith(CLI_PROMPT) ? promptText.slice(CLI_PROMPT.length) : promptText;
 }
 
 function cliBufferCharsToDelete(command, buffer) {

--- a/test/js/cli_entry_validation_word_split.test.js
+++ b/test/js/cli_entry_validation_word_split.test.js
@@ -2,33 +2,12 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { useCli } from "../../src/composables/useCli";
 import CliAutoComplete from "../../src/js/CliAutoComplete";
 import CONFIGURATOR from "../../src/js/data_storage";
+import FC from "../../src/js/fc";
 import GUI from "../../src/js/gui";
 import BFClipboard from "../../src/js/Clipboard";
 
-// NOT part of the #5445 fix. Discovered while building the #5445 reproduction harness
-// (see cli_welcome_banner_repro.test.js) and reported separately per that investigation's
-// scope rules — this is a different bug in the same code region, not the one #5445 describes.
-//
-// useCli.js's `validateText` (the buffer validateCliEntry() checks for the substring "CLI") is a
-// variable local to a single read() call — it is rebuilt from empty on every serial read and never
-// carries partial content across reads. If the 3-byte literal "CLI" itself is split across a
-// read() boundary (e.g. one read ends "...Entering CL", the next begins "I Mode..."), neither
-// read's isolated validateText ever contains the full substring, so CONFIGURATOR.cliValid never
-// becomes true. Because the `!cliValid` branch never records bytes into outputHistory (only into
-// the doomed, per-call validateText), every subsequent byte — the rest of the banner, the prompt,
-// and any real command output — is silently discarded for the remainder of the session.
-//
-// This is materially worse than #5445's hypothesized banner-duplication: it's total data loss,
-// not a duplicated fragment, and it does not require finding a specific reproduction — it happens
-// whenever a read() boundary lands inside the 3-byte word "CLI", which is a near-certainty in the
-// "extremely fragmented reads" case #5445 itself asked to test.
-//
-// These assert the current (buggy) behavior directly rather than using it.fails(): it.fails()
-// would pass for ANY thrown error, including an unrelated exception from makeCli()/feed()/
-// getHistory(), which would silently mask a different failure instead of documenting this one.
-// Asserting the buggy values directly means setup errors fail the test as themselves, and the
-// test will start *failing* — flagging that this file needs updating — the moment someone fixes
-// the underlying gap.
+// The firmware banner is transport-fragmented. Entry validation must therefore retain its state
+// across read() callbacks or a split inside "CLI" prevents validation and drops later output.
 
 const BANNER = "\r\nEntering CLI Mode, type 'exit' to reboot, or 'help'\r\n\r\n# ";
 
@@ -57,7 +36,7 @@ function getHistory(cli) {
     return text;
 }
 
-describe("useCli: CLI entry never validates when 'CLI' itself is split across reads (separate from #5445)", () => {
+describe("useCli CLI-entry validation across serial read boundaries", () => {
     beforeEach(() => {
         CONFIGURATOR.cliActive = true;
         CONFIGURATOR.cliValid = false;
@@ -66,13 +45,26 @@ describe("useCli: CLI entry never validates when 'CLI' itself is split across re
     });
 
     afterEach(() => {
+        CliAutoComplete.cleanup();
+        CliAutoComplete.configEnabled = false;
+        FC.CONFIG.flightControllerIdentifier = "";
         vi.restoreAllMocks();
         CONFIGURATOR.cliActive = false;
         CONFIGURATOR.cliValid = false;
-        CliAutoComplete.builder.state = "reset";
     });
 
-    it("BUG: splitting 'CL' | 'I...' leaves cliValid false and drops all subsequent traffic", () => {
+    it("preserves same-read normal output before autocomplete starts", () => {
+        const cli = makeCli();
+        FC.CONFIG.flightControllerIdentifier = "BTFL";
+        CliAutoComplete.configEnabled = true;
+        CliAutoComplete.initialize(vi.fn(), vi.fn(), () => Date.now() - cli.state.lastArrival > 250);
+
+        cli.read(bytes(`${BANNER}Betaflight / STM32F7X2\r`));
+
+        expect(getHistory(cli)).toContain("Betaflight / STM32F7X2");
+    });
+
+    it("validates when 'CLI' is split across reads and preserves subsequent traffic", () => {
         const cli = makeCli();
 
         feed(cli, ["\r\nEntering CL", "I Mode, type 'exit' to reboot, or 'help'\r\n\r\n# "]);
@@ -80,13 +72,11 @@ describe("useCli: CLI entry never validates when 'CLI' itself is split across re
 
         const history = getHistory(cli);
 
-        // Current (buggy) behavior. Once the underlying gap is fixed, cliValid should become
-        // true and the version response should be recorded — flip these assertions then.
-        expect(CONFIGURATOR.cliValid).toBe(false);
-        expect(history).not.toContain("Betaflight / STM32F7X2");
+        expect(CONFIGURATOR.cliValid).toBe(true);
+        expect(history).toContain("Betaflight / STM32F7X2");
     });
 
-    it("BUG: byte-by-byte fragmentation of the whole banner leaves cliValid false", () => {
+    it("validates a byte-fragmented banner and preserves subsequent traffic", () => {
         const cli = makeCli();
 
         feed(cli, BANNER.split(""));
@@ -94,7 +84,7 @@ describe("useCli: CLI entry never validates when 'CLI' itself is split across re
 
         const history = getHistory(cli);
 
-        expect(CONFIGURATOR.cliValid).toBe(false);
-        expect(history).not.toContain("Betaflight / STM32F7X2");
+        expect(CONFIGURATOR.cliValid).toBe(true);
+        expect(history).toContain("Betaflight / STM32F7X2");
     });
 });

--- a/test/js/cli_welcome_banner_repro.test.js
+++ b/test/js/cli_welcome_banner_repro.test.js
@@ -13,6 +13,12 @@ import BFClipboard from "../../src/js/Clipboard";
 //   cliPrintLine("\r\nEntering CLI Mode, type 'exit' to reboot, or 'help'") -> "...'help'" + "\r\n"
 //   cliPrompt()                                                            -> "\r\n# "
 const BANNER = "\r\nEntering CLI Mode, type 'exit' to reboot, or 'help'\r\n\r\n# ";
+const NORMAL_OUTPUT_CHUNKS = [
+    "version\r\n",
+    "Betaflight / STM32F7X2 (S7X2) 4.6.0 ",
+    "Jan  1 2026 / 00:00:00\r\n\r\n# ",
+];
+const EXPECTED_HISTORY = `# ${NORMAL_OUTPUT_CHUNKS.join("")}`;
 
 function bytes(str) {
     return new TextEncoder().encode(str);
@@ -66,10 +72,7 @@ describe("useCli welcome-banner split-read handling (#5445)", () => {
     });
 
     // Split boundaries requested by #5445, covering every place the banner could be torn across
-    // a read() event. "split inside 'CLI'" and the byte-by-byte case are exercised here too: even
-    // though they trip a *different* bug (see cli_entry_validation_word_split.test.js — cliValid
-    // never validates, so nothing is recorded at all), that is itself proof there is no leaked
-    // banner *fragment* in those cases either — there's nothing in outputHistory whatsoever.
+    // a read() event.
     const cases = [
         ["complete banner in one read", [BANNER]],
         ["split immediately before 'CLI'", ["\r\nEntering ", "CLI Mode, type 'exit' to reboot, or 'help'\r\n\r\n# "]],
@@ -87,35 +90,28 @@ describe("useCli welcome-banner split-read handling (#5445)", () => {
         ["extremely fragmented reads (one byte per read)", BANNER.split("")],
     ];
 
-    it.each(cases)("%s: the banner phrase is never duplicated in outputHistory", (_label, chunks) => {
+    it.each(cases)("%s: the welcome banner is kept out of outputHistory", (_label, chunks) => {
         const cli = makeCli();
 
         feed(cli, chunks);
         // Real traffic continuing after CLI entry, exactly as it would arrive from the FC.
-        feed(cli, ["version\r\n", "Betaflight / STM32F7X2 (S7X2) 4.6.0 ", "Jan  1 2026 / 00:00:00\r\n\r\n# "]);
+        feed(cli, NORMAL_OUTPUT_CHUNKS);
 
         const history = getHistory(cli);
 
-        // This is the literal claim under test: the CLI-entry handshake text must appear at most
-        // once in the recorded history (0 times is fine — see the note above the case list — but
-        // it must never be duplicated).
-        expect(countOccurrences(history, "Entering CLI Mode")).toBeLessThanOrEqual(1);
+        // Exact history catches leaked partial suffixes that do not contain the full banner phrase.
+        expect(history).toBe(EXPECTED_HISTORY);
+        expect(countOccurrences(history, "Entering CLI Mode")).toBe(0);
     });
 
-    // The splits that do validate from the banner (i.e. every case except the pathological
-    // word-split ones covered separately) must still preserve real command output untouched —
-    // the fix for #5445 must not come at the cost of losing or corrupting normal CLI traffic.
-    const validatingCases = cases.filter(
-        ([label]) => !label.includes("split inside the word") && !label.includes("fragmented"),
-    );
-
-    it.each(validatingCases)("%s: normal command output after entry is preserved", (_label, chunks) => {
+    // Entry validation must not come at the cost of losing or corrupting normal CLI traffic.
+    it.each(cases)("%s: normal command output after entry is preserved", (_label, chunks) => {
         const cli = makeCli();
 
         feed(cli, chunks);
         expect(CONFIGURATOR.cliValid).toBe(true);
 
-        feed(cli, ["version\r\n", "Betaflight / STM32F7X2 (S7X2) 4.6.0 ", "Jan  1 2026 / 00:00:00\r\n\r\n# "]);
+        feed(cli, NORMAL_OUTPUT_CHUNKS);
 
         const history = getHistory(cli);
         expect(countOccurrences(history, "Betaflight / STM32F7X2")).toBe(1);


### PR DESCRIPTION
Fixes #5445

`read()` treated each serial callback as a complete CLI-entry frame. Its validation text was local to one callback, so a boundary inside `CLI` prevented `CONFIGURATOR.cliValid` from ever becoming true and all later output was discarded. A boundary immediately after `CLI` caused the opposite transition too early: the remaining welcome banner was appended to Copy/Save history before the prompt arrived.

CLI-entry parsing now retains only a fixed-size suffix plus a marker flag across callbacks, both reset by `initialize()`. Validation runs only when the firmware's `\r\n# ` prompt is complete. It flips `cliValid` inside the byte loop so later bytes in that callback use normal CLI processing, but starts autocomplete only after `lastArrival` is updated. I checked the same prompt in firmware 4.2.11, 4.3.2, 4.4.3, 4.5.2, and current `master`; minimal CLI builds use that prompt too. This makes validation independent of transport chunk boundaries, avoids retaining unbounded serial input, and keeps the welcome banner out of history.

Validating as soon as the accumulated text contains `CLI` was not sufficient because it still initialized history in the middle of the banner. Restoring the legacy CLI buffer was also rejected because it has the same per-read assumption and would risk undoing later output and autocomplete fixes. Waiting for the existing firmware prompt is the narrow boundary that resolves both failures.

This keeps the current output batching, autocomplete ownership, bounded rendered scrollback, and full Copy/Save history behavior. The deterministic harness introduced in #5465 now asserts the intended behavior across every documented split boundary.

## Mutation evidence

On unchanged `master`:

- Changing the two word-split assertions to the intended behavior produced 2 failures because `cliValid` remained `false`.
- Requiring the welcome banner to be absent from history produced 3 failures because `Entering CLI Mode` appeared once.

During implementation, the first prompt-gated version started autocomplete inside the byte loop. A focused regression delivering the banner, prompt, and subsequent command output in one read produced 1 failure because that output was suppressed. Deferring autocomplete until after the read and `lastArrival` update made it pass.

With this change on Node v24.20.0:

- `node node_modules/vitest/vitest.mjs run test/js/cli_entry_validation_word_split.test.js test/js/cli_welcome_banner_repro.test.js`: 19 passed
- CLI-related Vitest suites: 63 passed
- `npm run lint`: passed
- `npm run test`: 1164 passed
- `npm run build`: passed

Credit to @Greninja44 for the reproduction harness and for documenting the word-split failure in #5465.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI entry detection when banners or prompts arrive split across serial reads.
  - Preserved valid CLI output during fragmented or combined responses.
  - Ensured command history initializes correctly after entering CLI mode.
  - Delayed autocomplete until CLI validation and initial reading are complete.

- **Tests**
  - Added coverage for fragmented banners, word-split prompts, combined responses, and preserved normal output.
  - Expanded validation checks across all tested serial-read split scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->