### PR TITLE
fix(blackbox): show all flight mode flags when bit 31 is set

### DIFF
--- a/src/blackbox-viewer/flightlog_fields_presenter.js
+++ b/src/blackbox-viewer/flightlog_fields_presenter.js
@@ -201,7 +201,9 @@ FlightLogFieldPresenter.presentFlags = function (flags, flagNames) {
             result += flagNames[i];
         }
 
-        flags >>= 1;
+        // `>>>` and not `>>`: a signed shift coerces to int32, so a set bit 31
+        // would turn the value negative and end the loop, hiding the rest.
+        flags >>>= 1;
         i++;
     }
 

--- a/test/js/blackbox_fields_presenter.test.js
+++ b/test/js/blackbox_fields_presenter.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { FlightLogFieldPresenter } from "../../src/blackbox-viewer/flightlog_fields_presenter.js";
+import {
+    adjustFieldDefsList,
+    FIRMWARE_TYPE_BETAFLIGHT,
+    FLIGHT_LOG_FLIGHT_MODE_NAME,
+} from "../../src/blackbox-viewer/flightlog_fielddefs.js";
+
+// `flightModeFlags` carries the firmware's rcModeActivationMask, so bit 31 is a real
+// mode: PREARM on 2025.12, CRASHFLIP on 2026.6. presentFlags used a signed `>>=`,
+// which coerces to int32 and turns a set bit 31 negative, ending the `flags > 0` loop
+// after one iteration and silently hiding every other flag. A pilot flying 2025.12
+// with a toggle PREARM switch sees the mode field read "ARM" for the whole log.
+// These pin the high bit down.
+
+// A stand-in table, long enough for a 32-bit field like every resolved table is.
+const NAMES = Array.from({ length: 40 }, (_, i) => `B${i}`);
+
+describe("presentFlags", () => {
+    it("reports no flags for zero", () => {
+        expect(FlightLogFieldPresenter.presentFlags(0, NAMES)).toBe("0");
+    });
+
+    it("decodes low bits", () => {
+        expect(FlightLogFieldPresenter.presentFlags(0x00100001, NAMES)).toBe("B0|B20");
+    });
+
+    it("keeps the remaining flags when bit 31 is set", () => {
+        expect(FlightLogFieldPresenter.presentFlags(0x80100001, NAMES)).toBe("B0|B20|B31");
+    });
+
+    it("does not report an empty set when only high bits are set", () => {
+        expect(FlightLogFieldPresenter.presentFlags(0x80000000, NAMES)).toBe("B31");
+        expect(FlightLogFieldPresenter.presentFlags(0x80000002, NAMES)).toBe("B1|B31");
+    });
+
+    it("decodes every bit of a full mask", () => {
+        const all = Array.from({ length: 32 }, (_, i) => `B${i}`).join("|");
+        expect(FlightLogFieldPresenter.presentFlags(0xffffffff, NAMES)).toBe(all);
+    });
+
+    it("names the real 2025.12 bit 31 alongside ARM", () => {
+        adjustFieldDefsList(FIRMWARE_TYPE_BETAFLIGHT, "2025.12.0");
+        expect(FlightLogFieldPresenter.presentFlags(0x80000001, FLIGHT_LOG_FLIGHT_MODE_NAME)).toBe("ARM|PREARM");
+    });
+
+    // 2026.6 inserts AUTOPILOT after GPSRESCUE, which shifts the table up one and
+    // moves FLIPOVERAFTERCRASH (firmware BOXCRASHFLIP) into bit 31.
+    it("names the real 2026.6 bit 31 alongside ARM", () => {
+        adjustFieldDefsList(FIRMWARE_TYPE_BETAFLIGHT, "2026.6.0");
+        expect(FlightLogFieldPresenter.presentFlags(0x80000001, FLIGHT_LOG_FLIGHT_MODE_NAME)).toBe(
+            "ARM|FLIPOVERAFTERCRASH",
+        );
+    });
+});

--- a/test/js/blackbox_fields_presenter.test.js
+++ b/test/js/blackbox_fields_presenter.test.js
@@ -1,3 +1,24 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { describe, expect, it } from "vitest";
 import { FlightLogFieldPresenter } from "../../src/blackbox-viewer/flightlog_fields_presenter.js";
 import {


### PR DESCRIPTION
`presentFlags()` walks the mask with a **signed** right shift:

```js
while (flags > 0) { ... flags >>= 1; }
```

`>>=` coerces to int32, so once bit 31 is set the value turns negative, the loop exits after one iteration, and every remaining flag is dropped silently. The parser hands the mask over positive (`readUnsignedVB` returns `result >>> 0`), so the loop is always entered and the truncation is real rather than theoretical.

### Bit 31 is a real mode

`blackbox.c` memcpys `rcModeActivationMask` into a `uint32_t`, so the bit index is the `boxId_e` index:

| firmware | bit 31 |
|---|---|
| 4.0 – 4.5 | `BOXPARALYZE` |
| 2025.12 | `BOXPREARM` |
| 2026.6 | `BOXCRASHFLIP` (`FLIPOVERAFTERCRASH` in the viewer's table) |

The clearest symptom is on 2025.12 with a toggle PREARM switch: the bit stays set for the whole flight, so the values panel reads `ARM` from start to finish. A frame with only high bits set reads `0`, which is indistinguishable from no flags at all.

```
                               before        after
armed + airmode (no prearm)    ARM|AIRMODE   ARM|AIRMODE
armed + airmode + PREARM       ARM           ARM|AIRMODE|PREARM
PREARM only                    0             PREARM
```

### Behaviour note

This makes bit 31 visible for the first time, and the 4.x table has no `PARALYZE` entry, so a 4.x log with it set will now read `USER1`. That is pre-existing table drift and still an improvement on hiding every other active mode. I'll follow up with the table fix separately, once the version gate is checked against firmware history.

### Scope

`flightModeFlags` and `stateFlags` both route through `presentFlags`, so this affects the values panel, the stats min/max/mean and the status bar. CSV export writes raw numerics and never reaches the presenter; the graph's event annotations use `presentChangeEvent`, which already loops to 32 with `(1 << i)`. Both were correct. `stateFlags` is a `uint8` field, so its behaviour is unchanged.

Every resolved name table has more than 32 entries (36 on pre-3.3 through 43 on 2026.6), so scanning the full word cannot produce `undefined`.

### Test

Added `test/js/blackbox_fields_presenter.test.js`, including real-table cases for 2025.12 and 2026.6 driven through `adjustFieldDefsList`. It fails on the unpatched code (5 of 7 cases), so it pins the bug rather than confirming the fix.

The standalone `blackbox-log-viewer` has the same line; happy to send a matching PR there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected flight log flag decoding so flags set at higher bit positions are displayed instead of being omitted.
  * Improved compatibility with firmware versions that use high-order flight mode flags.

* **Tests**
  * Added coverage for low- and high-order flags, full flag masks, empty values, and firmware-specific mode mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->