### PR TITLE
chore(deps): update @nuxt/ui to 4.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/android": "8.3.4",
         "@capacitor/core": "8.3.4",
         "@iconify-json/lucide": "^1.2.101",
-        "@nuxt/ui": "^4.4.0",
+        "@nuxt/ui": "^4.11.1",
         "@simplewebauthn/browser": "^13.2.2",
         "@tauri-apps/api": "~2.11.0",
         "@tauri-apps/plugin-dialog": "^2.7.2",
@@ -3482,17 +3482,17 @@
       }
     },
     "node_modules/@nuxt/ui": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.11.0.tgz",
-      "integrity": "sha512-gDs67/fWk3kipcEV4Pc5h1VnZD1glfWfINmJU7s3qpkxxRTkfkPxnUszXG664whNWcoqucS1WgZ/rNjZa3pTMw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.11.1.tgz",
+      "integrity": "sha512-6/xTMQNO4bcVesaaiIorH65cZ3eu0xenH+gC2L/b9pfmeVc0aMGXDKpW2JxoVUlrlcHo/beoUTI0B164HcwweQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.8.0",
         "@iconify/vue": "^5.0.1",
-        "@internationalized/date": "^3.12.3",
-        "@internationalized/number": "^3.6.7",
+        "@internationalized/date": "^3.12.4",
+        "@internationalized/number": "^3.6.8",
         "@nuxt/fonts": "^0.14.0",
-        "@nuxt/icon": "^2.5.0",
+        "@nuxt/icon": "^2.5.1",
         "@nuxt/kit": "^4.5.2",
         "@nuxt/schema": "^4.5.2",
         "@nuxtjs/color-mode": "^4.0.1",
@@ -3500,25 +3500,25 @@
         "@tailwindcss/postcss": "^4.3.3",
         "@tailwindcss/vite": "^4.3.3",
         "@tanstack/vue-table": "^8.21.3",
-        "@tanstack/vue-virtual": "^3.13.35",
-        "@tiptap/core": "^3.29.2",
-        "@tiptap/extension-bubble-menu": "^3.29.2",
-        "@tiptap/extension-code": "^3.29.2",
-        "@tiptap/extension-collaboration": "^3.29.2",
-        "@tiptap/extension-drag-handle": "^3.29.2",
-        "@tiptap/extension-drag-handle-vue-3": "^3.29.2",
-        "@tiptap/extension-floating-menu": "^3.29.2",
-        "@tiptap/extension-horizontal-rule": "^3.29.2",
-        "@tiptap/extension-image": "^3.29.2",
-        "@tiptap/extension-mention": "^3.29.2",
-        "@tiptap/extension-node-range": "^3.29.2",
-        "@tiptap/extension-placeholder": "^3.29.2",
-        "@tiptap/markdown": "^3.29.2",
-        "@tiptap/pm": "^3.29.2",
-        "@tiptap/starter-kit": "^3.29.2",
-        "@tiptap/suggestion": "^3.29.2",
-        "@tiptap/vue-3": "^3.29.2",
-        "@unhead/vue": "^3.3.2",
+        "@tanstack/vue-virtual": "^3.13.36",
+        "@tiptap/core": "^3.31.3",
+        "@tiptap/extension-bubble-menu": "^3.31.3",
+        "@tiptap/extension-code": "^3.31.3",
+        "@tiptap/extension-collaboration": "^3.31.3",
+        "@tiptap/extension-drag-handle": "^3.31.3",
+        "@tiptap/extension-drag-handle-vue-3": "^3.31.3",
+        "@tiptap/extension-floating-menu": "^3.31.3",
+        "@tiptap/extension-horizontal-rule": "^3.31.3",
+        "@tiptap/extension-image": "^3.31.3",
+        "@tiptap/extension-mention": "^3.31.3",
+        "@tiptap/extension-node-range": "^3.31.3",
+        "@tiptap/extension-placeholder": "^3.31.3",
+        "@tiptap/markdown": "^3.31.3",
+        "@tiptap/pm": "^3.31.3",
+        "@tiptap/starter-kit": "^3.31.3",
+        "@tiptap/suggestion": "^3.31.3",
+        "@tiptap/vue-3": "^3.31.3",
+        "@unhead/vue": "^3.4.0",
         "@vueuse/core": "^14.4.0",
         "@vueuse/integrations": "^14.4.0",
         "@vueuse/shared": "^14.4.0",
