### PR TITLE
fix(pid-tuning): keep loaded rates when switching rate profiles

### DIFF
--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -385,6 +385,10 @@ const ratesType = computed({
                 confirm: () => {
                     dialog.close();
                     FC.RC_TUNING.rates_type = value;
+                    // Only a user-initiated type change resets the rates to that type's defaults.
+                    // A type change coming from MSP (profile switch, reconnect) must keep the
+                    // values the FC just sent us.
+                    setDefaultsForRatesType(value);
                 },
                 cancel: () => {
                     dialog.close();
@@ -1829,13 +1833,6 @@ const setDefaultsForRatesType = (type) => {
             break;
     }
 };
-
-// Watch for rates type changes and set default values (only on an actual user change, not on initial mount)
-watch(ratesType, (newType, oldType) => {
-    if (oldType !== undefined && newType !== oldType) {
-        setDefaultsForRatesType(newType);
-    }
-});
 
 onUnmounted(() => {
     // Stop rendering immediately

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -1666,33 +1666,36 @@ function renderModel(timestamp) {
     animationFrameId = requestAnimationFrame(renderModel);
 }
 
-// Watch for changes and redraw
-// Watch for changes and redraw
-watch([ratesType, rcRate, rcRatePitch, rcRateYaw, rollRate, pitchRate, yawRate, rcExpo, rcPitchExpo, rcYawExpo], () => {
-    nextTick(() => {
-        drawRateCurves();
-    });
-});
+// Watch for changes and redraw. The rate limits are read straight off FC.RC_TUNING because
+// they have no scaled computed, but they feed both the curve and the max-velocity labels.
+watch(
+    [
+        ratesType,
+        rcRate,
+        rcRatePitch,
+        rcRateYaw,
+        rollRate,
+        pitchRate,
+        yawRate,
+        rcExpo,
+        rcPitchExpo,
+        rcYawExpo,
+        () => FC.RC_TUNING.roll_rate_limit,
+        () => FC.RC_TUNING.pitch_rate_limit,
+        () => FC.RC_TUNING.yaw_rate_limit,
+    ],
+    () => {
+        nextTick(() => {
+            drawRateCurves();
+        });
+    },
+);
 
 watch([throttleMid, throttleHover, throttleExpo, throttleLimitType, throttleLimitPercent], () => {
     nextTick(() => {
         drawThrottleCurve();
     });
 });
-
-// Watch for FC.RC_TUNING to become available (initial data load)
-watch(
-    () => FC.RC_TUNING,
-    (newValue) => {
-        if (newValue && newValue.rates_type !== undefined) {
-            nextTick(() => {
-                drawRateCurves();
-                drawThrottleCurve();
-            });
-        }
-    },
-    { immediate: true },
-);
 
 onMounted(() => {
     // Initialize 3D Model for rates preview


### PR DESCRIPTION
Fixes #5518

## Problem

Switching rate profiles in PID Tuning left both the rate values **and** the preview graph wrong until you selected the profile a second time or left the tab and came back.

## Root cause

Not a stale canvas — the values themselves were being overwritten right after they loaded.

`RatesSubTab.vue` had:

```js
watch(ratesType, (newType, oldType) => {
    if (oldType !== undefined && newType !== oldType) {
        setDefaultsForRatesType(newType);   // overwrites RC_RATE / *_rate / *_EXPO
    }
});
```

That watcher can't tell *why* `rates_type` changed. It fired for both:

- the user picking a new type in the dropdown — intended, reset to that type's defaults
- `MSP_RC_TUNING` arriving after a rate profile switch (`MSPHelper.js:519` writes the new `rates_type`) — **not** intended, it stomped the nine rate values the FC had just sent

On the reporter's config, selecting `AIR` (BETAFLIGHT, rc_rate 1.27 / srate 0.72 / expo 0.40) loaded correctly and was then overwritten with the BETAFLIGHT defaults 1.0 / 0.7 / 0. The graph wasn't stale, it faithfully drew the clobbered values.

Both workarounds follow from this: re-selecting the same profile reloads it with `rates_type` unchanged so the watcher never fires, and re-entering the tab remounts with `oldType === undefined`. The bug only shows on a switch that crosses rate types, which is why the reporter's identical `ANGLE`/`HORIZON` profiles looked fine.

## Fix

The confirmation dialog in the `ratesType` setter is the only non-MSP writer of `rates_type`, so apply the defaults there and drop the ambiguous watcher.

Redraws are unaffected — `ratesType` and the scaled value computeds are already sources of the `drawRateCurves()` watch, so both the user path and the MSP path still redraw.

## Also in this PR

Two latent issues found in the same file while tracing this, neither of which causes #5518:

- `watch(() => FC.RC_TUNING, ...)` compared the object reference, which `MSPHelper` only ever mutates in place and never reassigns. It therefore only ever ran via its `immediate: true`, during setup, before the canvas refs existed. Removed — `onMounted` already performs the initial draw.
- `roll/pitch/yaw_rate_limit` were missing from the `drawRateCurves()` watch sources, so a profile differing only in rate limits would not redraw the curve or refresh the max-velocity labels. Added.

## Testing

- `npm run test` — 1283 tests pass
- `npm run lint` + `vue-tsc --noEmit` clean
- Manually: switch between an Actual-rates profile and a Betaflight-rates profile, values and curve are now correct on the first selection. Changing rates type from the dropdown still resets to that type's defaults after confirming the dialog, and cancelling still leaves everything untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rate-type defaults are now applied only after a user confirms the change, preventing unintended adjustments during passive updates.
  - Rate curves now refresh when roll, pitch, or yaw rate limits change.
  - Curve rendering is more consistent when tuning data updates, improving the accuracy of displayed rate settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->