### PR TITLE
chore(debug): regenerate the debug tables against firmware master

### DIFF
--- a/src/js/debug_fields_table.ts
+++ b/src/js/debug_fields_table.ts
@@ -4,7 +4,7 @@
  * Generator    : `scripts/generate-debug-modes.mjs`
  * Source       : https://github.com/betaflight/betaflight (`//!<` annotations on the DEBUG_SET() call sites)
  * Firmware refs:
- *   API 1.49.0  d58d69e057 2026-09-07  (494 annotated fields)
+ *   API 1.49.0  f5fb2717b8 2026-09-12  (498 annotated fields)
  */
 
 /**
@@ -145,6 +145,12 @@ export const FIRMWARE_DEBUG_FIELDS: FirmwareDebugFields = Object.freeze({
             5: Object.freeze({ label: "Altitude D Term", unit: "us", scale: 1 }),
             6: Object.freeze({ label: "Altitude A Term", unit: "us", scale: 1 }),
             7: Object.freeze({ label: "Altitude Feedforward Term", unit: "us", scale: 1 }),
+        }),
+        AUTOPILOT_HEADING: Object.freeze({
+            0: Object.freeze({ label: "Aircraft Heading", unit: "deg", scale: 0.1 }),
+            1: Object.freeze({ label: "Target Heading", unit: "deg", scale: 0.1 }),
+            2: Object.freeze({ label: "Heading Error", unit: "deg", scale: 0.1 }),
+            3: Object.freeze({ label: "Yaw Rate Setpoint", unit: "dps", scale: 0.1 }),
         }),
         AUTOPILOT_PID: Object.freeze({
             0: Object.freeze({ label: "Velocity (dbg-axis)", unit: "cm/s", scale: 1 }),

--- a/src/js/debug_modes_table.ts
+++ b/src/js/debug_modes_table.ts
@@ -9,7 +9,7 @@
  *   API 1.46.0  5fd38528ba 2024-05-04  (90 modes)
  *   API 1.47.0  c120dd4e9d 2025-11-12  (100 modes)
  *   API 1.48.0  16e12368bc 2026-08-05  (103 modes)
- *   API 1.49.0  d58d69e057 2026-09-07  (104 modes)
+ *   API 1.49.0  f5fb2717b8 2026-09-12  (105 modes)
  */
 
 /**
@@ -583,6 +583,7 @@ export const FIRMWARE_DEBUG_MODES: Readonly<Record<string, readonly string[]>> =
         "AUTOPILOT_STOP", // 101
         "PITOT", // 102
         "POSITION_EST", // 103
+        "AUTOPILOT_HEADING", // 104
     ]),
 });
 

--- a/test/generated/debug_field_usage.json
+++ b/test/generated/debug_field_usage.json
@@ -1726,8 +1726,8 @@
             }
         },
         "1.49.0": {
-            "commit": "d58d69e0576d77dbdc291f4bf2b56cc8827a3011",
-            "date": "2026-09-07",
+            "commit": "f5fb2717b84b7bf186091771dc0f0487db9aa691",
+            "date": "2026-09-12",
             "modes": {
                 "ACCELEROMETER": {
                     "fields": [0, 1, 2, 3, 4],
@@ -1767,6 +1767,10 @@
                 },
                 "AUTOPILOT_ALTITUDE": {
                     "fields": [0, 1, 2, 3, 4, 5, 6, 7],
+                    "dynamic": false
+                },
+                "AUTOPILOT_HEADING": {
+                    "fields": [0, 1, 2, 3],
                     "dynamic": false
                 },
                 "AUTOPILOT_PID": {


### PR DESCRIPTION
## Summary

Regenerates the firmware debug tables now that betaflight/betaflight#15596 — the `DEBUG_SET()` field annotations — has merged. They were last generated against that pull request's head, so the generator can now read plain `master`.

Generated, not hand-edited:

```
npm run generate:debug-modes -- --dev-ref upstream/master
```

against betaflight/betaflight `f5fb2717b8` (2026-09-12).

## What changed

| File | Change |
|---|---|
| `src/js/debug_modes_table.ts` | API 1.49.0: 104 → 105 modes. `AUTOPILOT_HEADING` appended at index 104. |
| `src/js/debug_fields_table.ts` | 494 → 498 annotated fields: the four `AUTOPILOT_HEADING` fields. |
| `test/generated/debug_field_usage.json` | Matching 1.49.0 fixture entry, ref bumped. |

`AUTOPILOT_HEADING` comes from betaflight/betaflight#15672 (heading hold in `POS_HOLD_MODE`) and arrives fully annotated:

| index | label | unit | scale |
|---|---|---|---|
| 0 | Aircraft Heading | deg | 0.1 |
| 1 | Target Heading | deg | 0.1 |
| 2 | Heading Error | deg | 0.1 |
| 3 | Yaw Rate Setpoint | dps | 0.1 |

The mode is **appended**, so no existing index moves and no previously recorded blackbox log is re-mapped. Older API versions in the table are untouched — the generator refuses a non-append change to a committed version unless `--allow-rewrite` is passed, and it was not.

## Testing

- `npm run generate:debug-modes -- --check` → *up to date with the firmware source*.
- `npx vitest run test/js/utils/debugFieldAnnotations.test.ts test/js/utils/debugModesFirmware.test.ts test/js/utils/debugModesGenerator.test.ts test/js/utils/debugModes.test.js test/js/blackbox_debug_curves.test.js` → 120 passed.

## Firmware-side warnings, unchanged by this PR

The generator still reports the known upstream collisions, none of them new here and none of them introduced by this change:

- `DEBUG_BATTERY[3]`, `DEBUG_LIDAR_TF[0..4]` — betaflight/betaflight#15594
- `DSHOT_RPM_ERRORS`, `RX_STATE_TIME` (write `debug[]` directly) and `SDIO`, `RPM_FILTER`, `AC_CORRECTION`, `AC_ERROR` (hold an enum slot, write nothing) — betaflight/betaflight#15610
- `DEBUG_RX_FRSKY_SPI[0..2]` — shared between the FrSky and Redpine CC2500 drivers, filed as betaflight/betaflight#15691


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Autopilot Heading debug mode with telemetry for aircraft heading, target heading, heading error, and yaw-rate setpoint.
  - Heading-related values are reported with degree-based units and improved precision.

- **Documentation**
  - Updated the firmware reference to API version 1.49.0, including the latest available debug fields and modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->