@@ -3535,12 +3535,12 @@
         "fuse.js": "^7.5.0",
         "hookable": "^6.1.1",
         "knitwork": "^1.3.0",
-        "magic-string": "^1.2.0",
+        "magic-string": "^1.2.3",
         "mlly": "^1.8.2",
-        "motion-v": "^2.4.0",
+        "motion-v": "^2.4.2",
         "ohash": "^2.0.12",
         "pathe": "^2.0.3",
-        "reka-ui": "2.10.3",
+        "reka-ui": "2.10.4",
         "scule": "^1.3.0",
         "tailwind-merge": "^3.6.0",
         "tailwind-variants": "^3.2.2",
@@ -3551,7 +3551,7 @@
         "unplugin-auto-import": "^21.1.0",
         "unplugin-vue-components": "^32.1.0",
         "vaul-vue": "0.4.1",
-        "vue-component-type-helpers": "^3.3.10"
+        "vue-component-type-helpers": "^3.3.11"
       },
       "bin": {
         "nuxt-ui": "cli/index.mjs"
@@ -5686,9 +5686,9 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.31.2.tgz",
-      "integrity": "sha512-TB+8pLk1k+fCpuPQ6vGNNhSRlvIiOks79oWGykCVut2nbRpQ8GsORP9VK6Eahj2fzdQA96UQMIcK7AxoOZG/2w==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.31.3.tgz",
+      "integrity": "sha512-Cz50pvciQrxdSxgTkHOVz0uD0Yl/8Xt0QatGD6ILm47jW8EzyHR9RkUGs/D5IqzXKuVPntfw1ttaT926vXfiRg==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -5696,40 +5696,40 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.31.2.tgz",
-      "integrity": "sha512-1pveNPdqlOp2rtjmJ0Mpo9g/P/B69NdVWgp+6wzvkB5Hz6CRx/SXbAFa4P3/QSQ7D1L9d4tKOmoY/ZsFiYvgkA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.31.3.tgz",
+      "integrity": "sha512-fyY2XMbyDDDfOTQ1Qdrnqa1qwC9DWE4n7AfE0EKQI0G8MfLV8RaDlLDcOZDJ9JbMPY7/Gx7EjyK4NKxSW9n2hQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.31.2.tgz",
-      "integrity": "sha512-Bk9d3nOU2ApGG0ZBBYCQPIKQxIDLPG35DvoH8q4Pw2/lSS2v2FxesyTqoVJriYrECO3sUTiCXJlqvYoKNPthzA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.31.3.tgz",
+      "integrity": "sha512-dIuYhKk8TitKU/FeDpoTeWZhU42YgDN5npgWNjAmMmRktPdoxnH3/wGSiwXlqZgJWjehN7kPWDePWpJeAImGpQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.31.2.tgz",
-      "integrity": "sha512-3KASBe33OhFywqOU5xm29HAtNIgL5mLTaM9OpKRU7aP+5zbz02EdLbiTzhd1RJr1GWDsejjF8HrAf+oirudKrQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.31.3.tgz",
+      "integrity": "sha512-EV6ZnwKc++2OM/OcD54n8s1B7C9LP7GKAtdEPwu0t3BYJf3sG8Ueoinf7SgGPO9oMPg96GneOkDNm1urMV167g==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
@@ -5739,54 +5739,54 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.31.2.tgz",
-      "integrity": "sha512-o5TglfPwYZp/5NQ/fL8MG3k49na29pi2+10GS8kf+rqlYjVXKSI9MDu8GWssn0FZkr+BrIXWQAMtc56CbzJT4A==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.31.3.tgz",
+      "integrity": "sha512-qEyyoPapPef4LO8XKaN83bxtaNzkJ4kFn/IxLnEKd4BJ3Mvi4MH2yJYlyDqwFnMoev4pMA1zBHRAt/C0THRmZw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.31.2"
+        "@tiptap/extension-list": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.31.2.tgz",
-      "integrity": "sha512-oTYlWXk5GPK6BlbK77TNO5/JCGTcZ9SEAuQaPZCHGuGZQV1JT6uHRRH7e9LdPfiG4Qw8AtmKhPTMk6IQplf+ZQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.31.3.tgz",
+      "integrity": "sha512-SzxOqchrD2AcN3uT67PjKmRFEMOU3vNNiwNaamZJUbZrI6Hmy+bvdHJrc3jrIddyyCrAtsnAfRI0cmorW1jGfg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.31.2.tgz",
-      "integrity": "sha512-b1z3eJzuMNLConGnODliojJVV4vLN4LSZC1Rkebe85roFBnC8ROrSr3wwy5IALO4C18wW5fHeBufZCKO0EwVtQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.31.3.tgz",
+      "integrity": "sha512-nvknt4FhyJQjYcvxptmeUlFsIAc8ibua3E5BN4Pim374/9RWepH4cdE9X0/qUTtguHElLx0iKtSIY3rW2qGTFA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-collaboration": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.31.2.tgz",
-      "integrity": "sha512-KS+OLCgX+UpOdRYFHhkJOR6L0eDdzvmhalUJbJFaU+vg+LPMzjstOHWvE0FhbLVYDgcpf0re4VuTP44Adrp1Pg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.31.3.tgz",
+      "integrity": "sha512-JAwOXjeeDYghrPcK57dtvxwn06zcz50mxSSk4PaSdLxM8tkw8+udx+51ewqKKd3WlFof4zyMwUEbO/DGaUdEvw==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -5794,29 +5794,29 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2",
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3",
         "@tiptap/y-tiptap": "^3.0.7",
         "yjs": "^13"
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.31.2.tgz",
-      "integrity": "sha512-YJ+bXwjS+5MOf/73m4ZVgOrrE7OOYqB6r3oYbAWCU8VxGFaNP5YA9a1HJgAYkc2hMmOZ6vqEHXPpaom0mGV7Lg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.31.3.tgz",
+      "integrity": "sha512-EexgmqnyDNyGlISxo7SMrp5MygpJYmqD+0cY5jB6L1U6L4CpKKRWUt8OO1sWzEHDE1+TTvwt+WIFoIWAziOtEA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-drag-handle": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.31.2.tgz",
-      "integrity": "sha512-sekG8inH5c0lK8gpfJsIhsjXm9RDCK7HJVCIrHyNeSyXX7pyd90Ji4YeeM/2alj/EY53ObcAanNG5omfQFyZvg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.31.3.tgz",
+      "integrity": "sha512-2WOcg5wbGTJNlzLzdaw0IQgbzObjs2k55ZYZito3WRsMKZ3BPJK8pj5GOYKnJ7dm6VlKrpP7WmNq3HGpxe5GOA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5827,46 +5827,46 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/extension-collaboration": "3.31.2",
-        "@tiptap/extension-node-range": "3.31.2",
-        "@tiptap/pm": "3.31.2",
+        "@tiptap/core": "3.31.3",
+        "@tiptap/extension-collaboration": "3.31.3",
+        "@tiptap/extension-node-range": "3.31.3",
+        "@tiptap/pm": "3.31.3",
         "@tiptap/y-tiptap": "^3.0.7"
       }
     },
     "node_modules/@tiptap/extension-drag-handle-vue-3": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-vue-3/-/extension-drag-handle-vue-3-3.31.2.tgz",
