### PR TITLE
Add placeholder noting Betaflight 10.10.0 .deb

### DIFF
--- a/ADD_BETAFLIGHT_DEB.md
+++ b/ADD_BETAFLIGHT_DEB.md
@@ -1,0 +1,7 @@
+Add Betaflight DEB (placeholder)
+
+The Betaflight Configurator 10.10.0 amd64 .deb installer was downloaded during this session but excluded from the branch due to GitHub's file size limits (>100 MB).
+
+This placeholder documents that the binary exists locally and recommends uploading the installer as a GitHub Release asset or hosting it outside the repository.
+
+If you'd like the binary included via Git LFS or uploaded to Releases, say which option to use.


### PR DESCRIPTION
Why

Document that the Betaflight Configurator 10.10.0 amd64 .deb installer was downloaded during this session but excluded from the branch due to GitHub file-size limits.

Approach

Adds a short placeholder file (ADD_BETAFLIGHT_DEB.md) describing the artifact and recommending next steps (upload to GitHub Releases or use Git LFS). No source code changes are included.

Notes and trade-offs

- The binary exceeds GitHub's 100 MB file limit and was intentionally excluded. Prefer GitHub Releases, CI artifacts, or Git LFS for distributing installers.
- If maintainers prefer the binary inside the repo, convert the repo to use Git LFS and re-commit the file.

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note explaining that the Betaflight Configurator 10.10.0 amd64 DEB installer is unavailable in the repository due to file-size limits.
  * Documented alternative distribution options, including release assets, external hosting, and Git LFS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->