### PR TITLE
Document excluded Betaflight 10.10.0 DEB

### DIFF
--- a/ADD_BETAFLIGHT_DEB.md
+++ b/ADD_BETAFLIGHT_DEB.md
@@ -1,0 +1,7 @@
+Add Betaflight DEB (placeholder)
+
+The Betaflight Configurator 10.10.0 amd64 .deb installer was downloaded during this session but excluded from the branch due to GitHub's file size limits (>100 MB).
+
+This placeholder documents that the binary exists locally and recommends uploading the installer as a GitHub Release asset or hosting it outside the repository.
+
+If you'd like the binary included via Git LFS or uploaded to Releases, say which option to use.


### PR DESCRIPTION
Document that the Betaflight Configurator 10.10.0 amd64 .deb installer was downloaded for local use but excluded from the repository because GitHub rejects files larger than 100 MB.

The change adds a concise placeholder recommending GitHub Releases, CI artifacts, or Git LFS for distributing the binary. No application source code is changed.

The repository PR guidance was reviewed; no issue-closing reference applies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for distributing the Betaflight Configurator 10.10.0 Debian installer outside the repository due to file-size limitations.
  - Documents options for hosting the installer as a release asset or through Git LFS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->