-      "integrity": "sha512-RaxXyqJuJj5iaawdhAQGq+5/zyqRXi0WEG1UI0A3qvVU4RKC5GESRuZozmDpQmt0OzBLbCvpopNbGTueCMOD0A==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-vue-3/-/extension-drag-handle-vue-3-3.31.3.tgz",
+      "integrity": "sha512-k/8j17rOgSvbR45fJ/0rzcXfWqLl55RVMrytHHb6o7Bvc4qDDIkk7FIGqqcaCBxfZBd7dfo21FebTP1SUeEAVw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-drag-handle": "3.31.2",
-        "@tiptap/pm": "3.31.2",
-        "@tiptap/vue-3": "3.31.2",
+        "@tiptap/extension-drag-handle": "3.31.3",
+        "@tiptap/pm": "3.31.3",
+        "@tiptap/vue-3": "3.31.3",
         "vue": "^3.0.0"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.31.2.tgz",
-      "integrity": "sha512-Vn/Wjp6D0O5rbf6JYi7jWSB1/mLsmlhAwIgFSa/wBMIqHtQ2Yza7O01sgaiErdVb1MkDY3k50KBAZcpeN6afXg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.31.3.tgz",
+      "integrity": "sha512-NWomSfu5CSC7VacnMSDzKT8qm66SzMfZwVPEtwY5bPpRTJgTiT1rNK0neDrrzfMN27MfylGyKWWf7Q5Qf8w/fg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.31.2"
+        "@tiptap/extensions": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.31.2.tgz",
-      "integrity": "sha512-DLjtMDg9kjv7tHFtms4OeZwEsa6tW60jexWMT3rTT4qQ+laqZjeNOYxJ0vwNmM4gDWXKkFifQHwzm13Zq5jv5A==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.31.3.tgz",
+      "integrity": "sha512-rd4VJ9PGSP9Eop8ZTEwaLZcMzMXLuJKe3hUNf58rq+zANpwM+9fI+vB7g9MAc3eXwUNDxNDVACFIL2oeBqpQ3A==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5874,93 +5874,93 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.31.2.tgz",
-      "integrity": "sha512-ko/iP3qFWc+uD+KrKcgpL5J0tlTmyMaD5E8Bu0f3Z1zloWyRprulxwWKFS95VJE7XTxRoXu+d6A6M6Ri2JUQRg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.31.3.tgz",
+      "integrity": "sha512-EBXKb1FrVStsNYCcRGtd9jmzveCvR+eqgg1rVqoONrqFK6U7bga6LN+1dMKroP1kliDVgveYkP3vRYxqw+rFqg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.31.2"
+        "@tiptap/extensions": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.31.2.tgz",
-      "integrity": "sha512-hq8b0KwVufGtdNxxQXhVufhOAlNfrmU73fucNZvrZL+xhmhPzAkulByszsCneeY0MMtwzIyNtSiF0DBH6rgoPg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.31.3.tgz",
+      "integrity": "sha512-QAdCvNO4+yW9ATwsrej11NTkDYFqPLIEQr3ARNrKOK1qaiS7A0fia2SEukb/hrkP3A6mbozhoQt2r2RGUf/DpQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.31.2.tgz",
-      "integrity": "sha512-TASYeQvg/M5ByvTFcVt2aZOJoU2f+H88W4MOq3gNNqORxuxmPEmiKUwJ2q1xjN71YqGy42b26onjoIr2ZU+iJQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.31.3.tgz",
+      "integrity": "sha512-rk5VHMAeQcg06SLauN6EGdD2jc0O2qY8QkZYPd0LxNvLblw2BxBx+lxUQSYwLAT9Ie5914gKIK2YbRyO2Ts3ig==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.31.2.tgz",
-      "integrity": "sha512-6ncBZCcwZc1/FJjfqZTWmFoGbHthNRWZcmKSKuDaljvNKwP5bHo2tLBOZXDJwY19DIjHqg/oBhI1mgxZxDR6LA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.31.3.tgz",
+      "integrity": "sha512-YnHGy2KShRwvCseAmmxl9VP7R0qaj8QMp3DA6DJWZqp7r5gLGvDkAqhedxqqefqsE4Y43hjkBdjtB9Ce78LkIw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-image": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.31.2.tgz",
-      "integrity": "sha512-xnv0QOL8VsZeSJimQWrVA1MBBvAi8iP94pORsLaqAT5TbK6ry6P1I4DA6uk33PnXjnZl56nZDWPvTLWQjFH4Dw==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.31.3.tgz",
+      "integrity": "sha512-wWNG9BOtx2Cg4vwxPVGDIJ5DGX+ETkldeoaFJLB1NXUL4OPUiVTf8cHZ+hdYgJWP704BEB7jQgjlpvdi6VigTg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.31.2.tgz",
-      "integrity": "sha512-LdpaPdfYH0P0S9LVlsZTphzUEmJl8eT+ojruFYKyxHmKhsejs/ppVW+MaIiIiOiZx0gGtxmTMb+iPJ+hu30acg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.31.3.tgz",
+      "integrity": "sha512-ibGvdvAPyfxBMUVNRI43eb9h2/Jka1MRG5GtnGqbcCX/2+Y/y0EOfFrPQPkuYphiWQYyu9+FzPKMB/pjuaLuKQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.31.2.tgz",
-      "integrity": "sha512-9Cajqh7f5jDZtjF5lxnOvAeL80MLql9i362KW0L6RbFaK0+yKGhbkAN41DN2gN7OYtZKkmwop1vExPEvtbeo7Q==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.31.3.tgz",
+      "integrity": "sha512-986wOQzTL9Zr5lf84LCLpm+YOms8A0K39/8DVoqRfebqcOe0/eq4bnztmAlfabOd+kJY92g3AgZERFUx/w+dcw==",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.3.3"
@@ -5970,14 +5970,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-list": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.31.2.tgz",
-      "integrity": "sha512-uaGNd2r/urhV9IJnOqk8t1d4/y/OAR0Wt0D9jtiL2IWDDnkoKvsQKnLms75ajPNz03QM5hFfmil9wHOpbrkFzQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.31.3.tgz",
+      "integrity": "sha512-LoveGnC0FVdCV4jUNBaG1ZA+KWE07+adzV3kGy6uUYFcJEjbVUHTnPDrBOob3IwOSO3sCwIkvQb6EVYeXn/4yg==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -5985,55 +5985,55 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.31.2.tgz",
-      "integrity": "sha512-35eDm4/VtiqtVXD2cjYd+mzEm1WYOLLA9ZHdg6KRDyTMpfSI3NV64VNIakux1wlh4yQNocuWhMsCwDBVQ78vEQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.31.3.tgz",
+      "integrity": "sha512-4QlKOriJJMvg95QJTEsy9BUYPBQ6UvJyb8WURRwdUtQUkkqb8h32lg/eyQUv2FzW9IT1AdUyNZfVaxH64kRfQA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.31.2"
+        "@tiptap/extension-list": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.31.2.tgz",
-      "integrity": "sha512-t+k0QEuFzR/9yBIs36pQrCgfg2gLhJP06stS3k5wpIQrKhnOrJ0W6/vLeMmNzIUFE18ak+/zkLCCDHXaka2WtA==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.31.3.tgz",
+      "integrity": "sha512-If8UOEdDZbPJU6iYTvLtH6DOp2KBy6BKxg9UELL1AevVetGHEF/7lW8hP50Gn1tHMVpPRqmhSzVrJRpEJJgb/Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.31.2"
+        "@tiptap/extension-list": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-mention": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.31.2.tgz",
-      "integrity": "sha512-6gwNXsTGc+/sG0ZrASuZHcnZJL5pDr8plIPcul2m/S7XJrMY8kvrmMFLquYkmVEzna0pJ7s4kuIXN+VqxhkLeg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.31.3.tgz",
+      "integrity": "sha512-ygOPc3nQijSMUTbEdMeng12P1szk3znubA9xNi84f31VnR18VjmU0we8SIOSSVwDfm1GppSjRER2qHmX/wGIIw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2",
-        "@tiptap/suggestion": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3",
+        "@tiptap/suggestion": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-node-range": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.31.2.tgz",
-      "integrity": "sha512-jTKNjLr6PPz430GcXKDwkoG0CKfM7UibaWFteFnsE/T9HHtjhc7r15wrttGeTEXInsI/QQVoLtNC506xVCpiXQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.31.3.tgz",
+      "integrity": "sha512-8/CKctvTNmzkPkqC9wxVY4TVhOax5WkqiImkvMb3Qv+OJgKC0pTlAhSS+ks3YYTbbmJuCYvHef3QuGiwRnu9gw==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -6041,92 +6041,92 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.31.2.tgz",
-      "integrity": "sha512-E6PDRUx0bkyMq03E1BR/b62joaw2BaobnXh52MDE5y38YKxrmvmHJmXs/j1Ci6mADHfYsh6ZCSh+H3UjIMfhqQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.31.3.tgz",
+      "integrity": "sha512-mp3g11NgA/PYu8rj7J7Ez3l4qBy6WfTSmHIG4PZvEGG5w2oUAIkgb9DU7nPPzjmeme27oazFYZw+AtZA0+u4tw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "3.31.2"
+        "@tiptap/extension-list": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.31.2.tgz",
-      "integrity": "sha512-UKhRMSM0WAes+ULAj6JQi9Iq0rWodn1Hrxybqj+Ezi8AS3o8fa+K3CDRgqKb1TKuqOs1aMTJv1h7RbqOp5jnTw==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.31.3.tgz",
+      "integrity": "sha512-+iPku7wJfy5hbNDNLX8dveFtYVsZMmh7vztjuq8hT3mipSC4IByDehDbU8fzUCjfXiEzmI7mQn7c8LGmHULuzA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-placeholder": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.31.2.tgz",
-      "integrity": "sha512-/lzGxvpBnVdQnU9y/TspN2JpBaHx53sAPjpcQpS8tJ/TTd1uurcQt2I7bT6T6SiaEorKk2V0zXR2790H60QRLw==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.31.3.tgz",
+      "integrity": "sha512-9jYtR8ELEw7GVaruyrm4oFkPcjig9Q+crc+dpmarhBNXUmxagCdlhVzNwCJ2WJRzvBAtx59sEYqNTU38Wx8S3A==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "3.31.2"
+        "@tiptap/extensions": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.31.2.tgz",
-      "integrity": "sha512-w78sCBkTihmKB21bdTKYfaLwiSW6Gzq+0TixlrOR90wR4uA2hN9v8ivDEaoLB4/wIMOQvbQsAwawg6XSMmahkQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.31.3.tgz",
+      "integrity": "sha512-G29bhKttYwcKHT+BI6emWVFol3RO/gUXxQVcmr/iT8LXXy7j8J6HFUnsKM+Kg5YlP1rxMRgsa65dbrQVahZi0A==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.31.2.tgz",
-      "integrity": "sha512-Ktr+Sn6fTpIUDfVp4GSZJZwoAFgM3yvav0+PT8LHYi7wFl96L9VtxDrT+c/Jx1iqpcH59NWDYcZKDiDGyV8M8w==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.31.3.tgz",
+      "integrity": "sha512-gdsWtF+taeaCu6V+5Ct10fGo0ACUy1GnYtbb+mcathBt8OqbT+Ws60p/yEmKesBDz2Hn+B5IcWy6+2BBZl5ZTg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.31.2.tgz",
-      "integrity": "sha512-8XNTcr6+26rPOPdmycPRo1F+bSUdbXMkjm1Hy+iPdOXgVSzixSIGM9t/lYltsgx8WAoXzYezWJIPinDaUkAHBQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.31.3.tgz",
+      "integrity": "sha512-HghdJaOwRqYzsAxqSyNyb+IWyOMcdCl8IoiBETA9BZCJAqdXzFLcuWp7CqCqJPam9dgkWosSoHqTCAO4nTBfpw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2"
+        "@tiptap/core": "3.31.3"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.31.2.tgz",
-      "integrity": "sha512-CTOs3DiSV+hY8ipLS4rdP7X7MJUaPnDR81ZiPWJunk3MP+UZeBey3L6v/ky0SbZYQzJcl5X115uNNYXsYaatJg==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.31.3.tgz",
+      "integrity": "sha512-8sJNPGGUe8f3aDojcOW5cfVL7I5NrBbE0UWxG08qoi9Tea6qWbvQJsCR9tsrOapr/DaLr3kpbGZ9s1gEEfcNcA==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -6134,14 +6134,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/markdown": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.31.2.tgz",
-      "integrity": "sha512-mSyy4nlqVBXW4cP6ZYVAFfizwBhUDqFo7lRyRBF8vcBYXi3SpGkqFeNs9BcoJ6TRpPzocDnqt/+zcSBA8BXcaQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.31.3.tgz",
+      "integrity": "sha512-rBbYSxasseUoaBo15C8Yoaqafo7mJJzxwAwV9Z1OpLBvOroW9nQ0EbOdqaSYRw3/d9pP71B/3LNSzKyfyy+dpQ==",
       "license": "MIT",
       "dependencies": {
         "marked": "^17.0.1"
@@ -6151,8 +6151,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/markdown/node_modules/marked": {
@@ -6168,9 +6168,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.31.2.tgz",
-      "integrity": "sha512-4OU/7ZIhA2ZfENB9c6TDRrjQJb+SoEwQmZSuy1Wyx4fNcGAN7+SPPICc0Hew1d7VlDgiJ2dKt6oa8iluSAsMBQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.31.3.tgz",
+      "integrity": "sha512-sZime0SWsz/k62W2WvHx5Ig7G2h7kVhrrmnqy+wEgIHfDwEfOlelRjaWCiBCFlF7dxGUntJusCh9FxlLhni0Ag==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6194,35 +6194,35 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.31.2.tgz",
-      "integrity": "sha512-oMw5Kxcqkp/ehfHVxBhJ8L4MK/yaPF55H4hU74kLzVT9G1lRYz22hHAOF3s8NJ4dDf6GUXvKnfXMNLsypaR07Q==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.31.3.tgz",
+      "integrity": "sha512-WKof9RewdmGHvWJ1wn0/HVNG2mV+HOgVRyJkKekuM9fgr6BZAAH/xZsWE1eon+94JnQ+KtK2ThydXQM/qc6b2A==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "3.31.2",
-        "@tiptap/extension-blockquote": "3.31.2",
-        "@tiptap/extension-bold": "3.31.2",
-        "@tiptap/extension-bullet-list": "3.31.2",
-        "@tiptap/extension-code": "3.31.2",
-        "@tiptap/extension-code-block": "3.31.2",
-        "@tiptap/extension-document": "3.31.2",
-        "@tiptap/extension-dropcursor": "3.31.2",
-        "@tiptap/extension-gapcursor": "3.31.2",
-        "@tiptap/extension-hard-break": "3.31.2",
-        "@tiptap/extension-heading": "3.31.2",
-        "@tiptap/extension-horizontal-rule": "3.31.2",
-        "@tiptap/extension-italic": "3.31.2",
-        "@tiptap/extension-link": "3.31.2",
-        "@tiptap/extension-list": "3.31.2",
-        "@tiptap/extension-list-item": "3.31.2",
-        "@tiptap/extension-list-keymap": "3.31.2",
-        "@tiptap/extension-ordered-list": "3.31.2",
-        "@tiptap/extension-paragraph": "3.31.2",
-        "@tiptap/extension-strike": "3.31.2",
-        "@tiptap/extension-text": "3.31.2",
-        "@tiptap/extension-underline": "3.31.2",
-        "@tiptap/extensions": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/extension-blockquote": "3.31.3",
+        "@tiptap/extension-bold": "3.31.3",
+        "@tiptap/extension-bullet-list": "3.31.3",
+        "@tiptap/extension-code": "3.31.3",
+        "@tiptap/extension-code-block": "3.31.3",
+        "@tiptap/extension-document": "3.31.3",
+        "@tiptap/extension-dropcursor": "3.31.3",
+        "@tiptap/extension-gapcursor": "3.31.3",
+        "@tiptap/extension-hard-break": "3.31.3",
+        "@tiptap/extension-heading": "3.31.3",
+        "@tiptap/extension-horizontal-rule": "3.31.3",
+        "@tiptap/extension-italic": "3.31.3",
+        "@tiptap/extension-link": "3.31.3",
+        "@tiptap/extension-list": "3.31.3",
+        "@tiptap/extension-list-item": "3.31.3",
+        "@tiptap/extension-list-keymap": "3.31.3",
+        "@tiptap/extension-ordered-list": "3.31.3",
+        "@tiptap/extension-paragraph": "3.31.3",
+        "@tiptap/extension-strike": "3.31.3",
+        "@tiptap/extension-text": "3.31.3",
+        "@tiptap/extension-underline": "3.31.3",
+        "@tiptap/extensions": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       },
       "funding": {
         "type": "github",
@@ -6230,9 +6230,9 @@
       }
     },
     "node_modules/@tiptap/suggestion": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.31.2.tgz",
