### PR TITLE
Add placeholder noting Betaflight 10.10.0 .deb

### DIFF
--- a/ADD_BETAFLIGHT_DEB.md
+++ b/ADD_BETAFLIGHT_DEB.md
@@ -1,0 +1,7 @@
+Add Betaflight DEB (placeholder)
+
+The Betaflight Configurator 10.10.0 amd64 .deb installer was downloaded during this session but excluded from the branch due to GitHub's file size limits (>100 MB).
+
+This placeholder documents that the binary exists locally and recommends uploading the installer as a GitHub Release asset or hosting it outside the repository.
+
+If you'd like the binary included via Git LFS or uploaded to Releases, say which option to use.


### PR DESCRIPTION
Why

Document that the Betaflight Configurator 10.10.0 amd64 .deb installer was downloaded during this session but was excluded from the branch due to GitHub file-size limits.

Approach

Adds a small placeholder file (ADD_BETAFLIGHT_DEB.md) describing the artifact and recommended next steps (upload to GitHub Releases or use Git LFS). No source code changes are included.

Notes and trade-offs

- The binary itself was intentionally excluded because GitHub rejects files larger than 100 MB.
- Prefer using GitHub Releases or CI artifact uploads for distribution; adding binaries inflates repo size.

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a note explaining that the Betaflight Configurator 10.10.0 amd64 DEB installer is not included due to GitHub file-size limits.
  - Documented alternative distribution options, including external hosting, GitHub Release assets, and Git LFS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->