### PR TITLE
fix(status-bar): Display forced battery cell count when available 

### DIFF
--- a/src/components/quad-status/BatteryIcon.vue
+++ b/src/components/quad-status/BatteryIcon.vue
@@ -20,6 +20,10 @@ export default defineComponent({
             type: Number,
             default: 0,
         },
+        cellCount: {
+            type: Number,
+            default: 0,
+        },
         vbatmaxcellvoltage: {
             type: Number,
             default: 1,
@@ -34,7 +38,9 @@ export default defineComponent({
         },
     },
     setup(props) {
-        const nbCells = computed(() => estimateCellCount(props.voltage, props.vbatmaxcellvoltage));
+        const nbCells = computed(() =>
+            props.cellCount > 0 ? props.cellCount : estimateCellCount(props.voltage, props.vbatmaxcellvoltage),
+        );
 
         const min = computed(() => {
             return props.vbatwarningcellvoltage * nbCells.value;

--- a/src/components/quad-status/BatteryLegend.vue
+++ b/src/components/quad-status/BatteryLegend.vue
@@ -9,12 +9,13 @@ import { NO_BATTERY_VOLTAGE_MAXIMUM, estimateCellCount } from "../../js/utils/ba
 
 const props = defineProps({
     voltage: { type: Number, default: 0 },
+    cellCount: { type: Number, default: 0 },
     vbatmaxcellvoltage: { type: Number, default: 1 },
     compact: { type: Boolean, default: false },
 });
 
 const reading = computed(() => {
-    const nbCells = estimateCellCount(props.voltage, props.vbatmaxcellvoltage);
+    const nbCells = props.cellCount > 0 ? props.cellCount : estimateCellCount(props.voltage, props.vbatmaxcellvoltage);
     const cellsText = props.voltage > NO_BATTERY_VOLTAGE_MAXIMUM ? `${nbCells}S` : "USB";
     return `${props.voltage.toFixed(2)}V (${cellsText})`;
 });

--- a/src/components/status-bar/StatusBar.vue
+++ b/src/components/status-bar/StatusBar.vue
@@ -67,6 +67,7 @@
                 <BatteryIcon
                     compact
                     :voltage="analog.voltage ?? 0"
+                    :cell-count="batteryState.cellCount ?? 0"
                     :vbatmaxcellvoltage="batteryConfig.vbatmaxcellvoltage ?? 1"
                     :vbatwarningcellvoltage="batteryConfig.vbatwarningcellvoltage ?? 1"
                     :battery-state="batteryState.batteryState"
@@ -74,6 +75,7 @@
                 <BatteryLegend
                     compact
                     :voltage="analog.voltage ?? 0"
+                    :cell-count="batteryState.cellCount ?? 0"
                     :vbatmaxcellvoltage="batteryConfig.vbatmaxcellvoltage ?? 1"
                 />
 


### PR DESCRIPTION
### Issue
The battery cell count displayed in the status bar was calculated from the measured voltage and vbatmaxcellvoltage.

When force_battery_cell_count was set via the CLI, the displayed count could differ from the configured value.

### Fix
Use the firmware-reported battery cell count when available for both the battery legend and icon.

Voltage-based estimation remains as a fallback when no cell count is reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Battery status indicators now use the reported battery cell count when available.
  - Battery cell counts are estimated from voltage when no explicit count is provided, improving battery status accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->