### PR TITLE
fix(osd): show "Save and Reboot" when a port setting changed

### DIFF
--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -576,7 +576,7 @@
                     {{ $t("osdSetupFontManagerTitle") }}
                 </UButton>
                 <UFieldGroup size="xs" orientation="horizontal" class="flex!">
-                    <UButton @click="saveConfig()" :disabled="!portsOrConfigDirty || isSaving" size="xs">
+                    <UButton @click="savePrimaryAction()" :disabled="!portsOrConfigDirty || isSaving" size="xs">
                         {{ saveButtonText }}
                     </UButton>
                     <UDropdownMenu v-slot="{ open }" :items="saveMenuItems" :content="{ align: 'end', side: 'top' }">
@@ -643,8 +643,12 @@ const {
 
 const customTextPortAssigned = computed(() => customTextPortIdentifier.value !== PORT_NONE);
 
+// A UART assignment only takes effect at serial init, so a pending port change turns the primary
+// button into Save and Reboot instead of a plain Save.
+const portSettingsChanged = computed(() => osdPortChanged.value || customTextPortChanged.value);
+
 // A port-only change still has to enable Save; the OSD store's dirty state cannot see these.
-const portsOrConfigDirty = computed(() => osdStore.dirty || osdPortChanged.value || customTextPortChanged.value);
+const portsOrConfigDirty = computed(() => osdStore.dirty || portSettingsChanged.value);
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
 import UiBox from "@/components/elements/UiBox.vue";
@@ -690,7 +694,9 @@ const logoImageSizeParams = {
     logoWidthPx: FONT.constants.SIZES.CHAR_WIDTH * 24,
     logoHeightPx: FONT.constants.SIZES.CHAR_HEIGHT * 4,
 };
-const { label: saveButtonText, flash: flashSaveButtonText } = useTransientLabel(() => i18n.getMessage("osdSetupSave"));
+const { label: saveButtonText, flash: flashSaveButtonText } = useTransientLabel(() =>
+    i18n.getMessage(portSettingsChanged.value ? "osdSetupSaveReboot" : "osdSetupSave"),
+);
 const saveMenuItems = computed(() => [
     [
         {
@@ -1460,6 +1466,9 @@ const saveAndRebootConfig = async () => {
     await saveConfig();
     await reboot();
 };
+
+// The primary button does what its label says: with a port change pending it saves and reboots.
+const savePrimaryAction = () => (portSettingsChanged.value ? saveAndRebootConfig() : saveConfig());
 
 // Font Manager
 const fontCharacterUrls = computed(() => {


### PR DESCRIPTION
### Problem

The OSD tab's port rows (OSD display port, custom text port) assign UARTs. A UART assignment only takes effect at serial init, so it needs a reboot to bite — but the primary button always read **Save**, with **Save and Reboot** tucked away in the dropdown. Changing only a port therefore looked applied while nothing had actually changed on the board.

### Fix

The primary button now follows the pending port state:

- New `portSettingsChanged` computed — true when the OSD display port or the custom text port row has a pending change. `portsOrConfigDirty` reuses it instead of repeating the two flags.
- Label resolves to **Save and Reboot** while a port change is pending, **Save** otherwise. The transient "Saved" flash still overrides it, and the label reverts once the ports reload clean.
- Click routes to `saveAndRebootConfig()` when a port change is pending, `saveConfig()` otherwise — so the action matches what the label promises.

The dropdown keeps both explicit **Save** and **Save and Reboot** entries, so a reboot is still reachable when no port changed.

### Testing

- Change only the OSD display port or the custom text port → button reads **Save and Reboot** and reboots after saving.
- Change any other OSD setting → button reads **Save** and saves without rebooting.
- After a save, the button flashes "Saved" and settles back to **Save**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The OSD settings Save button now displays “Save and Reboot” when UART port changes require a reboot to take effect.
  - Port changes use the save-and-reboot flow, while unchanged settings continue to use the standard “Save” action.

- **Bug Fixes**
  - The capacity alarm is now hidden when battery profiles are available on supported API versions, reducing unnecessary alarm notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->