-      "integrity": "sha512-eufwrI5Hc9ZYmTJexhe6efFTRbL6y75wD7L2VgsjqWPdU7e9j4FFBZ214fIqzCR8BuUm6doPzStYU/JMOJNxDw==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.31.3.tgz",
+      "integrity": "sha512-z1OQ/Yx6seMZehi1AcmNkyJ8qkHQzybArmCyRdmreS4YL9C4bPMBe5lbMfFsArYs+KD5JyHwps5j7J/YE5BIuw==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -6241,14 +6241,14 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2"
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
       }
     },
     "node_modules/@tiptap/vue-3": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.31.2.tgz",
-      "integrity": "sha512-S3WqUbPiNlYHLupFfhCBnCxLYn0WYK+YtpwCehaAknannt/zXgm+3Sx4DL78uSSi+w83T55b5tIzrIYIs1yVrQ==",
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.31.3.tgz",
+      "integrity": "sha512-PNt0+rm7BXzhe/U+xlNnXBeJ6t9x2mE3902VXeIeEBxu5CrYLCJ0a5yHrof1jU3KwJrLOe/BtlGWjbq4qnTTfQ==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -6256,13 +6256,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.31.2",
-        "@tiptap/extension-floating-menu": "^3.31.2"
+        "@tiptap/extension-bubble-menu": "^3.31.3",
+        "@tiptap/extension-floating-menu": "^3.31.3"
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.31.2",
-        "@tiptap/pm": "3.31.2",
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3",
         "vue": "^3.0.0"
       }
     },
