### PR TITLE
fix(pid-tuning): normalize slider display values

### DIFF
--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -22,7 +22,9 @@
                     class="flex-1 sm:flex-none min-w-0 sm:min-w-32 text-xs"
                     v-html="$t('pidTuningGyroFilterSlider')"
                 ></div>
-                <span class="min-w-10 text-center text-sm font-semibold">{{ gyroFilterMultiplier.toFixed(2) }}</span>
+                <span class="min-w-10 text-center text-sm font-semibold">{{
+                    formatSliderValue(gyroFilterMultiplier)
+                }}</span>
                 <div class="flex items-center gap-3 basis-full sm:basis-0 sm:flex-1">
                     <USlider
                         v-model="gyroFilterMultiplier"
@@ -43,7 +45,9 @@
                     class="flex-1 sm:flex-none min-w-0 sm:min-w-32 text-xs"
                     v-html="$t('pidTuningDTermFilterSlider')"
                 ></div>
-                <span class="min-w-10 text-center text-sm font-semibold">{{ dtermFilterMultiplier.toFixed(2) }}</span>
+                <span class="min-w-10 text-center text-sm font-semibold">{{
+                    formatSliderValue(dtermFilterMultiplier)
+                }}</span>
                 <div class="flex items-center gap-3 basis-full sm:basis-0 sm:flex-1">
                     <USlider
                         v-model="dtermFilterMultiplier"
@@ -670,6 +674,10 @@ const dtermSliderEnabled = computed({
 // Filter Sliders
 // Local refs for slider positions — decoupled from FC state so MSP responses
 // writing back to FC.TUNING_SLIDERS don't cause the slider to bounce.
+function formatSliderValue(value) {
+    return Number(value).toFixed(2);
+}
+
 const gyroFilterMultiplier = ref((FC.TUNING_SLIDERS.slider_gyro_filter_multiplier || 100) / 100);
 const dtermFilterMultiplier = ref((FC.TUNING_SLIDERS.slider_dterm_filter_multiplier || 100) / 100);
 

--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -1493,14 +1493,18 @@ const masterChanged = computed(
 );
 
 // Computed display values to ensure reactivity
-const sliderDGainDisplay = computed(() => sliderDGain.value.toFixed(2));
-const sliderPIGainDisplay = computed(() => sliderPIGain.value.toFixed(2));
-const sliderFFGainDisplay = computed(() => sliderFeedforwardGain.value.toFixed(2));
-const sliderDMaxGainDisplay = computed(() => sliderDMaxGain.value.toFixed(2));
-const sliderIGainDisplay = computed(() => sliderIGain.value.toFixed(2));
-const sliderRPRatioDisplay = computed(() => sliderRollPitchRatio.value.toFixed(2));
-const sliderPitchPIDisplay = computed(() => sliderPitchPIGain.value.toFixed(2));
-const sliderMasterDisplay = computed(() => sliderMasterMultiplier.value.toFixed(2));
+function formatSliderValue(value) {
+    return Number(value).toFixed(2);
+}
+
+const sliderDGainDisplay = computed(() => formatSliderValue(sliderDGain.value));
+const sliderPIGainDisplay = computed(() => formatSliderValue(sliderPIGain.value));
+const sliderFFGainDisplay = computed(() => formatSliderValue(sliderFeedforwardGain.value));
+const sliderDMaxGainDisplay = computed(() => formatSliderValue(sliderDMaxGain.value));
+const sliderIGainDisplay = computed(() => formatSliderValue(sliderIGain.value));
+const sliderRPRatioDisplay = computed(() => formatSliderValue(sliderRollPitchRatio.value));
+const sliderPitchPIDisplay = computed(() => formatSliderValue(sliderPitchPIGain.value));
+const sliderMasterDisplay = computed(() => formatSliderValue(sliderMasterMultiplier.value));
 
 // Slider disabled states — matches original updateExpertModePidSlidersDisplay()
 // Disable when mode is OFF, or when slider is outside non-expert range and not in expert mode


### PR DESCRIPTION
### Issue
An error on master regarding the PID-Sliders disappearing was posted on Discord.

The slider values were not always returned as numbers, but the display code called .toFixed() directly on them.

This behavior starts after PR #5494 was merged.

### Fix
Added a small formatter that converts the slider value to a number before calling .toFixed(2).

This keeps the displayed values unchanged while preventing the PID tuning tab from throwing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PID tuning slider value displays by consistently formatting numeric values to two decimal places.
  - Prevented display issues when slider values are provided in non-number formats.
  - Applied consistent formatting to gyro and D-term filter slider labels for clearer, more reliable readings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->