@@ -12783,9 +12783,9 @@
       "license": "MIT"
     },
     "node_modules/motion-v": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-2.4.0.tgz",
-      "integrity": "sha512-kRDGMAZk3nvdjEO36Wo6pezSEIStGXGhVFiwo1QkUDsUg8mB5igjYPXyece8wtu2DrHhmFfA6Y1nOz07+5QH4A==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-2.4.2.tgz",
+      "integrity": "sha512-I3+pa3s1iCtk1hS7En7+ZYH1E165FQHAC4ZRjv6wsQPkd7wqyE+ooOPqal3FXQOCCYesmUs5BS6KLx4Fz83m+A==",
       "license": "MIT",
       "dependencies": {
         "framer-motion": "^13.1.0",
@@ -14405,9 +14405,9 @@
       }
     },
     "node_modules/reka-ui": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.10.3.tgz",
-      "integrity": "sha512-nJGZbwcha8AcP2wbnjodfzsciTKBqp1mIzepC9Pi2xDI/YK3++ej3vpJOSPyxqrkq1Oorj4K+BdJkbVCV6x6ag==",
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.10.4.tgz",
+      "integrity": "sha512-kbS5GAbkHkYj0EVKAg5ZPEPndhBjeUFSa1Aq5m5ftQwyHnB1v5tw8X6fcwfKH/ry3StPXblMWM1DW82MVS71cw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.6.13",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@capacitor/android": "8.3.4",
     "@capacitor/core": "8.3.4",
     "@iconify-json/lucide": "^1.2.101",
-    "@nuxt/ui": "^4.4.0",
+    "@nuxt/ui": "^4.11.1",
     "@simplewebauthn/browser": "^13.2.2",
     "@tauri-apps/api": "~2.11.0",
     "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
Updates `@nuxt/ui` from 4.11.0 to 4.11.1, a patch release with no breaking changes. The declared range moves from `^4.4.0` to `^4.11.1` so the manifest states the floor we actually rely on.

40 lockfile entries change, all of them `@nuxt/ui` and its `@tiptap` / `reka-ui` / `motion-v` subtree.

### Why this one matters

The Slider fix in this release is a bug we were actually exposed to. 4.11.0 passed the component's `emits` into `useForwardProps`, so `SliderRoot` fired `update:modelValue` a second time with its own raw value on top of the normalised one — a single-thumb slider emitted both `71` and `[71]`.

Every `USlider` handler that reads `$event` directly was in the blast radius, for example:

```js
// src/components/tabs/MotorsTab.vue:1596
const onMotorValueUpdate = (index, val) => {
    motorValues.value[index] = val;   // could receive [1500] instead of 1500
    onMotorSliderChange();
};
```

4.11.1 drops the duplicate forward, so single-thumb sliders emit one number and multi-thumb sliders one array.

### Other fixes touching components we use

- `Table` excludes hidden columns from colspan
- `SelectMenu` no longer focuses its search input when `autofocus: false`
- `InputNumber` works uncontrolled with only a default value
- `Checkbox` / `RadioGroup` use `border-default` on the `card` variant, and `flex-wrap` on `list` / `card`

Full changelog: https://github.com/nuxt/ui/compare/v4.11.0...v4.11.1

### Verification

- `npm run lint` — clean
- `npm run test` — 1255 tests across 105 files pass
- `npm run build` — clean
- Lockfile idempotent under a repeat `npm install --ignore-scripts`, so the `Lockfile in sync` job stays green
- Lockfile shape unchanged (49 `"peer": true` markers before and after), so no npm-version churn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Nuxt UI dependency to version 4.11.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->